### PR TITLE
:sparkles: Re-enforce active/passive boot strategy

### DIFF
--- a/overlay/files/etc/cos/bootargs.cfg
+++ b/overlay/files/etc/cos/bootargs.cfg
@@ -4,7 +4,7 @@ if [ -n "$recoverylabel" ]; then
     set kernelcmd="console=tty1 root=live:CDLABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5"
 else
     # Boot arguments when the image is used as active/passive
-    set kernelcmd="console=tty1 root=LABEL=$label net.ifnames=1 iso-scan/filename=$img panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1"
+    set kernelcmd="console=tty1 root=LABEL=$label net.ifnames=1 iso-scan/filename=$img panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1 fsck.mode=force fsck.repair=yes systemd.crash_reboot=yes"
 fi
 
 set initramfs=/boot/initrd


### PR DESCRIPTION
Boot assessment would take care of falling back, so reboot by default

Signed-off-by: Ettore Di Giacinto <mudler@users.noreply.github.com>