### PR TITLE
✨ Added /etc/kubernetes to persistent path list

### DIFF
--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -17,6 +17,7 @@ stages:
           /etc/ssh
           /etc/iscsi 
           /etc/cni
+          /etc/kubernetes
           /home
           /opt
           /root
@@ -44,6 +45,7 @@ stages:
           /etc/ssh
           /etc/iscsi 
           /etc/cni
+          /etc/kubernetes
           /home
           /opt
           /root


### PR DESCRIPTION
This change is in accordance with the support for the kubeadm provider. 
