### PR TITLE
:robot: Enhance test coverage

### DIFF
--- a/overlay/files/etc/cos/bootargs.cfg
+++ b/overlay/files/etc/cos/bootargs.cfg
@@ -4,7 +4,7 @@ if [ -n "$recoverylabel" ]; then
     set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.cos.oemlabel=COS_OEM"
 else
     # Boot arguments when the image is used as active/passive
-    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1 fsck.mode=force fsck.repair=yes systemd.crash_reboot=yes"
+    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img rd.emergency=reboot rd.shell=0 panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1 fsck.mode=force fsck.repair=yes systemd.crash_reboot=yes"
 fi
 
 set initramfs=/boot/initrd

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -92,8 +92,14 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 				))
 		})
 
+		It("uses the dracut immutable module", func() {
+			out, err := Sudo("cat /proc/cmdline")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("cos-img/filename="))
+		})
+
 		It("has writeable tmp", func() {
-			_, err := Machine.Command("sudo echo 'foo' > /tmp/bar")
+			_, err := Sudo("echo 'foo' > /tmp/bar")
 			Expect(err).ToNot(HaveOccurred())
 
 			out, err := Machine.Command("sudo cat /tmp/bar")

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -98,6 +98,18 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 			Expect(out).To(ContainSubstring("cos-img/filename="))
 		})
 
+		It("installs Auto assessment", func() {
+			// Auto assessment was installed
+			out, _ := Sudo("cat /run/initramfs/cos-state/grubcustom")
+			Expect(out).To(ContainSubstring("bootfile_loc"))
+
+			out, _ = Sudo("cat /run/initramfs/cos-state/grub_boot_assessment")
+			Expect(out).To(ContainSubstring("boot_assessment_blk"))
+
+			cmdline, _ := Sudo("cat /proc/cmdline")
+			Expect(cmdline).To(ContainSubstring("rd.emergency=reboot rd.shell=0 panic=5"))
+		})
+
 		It("has writeable tmp", func() {
 			_, err := Sudo("echo 'foo' > /tmp/bar")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: Enhance current test suites to check basic configuration (dracut module enabled, boot assessment) and adds default bootargs to reboot the machine automatically in case active/passive is not booting to handle automatic fallback

