### PR TITLE
:sparkles: Switch to systemd-networkd on systemd-based flavors

### DIFF
--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -52,6 +52,7 @@ RUN zypper in -y \
     squashfs \
     strace \
     systemd \
+    systemd-network \
     systemd-sysvinit \
     tar \
     timezone \

--- a/images/Dockerfile.opensuse-arm-rpi
+++ b/images/Dockerfile.opensuse-arm-rpi
@@ -68,6 +68,7 @@ RUN zypper in -y \
     sysconfig \
     sysconfig-netconfig \
     sysvinit-tools \
+    systemd-network \
     wicked \
     wicked-service \
     rng-tools \

--- a/overlay/files/system/oem/05_network.yaml
+++ b/overlay/files/system/oem/05_network.yaml
@@ -2,11 +2,14 @@ name: "Default network configuration"
 stages:
    initramfs:
      - name: "Setup network"
+       if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
        systemctl:
          enable: 
          - systemd-networkd
+         - systemd-resolved
          disable: 
          - NetworkManager
+         - wicked
        files:
        - path: /etc/systemd/network/20-dhcp.network
          content: |


### PR DESCRIPTION
This should make uniform all systemd-based flavors network settings, by adopting systemd-networkd - no specific tests needed as the suite runs over SSH and node is expected to bring up network automatically