### PR TITLE
:penguin: Disable temporarly SELinux on fedora

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,7 @@ jobs:
          - flavor: "alpine"
          - flavor: "ubuntu-rolling"
          - flavor: "ubuntu"
+         - flavor: "fedora"
    #      - flavor: "fedora"
    #      - flavor: "rockylinux"
     steps:

--- a/Earthfile
+++ b/Earthfile
@@ -242,6 +242,8 @@ docker:
         COPY overlay/files-opensuse-arm-rpi/ /
     ELSE IF [ "$FLAVOR" = "opensuse-arm-rpi" ]
         COPY overlay/files-opensuse-arm-rpi/ /
+    ELSE IF [ "$FLAVOR" = "fedora" ] || [ "$FLAVOR" = "rockylinux" ]
+        COPY overlay/files-fedora/ /
     ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-rolling" ]
         COPY overlay/files-ubuntu/ /
     END

--- a/overlay/files-fedora/etc/cos/bootargs.cfg
+++ b/overlay/files-fedora/etc/cos/bootargs.cfg
@@ -1,0 +1,11 @@
+set kernel=/boot/vmlinuz
+# temporarly disabling SELinux until we have a profile (https://github.com/kairos-io/kairos/issues/114)
+if [ -n "$recoverylabel" ]; then
+    # Boot arguments when the image is used as recovery
+    set kernelcmd="console=tty1 root=live:CDLABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5 selinux=0"
+else
+    # Boot arguments when the image is used as active/passive
+    set kernelcmd="console=tty1 root=LABEL=$label net.ifnames=1 iso-scan/filename=$img panic=5 rd.cos.oemlabel=COS_OEM selinux=0"
+fi
+
+set initramfs=/boot/initrd

--- a/overlay/files/system/oem/26_selinux.yaml
+++ b/overlay/files/system/oem/26_selinux.yaml
@@ -1,0 +1,10 @@
+name: "SELinux"
+stages:
+   initramfs:
+     - name: "Relabelling"
+       if: |
+          cat /proc/cmdline | grep "selinux=1"
+       commands:
+       - |
+           load_policy -i
+           restorecon -R -i -v /etc /root /opt /srv /var /home /usr/local /oem


### PR DESCRIPTION
SELinux support have to be handled separately in https://github.com/kairos-io/kairos/issues/114. fedora based version has selinux, which is enabled by default but we don't have support for it yet.

Fixes #63 . Now fedora installs and boots correctly afterwards