### PR TITLE
:sparkles: Add bundles to post-install hooks

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -169,7 +169,31 @@ jobs:
             mkdir build
             mv $ISO build/kairos.iso
             ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
-            ./earthly.sh +run-qemu-tests --FLAVOR=${{ matrix.flavor }} --FROM_ARTIFACTS=true
+            ./earthly.sh +run-qemu-datasource-tests --FLAVOR=${{ matrix.flavor }}
+
+  qemu-bundles-tests:
+    needs: 
+    - build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+       include:
+         - flavor: "opensuse"
+         - flavor: "ubuntu"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
+      with:
+          name: kairos-${{ matrix.flavor }}.iso.zip
+    - run: |
+            ls -liah
+            export ISO=$PWD/$(ls *.iso)
+            mkdir build
+            mv $ISO build/kairos.iso
+            ./earthly.sh +prepare-bundles-tests
+            ./earthly.sh +run-qemu-datasource-tests --FLAVOR=${{ matrix.flavor }}
 
   qemu-reset-tests:
     needs: 
@@ -194,7 +218,7 @@ jobs:
             mkdir build
             mv $ISO build/kairos.iso
             ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
-            ./earthly.sh +run-qemu-tests --TEST_SUITE=reset-test --FLAVOR=${{ matrix.flavor }} --FROM_ARTIFACTS=true
+            ./earthly.sh +run-qemu-datasource-tests --TEST_SUITE=reset-test --FLAVOR=${{ matrix.flavor }}
 
   upgrade-with-cli-test:
     needs: 
@@ -250,7 +274,7 @@ jobs:
             export ISO=$PWD/$(ls *.iso)
             sudo mkdir build
             sudo mv $ISO build/
-            ./earthly.sh +run-qemu-upgrade-test --FLAVOR=${{ matrix.flavor }} --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h --TEST_SUITE=upgrade-with-cli
+            ./earthly.sh +run-qemu-test --FLAVOR=${{ matrix.flavor }} --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h --TEST_SUITE=upgrade-with-cli
     - uses: actions/upload-artifact@v2
       if: failure()
       with:
@@ -313,7 +337,7 @@ jobs:
             export ISO=$PWD/$(ls kairos-${{matrix.flavor}}-*.iso)
             sudo mkdir build
             sudo mv $ISO build/
-            ./earthly.sh +run-qemu-upgrade-test --FLAVOR=${{ matrix.flavor }} --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h --TEST_SUITE=upgrade-latest-with-cli
+            ./earthly.sh +run-qemu-test --FLAVOR=${{ matrix.flavor }} --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h --TEST_SUITE=upgrade-latest-with-cli
     - uses: actions/upload-artifact@v2
       if: failure()
       with:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -193,7 +193,7 @@ jobs:
             mkdir build
             mv $ISO build/kairos.iso
             ./earthly.sh +prepare-bundles-tests
-            ./earthly.sh +run-qemu-datasource-tests --FLAVOR=${{ matrix.flavor }}
+            ./earthly.sh +run-qemu-bundles-tests --FLAVOR=${{ matrix.flavor }}
 
   qemu-reset-tests:
     needs: 

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -180,7 +180,6 @@ jobs:
       matrix:
        include:
          - flavor: "opensuse"
-         - flavor: "ubuntu"
     steps:
     - uses: actions/checkout@v2
     - name: Download artifacts

--- a/Earthfile
+++ b/Earthfile
@@ -492,8 +492,15 @@ examples-bundle-config:
     FROM alpine
     COPY . .
     RUN echo "" >> tests/assets/live-overlay.yaml
-    RUN echo "bundles:" >> tests/assets/live-overlay.yaml
-    RUN echo '- rootfs_path: "/usr/local/lib/extensions/kubo"' >> tests/assets/live-overlay.yaml
-    RUN echo "  targets:" >> tests/assets/live-overlay.yaml
-    RUN echo "  - container://${BUNDLE_IMAGE}" >> tests/assets/live-overlay.yaml
+    RUN echo "install:" >> tests/assets/live-overlay.yaml
+    RUN echo "  auto: true" >> tests/assets/live-overlay.yaml
+    RUN echo "  reboot: true" >> tests/assets/live-overlay.yaml
+    RUN echo "  device: auto" >> tests/assets/live-overlay.yaml
+    RUN echo "  grub_options:" >> tests/assets/live-overlay.yaml
+    RUN echo '    extra_cmdline: "foobarzz"' >> tests/assets/live-overlay.yaml
+    RUN echo '    extra_cmdline: "foobarzz"' >> tests/assets/live-overlay.yaml
+    RUN echo "  bundles:" >> tests/assets/live-overlay.yaml
+    RUN echo '  - rootfs_path: "/usr/local/lib/extensions/kubo"' >> tests/assets/live-overlay.yaml
+    RUN echo "    targets:" >> tests/assets/live-overlay.yaml
+    RUN echo "    - container://${BUNDLE_IMAGE}" >> tests/assets/live-overlay.yaml
     SAVE ARTIFACT tests/assets/live-overlay.yaml AS LOCAL bundles-config.yaml

--- a/Earthfile
+++ b/Earthfile
@@ -403,7 +403,7 @@ run-qemu-datasource-tests:
     ENV FLAVOR=$FLAVOR
     ENV SSH_PORT=60022
     ENV CREATE_VM=true
-    ARG CLOUD_CONFIG="assets/autoinstall.yaml"
+    ARG CLOUD_CONFIG="./tests/assets/autoinstall.yaml"
     ENV USE_QEMU=true
 
     ENV GOPATH="/go"
@@ -472,7 +472,7 @@ prepare-bundles-tests:
     END
     BUILD +examples-bundle-config --BUNDLE_IMAGE=$BUNDLE_IMAGE
 
-run-bundles-tests:
+run-qemu-bundles-tests:
     ARG FLAVOR
     BUILD +run-qemu-datasource-tests --CLOUD_CONFIG=./bundles-config.yaml --TEST_SUITE="bundles-test" --FLAVOR=$FLAVOR
 

--- a/Earthfile
+++ b/Earthfile
@@ -498,9 +498,8 @@ examples-bundle-config:
     RUN echo "  device: auto" >> tests/assets/live-overlay.yaml
     RUN echo "  grub_options:" >> tests/assets/live-overlay.yaml
     RUN echo '    extra_cmdline: "foobarzz"' >> tests/assets/live-overlay.yaml
-    RUN echo '    extra_cmdline: "foobarzz"' >> tests/assets/live-overlay.yaml
     RUN echo "  bundles:" >> tests/assets/live-overlay.yaml
-    RUN echo '  - rootfs_path: "/usr/local/lib/extensions/kubo"' >> tests/assets/live-overlay.yaml
+    RUN echo '   - rootfs_path: "/usr/local/lib/extensions/kubo"' >> tests/assets/live-overlay.yaml
     RUN echo "    targets:" >> tests/assets/live-overlay.yaml
     RUN echo "    - container://${BUNDLE_IMAGE}" >> tests/assets/live-overlay.yaml
     SAVE ARTIFACT tests/assets/live-overlay.yaml AS LOCAL bundles-config.yaml

--- a/examples/bundle/Dockerfile
+++ b/examples/bundle/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine as build
+# Install a binary
+ARG VERSION=v0.0.0-dfff908
+ENV VERSION=$VERSION
+
+RUN wget https://github.com/ipfs/kubo/releases/download/v0.15.0/kubo_v0.15.0_linux-amd64.tar.gz -O kubo.tar.gz
+RUN tar xvf kubo.tar.gz
+RUN mv kubo/ipfs /usr/bin/ipfs
+RUN mkdir -p /usr/lib/extension-release.d/
+RUN echo ID=kairos > /usr/lib/extension-release.d/extension-release.kubo
+RUN echo VERSION_ID=$VERSION >> /usr/lib/extension-release.d/extension-release.kubo
+
+
+FROM scratch
+
+COPY --from=build /usr/bin/ipfs /usr/bin/ipfs
+COPY --from=build /usr/lib/extension-release.d /usr/lib/extension-release.d

--- a/examples/bundle/Dockerfile
+++ b/examples/bundle/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine as build
 # Install a binary
-ARG VERSION=v0.0.0-dfff908
+ARG VERSION
 ENV VERSION=$VERSION
 
 RUN wget https://github.com/ipfs/kubo/releases/download/v0.15.0/kubo_v0.15.0_linux-amd64.tar.gz -O kubo.tar.gz

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -63,14 +63,14 @@ func Run(opts ...Option) error {
 	if !machine.SentinelExist("bundles") {
 		opts := c.Bundles.Options()
 		err := bundles.RunBundles(opts...)
-		if !c.IgnoreBundleErrors && err != nil {
+		if c.FailOnBundleErrors && err != nil {
 			return err
 		}
 
 		// Re-load providers
 		bus.Reload()
 		err = machine.CreateSentinel("bundles")
-		if !c.IgnoreBundleErrors && err != nil {
+		if c.FailOnBundleErrors && err != nil {
 			return err
 		}
 	}

--- a/internal/agent/hooks/bundles.go
+++ b/internal/agent/hooks/bundles.go
@@ -22,7 +22,7 @@ func (b BundleOption) Run(c config.Config) error {
 
 	opts := c.Install.Bundles.Options()
 	err := bundles.RunBundles(opts...)
-	if !c.IgnoreBundleErrors && err != nil {
+	if c.FailOnBundleErrors && err != nil {
 		return err
 	}
 

--- a/internal/agent/hooks/bundles.go
+++ b/internal/agent/hooks/bundles.go
@@ -10,12 +10,12 @@ type BundleOption struct{}
 
 func (b BundleOption) Run(c config.Config) error {
 
-	machine.Mount("COS_PERSISTENT", "/usr/local")
+	machine.Mount("COS_PERSISTENT", "/usr/local") //nolint:errcheck
 	defer func() {
 		machine.Umount("/usr/local")
 	}()
 
-	machine.Mount("COS_OEM", "/oem")
+	machine.Mount("COS_OEM", "/oem") //nolint:errcheck
 	defer func() {
 		machine.Umount("/oem")
 	}()

--- a/internal/agent/hooks/bundles.go
+++ b/internal/agent/hooks/bundles.go
@@ -1,0 +1,30 @@
+package hook
+
+import (
+	config "github.com/kairos-io/kairos/pkg/config"
+	"github.com/kairos-io/kairos/pkg/machine"
+	"github.com/kairos-io/kairos/sdk/bundles"
+)
+
+type BundleOption struct{}
+
+func (b BundleOption) Run(c config.Config) error {
+
+	machine.Mount("COS_PERSISTENT", "/usr/local")
+	defer func() {
+		machine.Umount("/usr/local")
+	}()
+
+	machine.Mount("COS_OEM", "/oem")
+	defer func() {
+		machine.Umount("/oem")
+	}()
+
+	opts := c.Install.Bundles.Options()
+	err := bundles.RunBundles(opts...)
+	if !c.IgnoreBundleErrors && err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -12,7 +12,7 @@ type GrubOptions struct{}
 
 func (b GrubOptions) Run(c config.Config) error {
 
-	machine.Mount("COS_OEM", "/tmp/oem")
+	machine.Mount("COS_OEM", "/tmp/oem") //nolint:errcheck
 	defer func() {
 		machine.Umount("/tmp/oem")
 	}()

--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -2,29 +2,20 @@ package hook
 
 import (
 	"fmt"
-	"strings"
 
 	config "github.com/kairos-io/kairos/pkg/config"
+	"github.com/kairos-io/kairos/pkg/machine"
 	"github.com/kairos-io/kairos/pkg/utils"
 )
 
 type GrubOptions struct{}
 
 func (b GrubOptions) Run(c config.Config) error {
-	oem, _ := utils.SH("blkid -L COS_OEM")
-	if oem == "" {
-		fmt.Println("OEM partition not found")
-		return nil // do not error out
-	}
 
-	oem = strings.TrimSuffix(oem, "\n")
-
-	oemMount, err := utils.SH(fmt.Sprintf("mkdir /tmp/oem && mount %s /tmp/oem", oem))
-	if err != nil {
-		fmt.Printf("could not mount oem: %s\n", oemMount+err.Error())
-		return nil // do not error out
-	}
-
+	machine.Mount("COS_OEM", "/tmp/oem")
+	defer func() {
+		machine.Umount("/tmp/oem")
+	}()
 	for k, v := range c.Install.GrubOptions {
 		out, err := utils.SH(fmt.Sprintf("grub2-editenv /tmp/oem/grubenv set %s=%s", k, v))
 		if err != nil {
@@ -33,6 +24,5 @@ func (b GrubOptions) Run(c config.Config) error {
 		}
 	}
 
-	utils.SH("umount /tmp/oem") //nolint:errcheck
 	return nil
 }

--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -11,7 +11,8 @@ type Interface interface {
 var All = []Interface{
 	&RunStage{},    // Shells out to stages defined from the container image
 	&GrubOptions{}, // Set custom GRUB options
-	&Lifecycle{},   // Handles poweroff/reboot by config options
+	&BundleOption{},
+	&Lifecycle{}, // Handles poweroff/reboot by config options
 }
 
 func Run(c config.Config, hooks ...Interface) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	header             string
 	ConfigURL          string            `yaml:"config_url,omitempty"`
 	Options            map[string]string `yaml:"options,omitempty"`
-	IgnoreBundleErrors bool              `yaml:"ignore_bundles_errors,omitempty"`
+	FailOnBundleErrors bool              `yaml:"fail_on_bundles_errors,omitempty"`
 	Bundles            Bundles           `yaml:"bundles,omitempty"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ type Install struct {
 	Device      string            `yaml:"device,omitempty"`
 	Poweroff    bool              `yaml:"poweroff,omitempty"`
 	GrubOptions map[string]string `yaml:"grub_options,omitempty"`
+	Bundles     Bundles           `yaml:"bundles,omitempty"`
 }
 
 type Config struct {

--- a/pkg/machine/file.go
+++ b/pkg/machine/file.go
@@ -1,0 +1,9 @@
+package machine
+
+import "os"
+
+func Exists(path string) bool {
+	_, err := os.Stat(path)
+
+	return !os.IsNotExist(err)
+}

--- a/pkg/machine/partitions.go
+++ b/pkg/machine/partitions.go
@@ -1,0 +1,26 @@
+package machine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kairos-io/kairos/pkg/utils"
+)
+
+func Umount(path string) {
+	utils.SH(fmt.Sprintf("umount %s", path)) //nolint:errcheck
+}
+
+func Mount(label, mountpoint string) {
+	part, _ := utils.SH(fmt.Sprintf("blkid -L %s", label))
+	if part == "" {
+		fmt.Printf("%s partition not found\n", label)
+	}
+
+	part = strings.TrimSuffix(part, "\n")
+
+	mount, err := utils.SH(fmt.Sprintf("mkdir %s && mount %s %s", mountpoint, part, mountpoint))
+	if err != nil {
+		fmt.Printf("could not mount: %s\n", mount+err.Error())
+	}
+}

--- a/pkg/machine/partitions.go
+++ b/pkg/machine/partitions.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/kairos-io/kairos/pkg/utils"
@@ -19,7 +20,10 @@ func Mount(label, mountpoint string) {
 
 	part = strings.TrimSuffix(part, "\n")
 
-	mount, err := utils.SH(fmt.Sprintf("mkdir %s && mount %s %s", mountpoint, part, mountpoint))
+	if !Exists(mountpoint) {
+		os.MkdirAll(mountpoint, 0755)
+	}
+	mount, err := utils.SH(fmt.Sprintf("mount %s %s", part, mountpoint))
 	if err != nil {
 		fmt.Printf("could not mount: %s\n", mount+err.Error())
 	}

--- a/pkg/machine/partitions.go
+++ b/pkg/machine/partitions.go
@@ -12,19 +12,25 @@ func Umount(path string) {
 	utils.SH(fmt.Sprintf("umount %s", path)) //nolint:errcheck
 }
 
-func Mount(label, mountpoint string) {
+func Mount(label, mountpoint string) error {
 	part, _ := utils.SH(fmt.Sprintf("blkid -L %s", label))
 	if part == "" {
 		fmt.Printf("%s partition not found\n", label)
+		return fmt.Errorf("partition not found")
 	}
 
 	part = strings.TrimSuffix(part, "\n")
 
 	if !Exists(mountpoint) {
-		os.MkdirAll(mountpoint, 0755)
+		err := os.MkdirAll(mountpoint, 0755)
+		if err != nil {
+			return err
+		}
 	}
 	mount, err := utils.SH(fmt.Sprintf("mount %s %s", part, mountpoint))
 	if err != nil {
 		fmt.Printf("could not mount: %s\n", mount+err.Error())
+		return err
 	}
+	return nil
 }

--- a/tests/assets/live-overlay.yaml
+++ b/tests/assets/live-overlay.yaml
@@ -1,0 +1,16 @@
+#node-config
+
+install:
+  auto: true
+  reboot: true
+  device: auto
+  grub_options:
+    extra_cmdline: "foobarzz"
+
+stages:
+   initramfs:
+     - name: "Set user and password"
+       users:
+        kairos:
+          passwd: "kairos"
+       hostname: kairos-{{ trunc 4 .Random }}

--- a/tests/assets/live-overlay.yaml
+++ b/tests/assets/live-overlay.yaml
@@ -1,12 +1,5 @@
 #node-config
 
-install:
-  auto: true
-  reboot: true
-  device: auto
-  grub_options:
-    extra_cmdline: "foobarzz"
-
 stages:
    initramfs:
      - name: "Set user and password"

--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -93,10 +93,16 @@ var _ = Describe("kairos bundles test", Label("bundles-test"), func() {
 		})
 
 		It("has kubo extension", func() {
-			out, err := Sudo("systemd-sysext")
+			// Eventually(func() string {
+			// 	out, _ := Sudo("systemd-sysext")
+			// 	return out
+			// }, 40*time.Minute, 1*time.Second).Should(
+			// 	Or(
+			// 		ContainSubstring("kubo"),
+			// 	))
+			syset, err := Sudo("systemd-sysext")
 			Expect(err).ToNot(HaveOccurred())
-
-			Expect(out).To(ContainSubstring("kubo"))
+			Expect(syset).To(ContainSubstring("kubo"))
 
 			ipfsV, err := Sudo("ipfs version")
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -72,9 +72,10 @@ var _ = Describe("kairos bundles test", Label("bundles-test"), func() {
 	})
 
 	Context("reboots and passes functional tests", func() {
-		By("checking after-install hook triggered")
 
 		It("has grubenv file", func() {
+			By("checking after-install hook triggered")
+
 			Eventually(func() string {
 				out, _ := Sudo("sudo cat /oem/grubenv")
 				return out

--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -1,0 +1,107 @@
+package mos_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/spectrocloud/peg/matcher"
+)
+
+var _ = Describe("kairos bundles test", Label("bundles-test"), func() {
+	BeforeEach(func() {
+		if os.Getenv("CLOUD_INIT") == "" || !filepath.IsAbs(os.Getenv("CLOUD_INIT")) {
+			Fail("CLOUD_INIT must be set and must be pointing to a file as an absolute path")
+		}
+
+		EventuallyConnects()
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			gatherLogs()
+		}
+	})
+
+	Context("live cd", func() {
+		It("has default service active", func() {
+			if os.Getenv("FLAVOR") == "alpine" {
+				out, _ := Sudo("rc-status")
+				Expect(out).Should(ContainSubstring("kairos"))
+				Expect(out).Should(ContainSubstring("kairos-agent"))
+				fmt.Println(out)
+			} else {
+				// Eventually(func() string {
+				// 	out, _ := machine.Command("sudo systemctl status kairososososos-agent")
+				// 	return out
+				// }, 30*time.Second, 10*time.Second).Should(ContainSubstring("no network token"))
+
+				out, _ := Machine.Command("sudo systemctl status kairos")
+				Expect(out).Should(ContainSubstring("loaded (/etc/systemd/system/kairos.service; enabled;"))
+				fmt.Println(out)
+			}
+
+			// Debug output
+			out, _ := Sudo("ls -liah /oem")
+			fmt.Println(out)
+			//	Expect(out).To(ContainSubstring("userdata.yaml"))
+			out, _ = Sudo("cat /oem/userdata")
+			fmt.Println(out)
+			out, _ = Sudo("sudo ps aux")
+			fmt.Println(out)
+
+			out, _ = Sudo("sudo lsblk")
+			fmt.Println(out)
+
+		})
+	})
+
+	Context("auto installs", func() {
+		It("to disk with custom config", func() {
+			Eventually(func() string {
+				out, _ := Sudo("ps aux")
+				return out
+			}, 30*time.Minute, 1*time.Second).Should(
+				Or(
+					ContainSubstring("elemental install"),
+				))
+		})
+	})
+
+	Context("reboots and passes functional tests", func() {
+		It("has grubenv file", func() {
+			Eventually(func() string {
+				out, _ := Sudo("sudo cat /oem/grubenv")
+				return out
+			}, 40*time.Minute, 1*time.Second).Should(
+				Or(
+					ContainSubstring("foobarzz"),
+				))
+		})
+
+		It("has custom cmdline", func() {
+			Eventually(func() string {
+				out, _ := Sudo("sudo cat /proc/cmdline")
+				return out
+			}, 30*time.Minute, 1*time.Second).Should(
+				Or(
+					ContainSubstring("foobarzz"),
+				))
+		})
+
+		It("has kubo extension", func() {
+			out, err := Sudo("systemd-sysext")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(out).To(ContainSubstring("kubo"))
+
+			ipfsV, err := Sudo("ipfs version")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(ipfsV).To(ContainSubstring("0.15.0"))
+		})
+	})
+})

--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -72,6 +72,8 @@ var _ = Describe("kairos bundles test", Label("bundles-test"), func() {
 	})
 
 	Context("reboots and passes functional tests", func() {
+		By("checking after-install hook triggered")
+
 		It("has grubenv file", func() {
 			Eventually(func() string {
 				out, _ := Sudo("sudo cat /oem/grubenv")
@@ -83,6 +85,7 @@ var _ = Describe("kairos bundles test", Label("bundles-test"), func() {
 		})
 
 		It("has custom cmdline", func() {
+			By("waiting reboot and checking cmdline is present")
 			Eventually(func() string {
 				out, _ := Sudo("sudo cat /proc/cmdline")
 				return out

--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -104,6 +104,8 @@ var _ = Describe("kairos bundles test", Label("bundles-test"), func() {
 			// 		ContainSubstring("kubo"),
 			// 	))
 			syset, err := Sudo("systemd-sysext")
+			ls, _ := Sudo("ls -liah /usr/local/lib/extensions")
+			fmt.Println("LS:", ls)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(syset).To(ContainSubstring("kubo"))
 


### PR DESCRIPTION
This adds the `bundles` list also into the `install` block. This has the effect that bundles here specified are run after-install before first-boot. 
Note: bundles should install things either to `/usr/local` or run custom container/code. In this phase `/usr/local` and `/oem` are accessible.