### PR TITLE
Fixing the interface names across OS flavors

### DIFF
--- a/overlay/files-iso/boot/grub2/grub.cfg
+++ b/overlay/files-iso/boot/grub2/grub.cfg
@@ -22,35 +22,35 @@ if [ -f ${font} ];then
 fi
 menuentry "kairos" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset nodepair.enable
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
 
 menuentry "kairos (manual)" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
 
 menuentry "kairos (interactive install)" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable interactive-install
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable interactive-install
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
 
 menuentry "kairos (remote recovery mode)" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset kairos.remote_recovery_mode
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 rd.cos.disable vga=795 nomodeset kairos.remote_recovery_mode
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
 
 menuentry "kairos (boot local node from livecd)" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 kairos.boot_live_mode
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty1 console=ttyS0 kairos.boot_live_mode
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }

--- a/overlay/files/etc/cos/bootargs.cfg
+++ b/overlay/files/etc/cos/bootargs.cfg
@@ -1,0 +1,10 @@
+set kernel=/boot/vmlinuz
+if [ -n "$recoverylabel" ]; then
+    # Boot arguments when the image is used as recovery
+    set kernelcmd="console=tty1 root=live:CDLABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5"
+else
+    # Boot arguments when the image is used as active/passive
+    set kernelcmd="console=tty1 root=LABEL=$label net.ifnames=1 iso-scan/filename=$img panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1"
+fi
+
+set initramfs=/boot/initrd


### PR DESCRIPTION
added net.ifnames=1 to kernel params.

Signed-off-by: vipsharm <sharma.vipin@gmail.com>