### PR TITLE
Enable tmp mount on ubuntu

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -246,6 +246,50 @@ jobs:
             ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
             ./earthly.sh +run-qemu-tests --FLAVOR=${{ matrix.flavor }} --FROM_ARTIFACTS=true
 
+  upgrade-with-cli-test:
+    needs: 
+    - build
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+       include:
+         - flavor: "alpine"
+           node: "A" # Arbitrary field
+         - flavor: "opensuse"
+           node: "B"
+#         - flavor: "alpine"
+#           node: "C"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: kairos-${{ matrix.flavor }}.iso.zip
+    - name: Install deps
+      run: |
+        brew install cdrtools jq
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+          go-version: '^1.16'
+    - run: |
+            ls -liah
+            export ISO=$PWD/$(ls kairos-core-*.iso)
+            export GOPATH="/Users/runner/go"
+            export CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h
+            export PATH=$PATH:$GOPATH/bin
+            export CLOUD_INIT=$PWD/tests/assets/config.yaml
+            export CREATE_VM=true
+            export FLAVOR=${{ matrix.flavor }} 
+            ./.github/run_test.sh "upgrade-with-cli"
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ matrix.flavor }}-upgrade-test.logs.zip
+        path: tests/**/logs/*
+        if-no-files-found: warn
+
   upgrade-latest-with-cli-test:
     needs: 
     - build

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <h3 align="center">Kairos - Kubernetes-focused, Cloud Native Linux meta-distribution</h3>
 <p align="center">
   <a href="https://github.com/kairos-io/kairos/issues"><img src="https://img.shields.io/github/issues/kairos-io/kairos"></a>
-  <a href="https://quay.io/repository/kairos/kairos"> <img src="https://quay.io/repository/kairos/kairos/status"></a>
+  <a href="https://github.com/kairos-io/kairos/actions/workflows/image.yaml"> <img src="https://github.com/kairos-io/kairos/actions/workflows/image.yaml/badge.svg"></a>
 </p>
 
 <p align="center">

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -45,6 +45,10 @@ RUN systemctl enable ssh
 RUN echo "auto lo" > /etc/network/interfaces
 RUN echo "iface lo inet loopback" >> /etc/network/interfaces
 
+# Enable tmp
+RUN cp -v /usr/share/systemd/tmp.mount /etc/systemd/system/ 
+RUN systemctl enable tmp.mount
+
 # Fixup sudo perms
 RUN chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo
 

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -70,7 +70,7 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 			Eventually(func() string {
 				out, _ := machine.SSHCommand("sudo cat /oem/grubenv")
 				return out
-			}, 30*time.Minute, 1*time.Second).Should(
+			}, 40*time.Minute, 1*time.Second).Should(
 				Or(
 					ContainSubstring("foobarzz"),
 				))

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -65,7 +65,7 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 		})
 	})
 
-	Context("reboots", func() {
+	Context("reboots and passes functional tests", func() {
 		It("has grubenv file", func() {
 			Eventually(func() string {
 				out, _ := machine.SSHCommand("sudo cat /oem/grubenv")
@@ -75,6 +75,7 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 					ContainSubstring("foobarzz"),
 				))
 		})
+
 		It("has custom cmdline", func() {
 			Eventually(func() string {
 				out, _ := machine.SSHCommand("sudo cat /proc/cmdline")
@@ -83,6 +84,16 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 				Or(
 					ContainSubstring("foobarzz"),
 				))
+		})
+
+		It("has writeable tmp", func() {
+			_, err := machine.SSHCommand("sudo echo 'foo' > /tmp/bar")
+			Expect(err).ToNot(HaveOccurred())
+
+			out, err := machine.SSHCommand("sudo cat /tmp/bar")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(out).To(ContainSubstring("foo"))
 		})
 	})
 })

--- a/tests/upgrade_cli_test.go
+++ b/tests/upgrade_cli_test.go
@@ -1,0 +1,98 @@
+package mos_test
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kairos-io/kairos/tests/machine"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("k3s upgrade manual test", Label("upgrade-with-cli"), func() {
+
+	containerImage := os.Getenv("CONTAINER_IMAGE")
+
+	BeforeEach(func() {
+		machine.EventuallyConnects()
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			gatherLogs()
+		}
+	})
+
+	Context("live cd", func() {
+
+		It("has default service active", func() {
+			if containerImage == "" {
+				Fail("CONTAINER_IMAGE needs to be set")
+			}
+
+			if os.Getenv("FLAVOR") == "alpine" {
+				out, _ := machine.Sudo("rc-status")
+				Expect(out).Should(ContainSubstring("kairos"))
+				Expect(out).Should(ContainSubstring("kairos-agent"))
+			} else {
+				// Eventually(func() string {
+				// 	out, _ := machine.SSHCommand("sudo systemctl status kairos-agent")
+				// 	return out
+				// }, 30*time.Second, 10*time.Second).Should(ContainSubstring("no network token"))
+
+				out, _ := machine.Sudo("systemctl status kairos")
+				Expect(out).Should(ContainSubstring("loaded (/etc/systemd/system/kairos.service; enabled"))
+			}
+		})
+	})
+
+	Context("install", func() {
+		It("to disk with custom config", func() {
+			err := machine.SendFile("assets/config.yaml", "/tmp/config.yaml", "0770")
+			Expect(err).ToNot(HaveOccurred())
+
+			out, _ := machine.Sudo("elemental install --cloud-init /tmp/config.yaml /dev/sda")
+			Expect(out).Should(ContainSubstring("Running after-install hook"))
+			fmt.Println(out)
+			machine.Sudo("sync")
+			machine.DetachCD()
+			machine.Restart()
+		})
+	})
+
+	Context("upgrades", func() {
+		It("can upgrade to current image", func() {
+
+			currentVersion, err := machine.SSHCommand("source /etc/os-release; echo $VERSION")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(currentVersion).To(ContainSubstring("v"))
+			_, err = machine.Sudo("kairos-agent")
+			if err == nil {
+				out, err := machine.Sudo("kairos-agent upgrade --force --image " + containerImage)
+				Expect(err).ToNot(HaveOccurred(), string(out))
+				Expect(out).To(ContainSubstring("Upgrade completed"))
+				Expect(out).To(ContainSubstring(containerImage))
+			} else {
+				out, err := machine.Sudo("kairos upgrade --force --image " + containerImage)
+				Expect(err).ToNot(HaveOccurred(), string(out))
+				Expect(out).To(ContainSubstring("Upgrade completed"))
+				Expect(out).To(ContainSubstring(containerImage))
+			}
+			machine.Sudo("reboot")
+			machine.EventuallyConnects(750)
+
+			Eventually(func() error {
+				_, err := machine.SSHCommand("source /etc/os-release; echo $VERSION")
+				return err
+			}, 10*time.Minute, 10*time.Second).ShouldNot(HaveOccurred())
+
+			var v string
+			Eventually(func() string {
+				v, _ = machine.SSHCommand("source /etc/os-release; echo $VERSION")
+				return v
+				// TODO: Add regex semver check here
+			}, 10*time.Minute, 10*time.Second).Should(ContainSubstring("v"))
+		})
+	})
+})


### PR DESCRIPTION
The service isn't enabled by default, and /tmp as such is not writeable - also adds corresponding tests.

It adds also upgrade test for the image built - we were not doing it previously here as the test was moved to the kairos provider.

Supersedes #135 