### PR TITLE
added support for fast mode

### DIFF
--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -16,6 +16,8 @@ type BrandingText struct {
 }
 
 type Config struct {
+	Fast bool `yaml:"fast,omitempty"`
+
 	Branding BrandingText `yaml:"branding"`
 }
 

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -122,7 +122,9 @@ func Install(dir ...string) error {
 
 	cmd.PrintText(agentConfig.Branding.Install, "Installation")
 
-	time.Sleep(5 * time.Second)
+	if !agentConfig.Fast {
+		time.Sleep(5 * time.Second)
+	}
 
 	if tk != "" {
 		qr.Print(tk)

--- a/internal/agent/recovery.go
+++ b/internal/agent/recovery.go
@@ -46,7 +46,9 @@ func Recovery() error {
 		return fmt.Errorf(busErr)
 	}
 
-	time.Sleep(5 * time.Second)
+	if !agentConfig.Fast {
+		time.Sleep(5 * time.Second)
+	}
 
 	pterm.Info.Println(msg)
 

--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -55,7 +55,9 @@ func Reset() error {
 		panic(utils.Shell().Run())
 	}()
 
-	time.Sleep(60 * time.Second)
+	if !agentConfig.Fast {
+		time.Sleep(60 * time.Second)
+	}
 	lock.Lock()
 	args := []string{"reset"}
 
@@ -98,7 +100,9 @@ func Reset() error {
 		panic(utils.Shell().Run())
 	}()
 
-	time.Sleep(60 * time.Second)
+	if !agentConfig.Fast {
+		time.Sleep(60 * time.Second)
+	}
 	lock2.Lock()
 	utils.Reboot()
 


### PR DESCRIPTION
I added a setting to the agent configuration to skip the sleeps.  In the context of a user interaction the sleeps make sense however if a user has additional plugins that automate all aspects of configuration the sleeps are not needed. 