### PR TITLE
change the automated installation http link in container.md page to correctly point to the automated installation page

### DIFF
--- a/docs/src/pages/architecture/container.md
+++ b/docs/src/pages/architecture/container.md
@@ -73,7 +73,7 @@ total 102M
 6692029 -rw-r--r-- 1 root root  11M Apr 16  2020 vmlinuz-5.14.21-150400.24.21-default
 ```
 
-The CI process generates bootable medium by the container images, and similarly, we can modify this image to introduce our changes and remaster an ISO as described in [Automated installation](installation/automated), but that can be resumed in the following steps:
+The CI process generates bootable medium by the container images, and similarly, we can modify this image to introduce our changes and remaster an ISO as described in [Automated installation](/installation/automated), but that can be resumed in the following steps:
 
 ```bash
 $ docker run -ti --name custom-container quay.io/kairos/core-alpine:v1.1.0


### PR DESCRIPTION
In the architecture/container section of the documentation, the http link pointing to the automated installation page is incorrect, there's a leading slash missing.

Nic