### PR TITLE
:robot: Add reset tests

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -207,6 +207,31 @@ jobs:
             ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
             ./earthly.sh +run-qemu-tests --FLAVOR=${{ matrix.flavor }} --FROM_ARTIFACTS=true
 
+  qemu-reset-tests:
+    needs: 
+    - build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+       include:
+         - flavor: "alpine"
+         - flavor: "opensuse"
+         - flavor: "ubuntu"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
+      with:
+          name: kairos-${{ matrix.flavor }}.iso.zip
+    - run: |
+            ls -liah
+            export ISO=$PWD/$(ls *.iso)
+            mkdir build
+            mv $ISO build/kairos.iso
+            ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
+            ./earthly.sh +run-qemu-tests --TEST_SUITE=reset-test --FLAVOR=${{ matrix.flavor }} --FROM_ARTIFACTS=true
+
   upgrade-with-cli-test:
     needs: 
     - build

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -88,43 +88,7 @@ jobs:
         run: | 
           docker tag quay.io/kairos/core-${{ matrix.flavor }}:latest ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h
           docker push ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h
-# Test start
-  build-vm-images:
-    needs: 
-    - build
-    runs-on: macos-12
-    strategy:
-      fail-fast: false
-      matrix:
-       include:
-         - flavor: "opensuse"
-         - flavor: "alpine"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install deps
-        run: |
-          brew install hudochenkov/sshpass/sshpass
-          brew install qemu
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: kairos-${{ matrix.flavor }}.iso.zip
-      - run: |
-              ls -liah
-              iso=$(ls *.iso)
-              bash scripts/build_vm.sh $iso
-      - uses: actions/upload-artifact@v2
-        with:
-          name: kairos-${{ matrix.flavor }}.qcow2.tar.xz
-          path: |
-            *.qcow2.tar.xz
-      - uses: actions/upload-artifact@v2
-        with:
-          name: kairos-${{ matrix.flavor }}.ova
-          path: |
-            *.ova
-          if-no-files-found: error
-
+  
   install-test:
     needs: 
     - build

--- a/tests/machine/vbox.go
+++ b/tests/machine/vbox.go
@@ -104,6 +104,12 @@ func Create(sshPort string) {
 }
 func HasDir(s string) {
 	out, err := SSHCommand("if [ -d " + s + " ]; then echo ok; else echo wrong; fi")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, out).Should(Equal("ok\n"))
+}
+
+func HasFile(s string) {
+	out, err := SSHCommand("if [ -f " + s + " ]; then echo ok; else echo wrong; fi")
 	Expect(err).ToNot(HaveOccurred())
 	Expect(out).Should(Equal("ok\n"))
 }

--- a/tests/reset_test.go
+++ b/tests/reset_test.go
@@ -1,0 +1,115 @@
+package mos_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kairos-io/kairos/tests/machine"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("kairos reset test", Label("reset-test"), func() {
+	BeforeEach(func() {
+		if os.Getenv("CLOUD_INIT") == "" || !filepath.IsAbs(os.Getenv("CLOUD_INIT")) {
+			Fail("CLOUD_INIT must be set and must be pointing to a file as an absolute path")
+		}
+
+		machine.EventuallyConnects()
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			gatherLogs()
+		}
+	})
+
+	Context("live cd", func() {
+		It("has default service active", func() {
+			if os.Getenv("FLAVOR") == "alpine" {
+				out, _ := machine.SSHCommand("sudo rc-status")
+				Expect(out).Should(ContainSubstring("kairos"))
+				Expect(out).Should(ContainSubstring("kairos-agent"))
+				fmt.Println(out)
+			} else {
+				// Eventually(func() string {
+				// 	out, _ := machine.SSHCommand("sudo systemctl status kairosososososos-agent")
+				// 	return out
+				// }, 30*time.Second, 10*time.Second).Should(ContainSubstring("no network token"))
+
+				out, _ := machine.SSHCommand("sudo systemctl status kairos")
+				Expect(out).Should(ContainSubstring("loaded (/etc/systemd/system/kairos.service; enabled;"))
+				fmt.Println(out)
+			}
+
+			out, _ := machine.SSHCommand("ls -liah /oem")
+			fmt.Println(out)
+			//	Expect(out).To(ContainSubstring("userdata.yaml"))
+			out, _ = machine.SSHCommand("cat /oem/userdata")
+			fmt.Println(out)
+			out, _ = machine.SSHCommand("sudo ps aux")
+			fmt.Println(out)
+
+			out, _ = machine.SSHCommand("sudo lsblk")
+			fmt.Println(out)
+
+		})
+	})
+
+	Context("auto installs", func() {
+		It("to disk with custom config", func() {
+			Eventually(func() string {
+				out, _ := machine.SSHCommand("sudo ps aux")
+				return out
+			}, 30*time.Minute, 1*time.Second).Should(
+				Or(
+					ContainSubstring("elemental install"),
+				))
+		})
+	})
+
+	Context("reboots and passes functional tests", func() {
+		It("has grubenv file", func() {
+			Eventually(func() string {
+				out, _ := machine.SSHCommand("sudo cat /oem/grubenv")
+				return out
+			}, 40*time.Minute, 1*time.Second).Should(
+				Or(
+					ContainSubstring("foobarzz"),
+				))
+		})
+
+		It("resets", func() {
+			_, err := machine.Sudo("echo 'test' > /usr/local/test")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = machine.Sudo("echo 'testoem' > /oem/test")
+			Expect(err).ToNot(HaveOccurred())
+
+			machine.HasFile("/oem/test")
+			machine.HasFile("/usr/local/test")
+
+			_, err = machine.Sudo("grub2-editenv /oem/grubenv set next_entry=statereset")
+			Expect(err).ToNot(HaveOccurred())
+
+			machine.Reboot()
+
+			Eventually(func() string {
+				out, _ := machine.Sudo("if [ -f /usr/local/test ]; then echo ok; else echo wrong; fi")
+				return out
+			}, 40*time.Minute, 1*time.Second).Should(
+				Or(
+					ContainSubstring("wrong"),
+				))
+			Eventually(func() string {
+				out, _ := machine.Sudo("if [ -f /oem/test ]; then echo ok; else echo wrong; fi")
+				return out
+			}, 40*time.Minute, 1*time.Second).Should(
+				Or(
+					ContainSubstring("ok"),
+				))
+		})
+	})
+})


### PR DESCRIPTION
This adds a simple test for the reset mode. 

It actually creates files into `/oem` and the persistent partition and check their existence after issuing a reset. There is much low hanging fruit here, some of the tests needs to be refactored. I've already created some libs to wrap the helpers up, but will do that in a follow-up