### PR TITLE
docs: Correction to Raspberry instructions

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -318,7 +318,7 @@ arm-image:
           ./images/arm-img-builder.sh --model $MODEL --directory "/build/image" build/$IMAGE_NAME && mv build ../
   END
   RUN xz -v /build/build/$IMAGE_NAME
-  SAVE ARTIFACT /build/build/$IMAGE_NAME.xz img AS LOCAL build/$IMAGE_NAME
+  SAVE ARTIFACT /build/build/$IMAGE_NAME.xz img AS LOCAL build/$IMAGE_NAME.xz
   SAVE ARTIFACT /build/build/$IMAGE_NAME.sha256 img-sha256 AS LOCAL build/$IMAGE_NAME.sha256
 
 ipxe-iso:

--- a/docs/src/pages/installation/raspberry.md
+++ b/docs/src/pages/installation/raspberry.md
@@ -24,10 +24,10 @@ wget https://github.com/kairos-io/provider-kairos/releases/download/v1.0.0-rc2/k
 
 ## Flash the image
 
-Plug the SD card to your system - to flash the image, you can either use Etcher or `dd`:
+Plug the SD card to your system - to flash the image, you can either use Etcher or `dd`, note it's compressed with "XZ" so we need to decompress it first:
 
 ```bash
-dd if=kairos-opensuse-arm-rpi-v1.0.0-rc2-k3sv1.21.14+k3s1.img of=<device> oflag=sync status=progress
+xzcat kairos-opensuse-arm-rpi-v1.0.0-rc2-k3sv1.21.14+k3s1.img | sudo dd of=<device> oflag=sync status=progress
 ```
 
 ## Configure your node


### PR DESCRIPTION
The images are in compressed with "XZ" but the extension of the images are only ".img". This happened when converting the build system to Earthly. The PR fixes Earthly and the docs accordingly.