### PR TITLE
Drop wicked, long live to systemd-networkd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,18 +264,18 @@ workflows:
     #         test_suite: ["upgrade-with-cli"]
     #     requires:
     #     - build-iso
-    - run-bundles-test:
-        matrix:
-          parameters:
-            flavor: ["opensuse"]
-        requires:
-        - build-iso
-    - build-iso:
-        matrix:
-          parameters:
-            image: [quay.io/kairos/core]
-            flavor: ["alpine","opensuse","ubuntu", "rockylinux", "fedora"]
-            release: ["no"]
+    # - run-bundles-test:
+    #     matrix:
+    #       parameters:
+    #         flavor: ["opensuse"]
+    #     requires:
+    #     - build-iso
+    # - build-iso:
+    #     matrix:
+    #       parameters:
+    #         image: [quay.io/kairos/core]
+    #         flavor: ["alpine","opensuse","ubuntu", "rockylinux", "fedora"]
+    #         release: ["no"]
     # - run-datasource-test:
     #     matrix:
     #       parameters:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -175,28 +175,28 @@ jobs:
             ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
             ./earthly.sh +run-qemu-datasource-tests --FLAVOR=${{ matrix.flavor }}
 
-  # qemu-bundles-tests:
-  #   needs: 
-  #   - build
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #      include:
-  #        - flavor: "opensuse"
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Download artifacts
-  #     uses: actions/download-artifact@v2
-  #     with:
-  #         name: kairos-${{ matrix.flavor }}.iso.zip
-  #   - run: |
-  #           ls -liah
-  #           export ISO=$PWD/$(ls *.iso)
-  #           mkdir build
-  #           mv $ISO build/kairos.iso
-  #           ./earthly.sh +prepare-bundles-tests
-  #           ./earthly.sh +run-qemu-bundles-tests --FLAVOR=${{ matrix.flavor }}
+  qemu-bundles-tests:
+    needs: 
+    - build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+       include:
+         - flavor: "opensuse"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
+      with:
+          name: kairos-${{ matrix.flavor }}.iso.zip
+    - run: |
+            ls -liah
+            export ISO=$PWD/$(ls *.iso)
+            mkdir build
+            mv $ISO build/kairos.iso
+            ./earthly.sh +prepare-bundles-tests
+            ./earthly.sh +run-qemu-bundles-tests --FLAVOR=${{ matrix.flavor }}
 
   qemu-reset-tests:
     needs: 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+on:
+ push:
+   branches:
+     - master
+ pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.18'
+      - name: Run Lint checks
+        run: |
+          ./earthly.sh +lint

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,34 @@
+name: Unit tests
+on:
+ push:
+   branches:
+     - master
+ pull_request:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.18'
+      - name: Run Build
+        run: |
+          ./earthly.sh +dist
+      - name: Run tests
+        run: |
+          ./earthly.sh +test
+      - name: Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage.out
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build.zip
+          path: |
+            dist/*

--- a/Earthfile
+++ b/Earthfile
@@ -312,13 +312,13 @@ iso:
     SAVE ARTIFACT /build/$ISO_NAME.iso.sha256 kairos.iso.sha256 AS LOCAL build/$ISO_NAME.iso.sha256
 
 netboot:
-   FROM opensuse/leap
+   ARG OSBUILDER_IMAGE
+   FROM $OSBUILDER_IMAGE
    ARG VERSION
    ARG ISO_NAME=${OS_ID}
    WORKDIR /build
    COPY +iso/kairos.iso kairos.iso
    COPY . .
-   RUN zypper in -y cdrtools
    RUN /build/scripts/netboot.sh kairos.iso $ISO_NAME $VERSION
    SAVE ARTIFACT /build/$ISO_NAME.squashfs squashfs AS LOCAL build/$ISO_NAME.squashfs
    SAVE ARTIFACT /build/$ISO_NAME-kernel kernel AS LOCAL build/$ISO_NAME-kernel

--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -55,6 +55,7 @@ RUN zypper in -y \
     systemd \
     systemd-network \
     systemd-sysvinit \
+    sudo \
     tar \
     timezone \
     tmux \

--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -46,6 +46,7 @@ RUN zypper in -y \
     pigz \
     policycoreutils \
     procps \
+    python-azure-agent \
     qemu-guest-agent \
     rng-tools \
     rsync \

--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -46,7 +46,6 @@ RUN zypper in -y \
     pigz \
     policycoreutils \
     procps \
-    python-azure-agent \
     qemu-guest-agent \
     rng-tools \
     rsync \

--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -42,6 +42,7 @@ RUN zypper in -y \
     nfs-utils \
     open-iscsi \
     open-vm-tools \
+    openssh \
     parted \
     pigz \
     policycoreutils \

--- a/images/Dockerfile.opensuse-arm-rpi
+++ b/images/Dockerfile.opensuse-arm-rpi
@@ -69,8 +69,6 @@ RUN zypper in -y \
     sysconfig-netconfig \
     sysvinit-tools \
     systemd-network \
-    wicked \
-    wicked-service \
     rng-tools \
     rsync \
     squashfs \

--- a/images/Dockerfile.opensuse-arm-rpi
+++ b/images/Dockerfile.opensuse-arm-rpi
@@ -69,6 +69,8 @@ RUN zypper in -y \
     sysconfig-netconfig \
     sysvinit-tools \
     systemd-network \
+    wicked \
+    wicked-service \
     rng-tools \
     rsync \
     squashfs \

--- a/overlay/files/etc/dracut.conf.d/99-kairos.conf
+++ b/overlay/files/etc/dracut.conf.d/99-kairos.conf
@@ -1,0 +1,1 @@
+install_items+=" /etc/systemd/network/20-dhcp.network "

--- a/overlay/files/etc/systemd/network/20-dhcp.network
+++ b/overlay/files/etc/systemd/network/20-dhcp.network
@@ -1,0 +1,4 @@
+[Match]
+Name=en*
+[Network]
+DHCP=yes

--- a/overlay/files/system/oem/05_network.yaml
+++ b/overlay/files/system/oem/05_network.yaml
@@ -10,16 +10,6 @@ stages:
          disable: 
          - NetworkManager
          - wicked
-       files:
-       - path: /etc/systemd/network/20-dhcp.network
-         content: |
-                  [Match]
-                  Name=en*
-                  [Network]
-                  DHCP=yes
-         permissions: 0644
-         owner: 0
-         group: 0
        commands:
        - rm /etc/resolv.conf
        - ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf


### PR DESCRIPTION
This PR:
- Drops wicked references from openSUSE images
- Adds systemd-networkd settings to initramfs

![](https://media.giphy.com/media/28LOlpoqJh02X7QAyI/giphy.gif)