### PR TITLE
:penguin: Change ubuntu images location

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -21,7 +21,7 @@ jobs:
        include:
          - flavor: "opensuse"
          - flavor: "ubuntu"
-         - flavor: "ubuntu-rolling"
+         - flavor: "ubuntu-20-lts"
          - flavor: "alpine"
          - flavor: "fedora"
          - flavor: "rockylinux"
@@ -158,7 +158,7 @@ jobs:
          - flavor: "alpine"
          - flavor: "opensuse"
          - flavor: "ubuntu"
-         - flavor: "ubuntu-rolling"
+         - flavor: "ubuntu-20-lts"
     steps:
     - uses: actions/checkout@v2
     - name: Download artifacts

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -22,6 +22,7 @@ jobs:
          - flavor: "opensuse"
          - flavor: "ubuntu"
          - flavor: "ubuntu-20-lts"
+         - flavor: "ubuntu-22-lts"
          - flavor: "alpine"
          - flavor: "fedora"
          - flavor: "rockylinux"
@@ -159,6 +160,7 @@ jobs:
          - flavor: "opensuse"
          - flavor: "ubuntu"
          - flavor: "ubuntu-20-lts"
+         - flavor: "ubuntu-22-lts"
     steps:
     - uses: actions/checkout@v2
     - name: Download artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,7 @@ jobs:
          - flavor: "opensuse"
          - flavor: "alpine"
          - flavor: "ubuntu-20-lts"
+         - flavor: "ubuntu-22-lts"
          - flavor: "ubuntu"
          - flavor: "fedora"
    #      - flavor: "fedora"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
        include:
          - flavor: "opensuse"
          - flavor: "alpine"
-         - flavor: "ubuntu-rolling"
+         - flavor: "ubuntu-20-lts"
          - flavor: "ubuntu"
          - flavor: "fedora"
    #      - flavor: "fedora"

--- a/Earthfile
+++ b/Earthfile
@@ -162,7 +162,7 @@ framework:
 
     ENV USER=root
 
-    IF [ "$FLAVOR" == "ubuntu-20-lts" ]
+    IF [ "$FLAVOR" == "ubuntu-20-lts" ] || [ "$FLAVOR" == "ubuntu-22-lts" ]
         ARG TOOLKIT_IMG="ubuntu"
     ELSE IF [ "$FLAVOR" == "rockylinux" ]
         ARG TOOLKIT_IMG="fedora"
@@ -245,7 +245,7 @@ docker:
         COPY overlay/files-opensuse-arm-rpi/ /
     ELSE IF [ "$FLAVOR" = "fedora" ] || [ "$FLAVOR" = "rockylinux" ]
         COPY overlay/files-fedora/ /
-    ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-20-lts" ]
+    ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-20-lts" ] || [ "$FLAVOR" = "ubuntu-22-lts" ]
         COPY overlay/files-ubuntu/ /
     END
 
@@ -264,7 +264,7 @@ docker:
      RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
      # https://github.com/kairos-io/elemental-cli/blob/23ca64435fedb9f521c95e798d2c98d2714c53bd/pkg/elemental/elemental.go#L553
      RUN rm -rf /boot/initramfs-*
-    ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-20-lts" ]
+    ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-20-lts" ] || [ "$FLAVOR" = "ubuntu-22-lts" ]
      RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && \
             ln -sf "${kernel#/boot/}" /boot/vmlinuz
      RUN kernel=$(ls /lib/modules | head -n1) && \

--- a/Earthfile
+++ b/Earthfile
@@ -162,7 +162,7 @@ framework:
 
     ENV USER=root
 
-    IF [ "$FLAVOR" == "ubuntu-rolling" ]
+    IF [ "$FLAVOR" == "ubuntu-20-lts" ]
         ARG TOOLKIT_IMG="ubuntu"
     ELSE IF [ "$FLAVOR" == "rockylinux" ]
         ARG TOOLKIT_IMG="fedora"
@@ -245,7 +245,7 @@ docker:
         COPY overlay/files-opensuse-arm-rpi/ /
     ELSE IF [ "$FLAVOR" = "fedora" ] || [ "$FLAVOR" = "rockylinux" ]
         COPY overlay/files-fedora/ /
-    ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-rolling" ]
+    ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-20-lts" ]
         COPY overlay/files-ubuntu/ /
     END
 
@@ -264,7 +264,7 @@ docker:
      RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
      # https://github.com/kairos-io/elemental-cli/blob/23ca64435fedb9f521c95e798d2c98d2714c53bd/pkg/elemental/elemental.go#L553
      RUN rm -rf /boot/initramfs-*
-    ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-rolling" ]
+    ELSE IF [ "$FLAVOR" = "ubuntu" ] || [ "$FLAVOR" = "ubuntu-20-lts" ]
      RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && \
             ln -sf "${kernel#/boot/}" /boot/vmlinuz
      RUN kernel=$(ls /lib/modules | head -n1) && \

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:20.04
+ARG BASE_IMAGE=ubuntu:22.10
 
 FROM $BASE_IMAGE
 ARG K3S_VERSION
@@ -20,7 +20,7 @@ RUN apt install -y \
     iproute2 \
     squashfs-tools \
     parted dracut \
-    dracut-network tar \
+    dracut-network dracut-live tar \
     e2fsprogs \
     dosfstools \
     coreutils \
@@ -34,7 +34,7 @@ RUN apt install -y \
     jq \
     neovim \
     open-vm-tools \
-    linux-image-generic-hwe-20.04 && apt-get clean
+    linux-image-generic-hwe-22.04 && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv

--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:22.10
+ARG BASE_IMAGE=ubuntu:20.04
 
 FROM $BASE_IMAGE
 ARG K3S_VERSION
@@ -20,7 +20,7 @@ RUN apt install -y \
     iproute2 \
     squashfs-tools \
     parted dracut \
-    dracut-network dracut-live tar \
+    dracut-network tar \
     e2fsprogs \
     dosfstools \
     coreutils \
@@ -34,7 +34,7 @@ RUN apt install -y \
     jq \
     neovim \
     open-vm-tools \
-    linux-image-generic-hwe-22.04 && apt-get clean
+    linux-image-generic-hwe-20.04 && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv

--- a/images/Dockerfile.ubuntu-22-lts
+++ b/images/Dockerfile.ubuntu-22-lts
@@ -1,0 +1,56 @@
+ARG BASE_IMAGE=ubuntu:22.04
+
+FROM $BASE_IMAGE
+ARG K3S_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update
+RUN apt install -y software-properties-common
+RUN add-apt-repository ppa:oibaf/test
+RUN apt update
+RUN apt install -y \
+    systemd \
+    grub-pc-bin \
+    grub-efi-amd64-bin \
+    grub2 \
+    grub2-common \
+    nohang \
+    sudo \
+    iproute2 \
+    squashfs-tools \
+    parted dracut \
+    dracut-network dracut-live tar \
+    e2fsprogs \
+    dosfstools \
+    coreutils \
+    debianutils \
+    curl \
+    openssh-server \
+    nano \
+    gawk \
+    haveged \
+    rsync \
+    jq \
+    neovim \
+    open-vm-tools \
+    linux-image-generic-hwe-22.04 && apt-get clean
+
+RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
+RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
+RUN systemctl enable nohang-desktop.service
+RUN systemctl enable systemd-networkd
+RUN systemctl enable ssh
+RUN echo "auto lo" > /etc/network/interfaces
+RUN echo "iface lo inet loopback" >> /etc/network/interfaces
+
+# Enable tmp
+RUN cp -v /usr/share/systemd/tmp.mount /etc/systemd/system/ 
+RUN systemctl enable tmp.mount
+
+# Fixup sudo perms
+RUN chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo
+
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/cache/* && journalctl --vacuum-size=1K && rm /etc/machine-id && rm /var/lib/dbus/machine-id


### PR DESCRIPTION
this PR refactor the ubuntu images final location:

- ubuntu 22.04 as `quay.io/kairos/core-ubuntu-22-lts`
- ubuntu 20.04 (currently published as `ubuntu`)   as `quay.io/kairos/core-ubuntu-20-lts`
- ubuntu latest (currently published as `ubuntu-rolling`)  as `quay.io/kairos/core-ubuntu`

See also https://github.com/kairos-io/kairos/issues/150#issuecomment-1272909504.

It also adds the Ubuntu 22.04 LTS image.