### PR TITLE
:sparkles: Add kcrypt to images

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -172,8 +172,9 @@ framework:
         ARG TOOLKIT_IMG="$FLAVOR"
     END
 
+    # Framework files
     RUN luet install -y --system-target /framework \
-            system/elemental-toolkit-$TOOLKIT_IMG
+            system/elemental-toolkit-$TOOLKIT_IMG dracut/kcrypt system/kcrypt
 
     IF [ "$WITH_KERNEL" = "true" ] || [ "$FLAVOR" = "alpine" ] || [ "$FLAVOR" = "alpine-arm-rpi" ]
         RUN luet install -y --system-target /framework \

--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -12,6 +12,7 @@ var All = []Interface{
 	&RunStage{},    // Shells out to stages defined from the container image
 	&GrubOptions{}, // Set custom GRUB options
 	&BundleOption{},
+	&Kcrypt{},
 	&Lifecycle{}, // Handles poweroff/reboot by config options
 }
 

--- a/internal/agent/hooks/kcrypt.go
+++ b/internal/agent/hooks/kcrypt.go
@@ -1,0 +1,28 @@
+package hook
+
+import (
+	"fmt"
+	"time"
+
+	config "github.com/kairos-io/kairos/pkg/config"
+	"github.com/kairos-io/kairos/pkg/utils"
+)
+
+type Kcrypt struct{}
+
+func (k Kcrypt) Run(c config.Config) error {
+	for _, p := range c.Install.Encrypt {
+		out, err := utils.SH(fmt.Sprintf("kcrypt encrypt %s", p))
+		if err != nil {
+			fmt.Printf("could not encrypt partition: %s\n", out+err.Error())
+			if c.FailOnBundleErrors {
+				return err
+			}
+			// Give time to show the error
+			time.Sleep(10 * time.Second)
+			return nil // do not error out
+		}
+	}
+
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ type Install struct {
 	Poweroff    bool              `yaml:"poweroff,omitempty"`
 	GrubOptions map[string]string `yaml:"grub_options,omitempty"`
 	Bundles     Bundles           `yaml:"bundles,omitempty"`
+	Encrypt     []string          `yaml:"encrypted_partitions,omitempty"`
 }
 
 type Config struct {


### PR DESCRIPTION
This adds the https://github.com/kairos-io/kcrypt dracut module and the binary to the images.

This allows to manually call `kcrypt` after installation on already existing partitions. Can be used also after-deployment to encrypt partitions with `kcrypt encrypt PARTITION_LABEL`.

Note: it requires a discovery plugin to handle encryption. it has to be located under `/system/discovery/kcrypt-discovery-<plugin_name>`

During installation, it can be specified in the yaml of the node config as such:

```yaml
install:
  encrypted_partitions:
  - LABEL
```

Related to https://github.com/kairos-io/kairos/issues/184