### PR TITLE
✨ add env to config to use across all stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ docs/public
 docs/.vscode
 
 .DS_Store
+
+# editor and IDE paraphernalia
+.idea

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kairos-io/kairos
 
-go 1.17
+go 1.18
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,10 +8,10 @@ import (
 
 	events "github.com/kairos-io/kairos/sdk/bus"
 
+	hook "github.com/kairos-io/kairos/internal/agent/hooks"
 	"github.com/kairos-io/kairos/internal/bus"
 	config "github.com/kairos-io/kairos/pkg/config"
 	machine "github.com/kairos-io/kairos/pkg/machine"
-	bundles "github.com/kairos-io/kairos/sdk/bundles"
 	"github.com/nxadm/tail"
 )
 
@@ -60,16 +60,15 @@ func Run(opts ...Option) error {
 		}
 	}()
 
-	if !machine.SentinelExist("bundles") {
-		opts := c.Bundles.Options()
-		err := bundles.RunBundles(opts...)
-		if c.FailOnBundleErrors && err != nil {
+	if !machine.SentinelExist("firstboot") {
+
+		if err := hook.Run(*c, hook.FirstBoot...); err != nil {
 			return err
 		}
 
 		// Re-load providers
 		bus.Reload()
-		err = machine.CreateSentinel("bundles")
+		err = machine.CreateSentinel("firstboot")
 		if c.FailOnBundleErrors && err != nil {
 			return err
 		}

--- a/internal/agent/hooks/bundles.go
+++ b/internal/agent/hooks/bundles.go
@@ -12,12 +12,12 @@ func (b BundleOption) Run(c config.Config) error {
 
 	machine.Mount("COS_PERSISTENT", "/usr/local") //nolint:errcheck
 	defer func() {
-		machine.Umount("/usr/local")
+		machine.Umount("/usr/local") //nolint:errcheck
 	}()
 
 	machine.Mount("COS_OEM", "/oem") //nolint:errcheck
 	defer func() {
-		machine.Umount("/oem")
+		machine.Umount("/oem") //nolint:errcheck
 	}()
 
 	opts := c.Install.Bundles.Options()
@@ -26,5 +26,16 @@ func (b BundleOption) Run(c config.Config) error {
 		return err
 	}
 
+	return nil
+}
+
+type BundlePostInstall struct{}
+
+func (b BundlePostInstall) Run(c config.Config) error {
+	opts := c.Bundles.Options()
+	err := bundles.RunBundles(opts...)
+	if c.FailOnBundleErrors && err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -4,25 +4,25 @@ import (
 	"fmt"
 
 	config "github.com/kairos-io/kairos/pkg/config"
-	"github.com/kairos-io/kairos/pkg/machine"
-	"github.com/kairos-io/kairos/pkg/utils"
+	"github.com/kairos-io/kairos/sdk/system"
 )
 
 type GrubOptions struct{}
 
 func (b GrubOptions) Run(c config.Config) error {
-
-	machine.Mount("COS_OEM", "/tmp/oem") //nolint:errcheck
-	defer func() {
-		machine.Umount("/tmp/oem")
-	}()
-	for k, v := range c.Install.GrubOptions {
-		out, err := utils.SH(fmt.Sprintf(`grub2-editenv /tmp/oem/grubenv set "%s=%s"`, k, v))
-		if err != nil {
-			fmt.Printf("could not set boot option: %s\n", out+err.Error())
-			return nil // do not error out
-		}
+	err := system.Apply(system.SetGRUBOptions(c.Install.GrubOptions))
+	if err != nil {
+		fmt.Println(err)
 	}
+	return nil
+}
 
+type GrubPostInstallOptions struct{}
+
+func (b GrubPostInstallOptions) Run(c config.Config) error {
+	err := system.Apply(system.SetGRUBOptions(c.GrubOptions))
+	if err != nil {
+		fmt.Println(err)
+	}
 	return nil
 }

--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -16,6 +16,11 @@ var All = []Interface{
 	&Lifecycle{}, // Handles poweroff/reboot by config options
 }
 
+var FirstBoot = []Interface{
+	&BundlePostInstall{},
+	&GrubPostInstallOptions{},
+}
+
 func Run(c config.Config, hooks ...Interface) error {
 	for _, h := range hooks {
 		if err := h.Run(c); err != nil {

--- a/internal/agent/hooks/kcrypt.go
+++ b/internal/agent/hooks/kcrypt.go
@@ -21,7 +21,7 @@ func (k Kcrypt) Run(c config.Config) error {
 
 	machine.Mount("COS_OEM", "/oem") //nolint:errcheck
 	defer func() {
-		machine.Umount("/oem")
+		machine.Umount("/oem") //nolint:errcheck
 	}()
 
 	_ = os.MkdirAll("/oem/system/discovery", 0650)

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 	"time"
 
@@ -227,14 +226,8 @@ func RunInstall(options map[string]string) error {
 		c.Install.Reboot = true
 	}
 
-	for _, e := range c.Install.Env {
-		pair := strings.SplitN(e, "=", 2)
-		if len(pair) >= 2 {
-			os.Setenv(pair[0], pair[1])
-		}
-	}
-
-	envs := os.Environ()
+	env := append(c.Install.Env, c.Env...)
+	utils.SetEnv(env)
 
 	err := ioutil.WriteFile(f.Name(), []byte(cloudInit), os.ModePerm)
 	if err != nil {
@@ -246,7 +239,7 @@ func RunInstall(options map[string]string) error {
 	args = append(args, "-c", f.Name(), device)
 
 	cmd := exec.Command("elemental", args...)
-	cmd.Env = envs
+	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr

--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kairos-io/kairos/internal/bus"
 	"github.com/kairos-io/kairos/internal/cmd"
+	"github.com/kairos-io/kairos/pkg/config"
 	"github.com/kairos-io/kairos/pkg/machine"
 	"github.com/kairos-io/kairos/pkg/utils"
 	sdk "github.com/kairos-io/kairos/sdk/bus"
@@ -18,7 +19,7 @@ import (
 	"github.com/pterm/pterm"
 )
 
-func Reset() error {
+func Reset(dir ...string) error {
 	bus.Manager.Initialize()
 
 	options := map[string]string{}
@@ -69,6 +70,13 @@ func Reset() error {
 	} else {
 		args = append(args, "--reset-persistent")
 	}
+
+	c, err := config.Scan(config.Directories(dir...))
+	if err != nil {
+		return err
+	}
+
+	utils.SetEnv(c.Env)
 
 	cmd := exec.Command("elemental", args...)
 	cmd.Env = os.Environ()

--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/kairos-io/kairos/pkg/config"
 	events "github.com/kairos-io/kairos/sdk/bus"
 
 	"github.com/kairos-io/kairos/internal/bus"
@@ -40,7 +41,7 @@ func ListReleases() []string {
 	return releases
 }
 
-func Upgrade(version, image string, force, debug bool) error {
+func Upgrade(version, image string, force, debug bool, dirs []string) error {
 	bus.Manager.Initialize()
 
 	if version == "" && image == "" {
@@ -87,6 +88,13 @@ func Upgrade(version, image string, force, debug bool) error {
 	if debug {
 		fmt.Printf("Upgrading to image: '%s'\n", img)
 	}
+
+	c, err := config.Scan(config.Directories(dirs...))
+	if err != nil {
+		return err
+	}
+
+	utils.SetEnv(c.Env)
 
 	args := []string{"upgrade", "--system.uri", fmt.Sprintf("docker:%s", img)}
 

--- a/overlay/files-opensuse-arm-rpi/etc/elemental/config.yaml
+++ b/overlay/files-opensuse-arm-rpi/etc/elemental/config.yaml
@@ -16,3 +16,7 @@ reset:
   grub-entry-name: "kairos"
   system:
     size: 2000
+
+cloud-init-paths:
+- /run/initramfs/cos-state
+# - /run/initramfs/live

--- a/overlay/files/etc/elemental/config.yaml
+++ b/overlay/files/etc/elemental/config.yaml
@@ -16,3 +16,7 @@ reset:
   grub-entry-name: "Kairos"
   system:
     size: 3000
+
+cloud-init-paths:
+- /run/initramfs/cos-state
+# - /run/initramfs/live

--- a/overlay/files/etc/motd
+++ b/overlay/files/etc/motd
@@ -1,3 +1,3 @@
-Welcome to kairos!
+Welcome to Kairos!
 
 Refer to https://kairos.io for documentation.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,9 @@ type Config struct {
 	Options            map[string]string `yaml:"options,omitempty"`
 	FailOnBundleErrors bool              `yaml:"fail_on_bundles_errors,omitempty"`
 	Bundles            Bundles           `yaml:"bundles,omitempty"`
+	Env                []string          `yaml:"env,omitempty"`
+	GrubOptions        map[string]string `yaml:"grub_options,omitempty"`
+	Env                []string          `yaml:"env,omitempty"`
 }
 
 type Bundles []Bundle

--- a/pkg/machine/partitions.go
+++ b/pkg/machine/partitions.go
@@ -8,8 +8,20 @@ import (
 	"github.com/kairos-io/kairos/pkg/utils"
 )
 
-func Umount(path string) {
-	utils.SH(fmt.Sprintf("umount %s", path)) //nolint:errcheck
+func Umount(path string) error {
+	out, err := utils.SH(fmt.Sprintf("umount %s", path))
+	if err != nil {
+		return fmt.Errorf("failed umounting: %s: %w", out, err)
+	}
+	return nil
+}
+
+func Remount(opt, path string) error {
+	out, err := utils.SH(fmt.Sprintf("mount -o %s,remount %s", opt, path))
+	if err != nil {
+		return fmt.Errorf("failed umounting: %s: %w", out, err)
+	}
+	return nil
 }
 
 func Mount(label, mountpoint string) error {

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"os"
+	"strings"
+)
+
+func SetEnv(env []string) {
+
+	for _, e := range env {
+		pair := strings.SplitN(e, "=", 2)
+		if len(pair) >= 2 {
+			os.Setenv(pair[0], pair[1])
+		}
+	}
+}

--- a/repositories/repositories.yaml
+++ b/repositories/repositories.yaml
@@ -9,9 +9,9 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20221020115841-repository.yaml
+    reference: 20221022083123-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20221020120655-repository.yaml
+    reference: 20221022090040-repository.yaml

--- a/sdk/mounts/system.go
+++ b/sdk/mounts/system.go
@@ -1,0 +1,34 @@
+package mounts
+
+import (
+	"fmt"
+
+	"github.com/kairos-io/kairos/pkg/machine"
+	"github.com/kairos-io/kairos/sdk/state"
+)
+
+func PrepareWrite(partition state.PartitionState, mountpath string) error {
+	if partition.Mounted && partition.IsReadOnly {
+		if mountpath == partition.MountPoint {
+			return machine.Remount("rw", partition.MountPoint)
+		}
+		err := machine.Remount("rw", partition.MountPoint)
+		if err != nil {
+			return err
+		}
+		return machine.Mount(partition.Label, mountpath)
+	}
+
+	return machine.Mount(partition.Label, mountpath)
+}
+
+func Mount(partition state.PartitionState, mountpath string) error {
+	return machine.Mount(partition.Label, mountpath)
+}
+
+func Umount(partition state.PartitionState) error {
+	if !partition.Mounted {
+		return fmt.Errorf("partition not mounted")
+	}
+	return machine.Umount(partition.MountPoint)
+}

--- a/sdk/state/machine.go
+++ b/sdk/state/machine.go
@@ -1,0 +1,10 @@
+package state
+
+type Machine struct {
+	BootArgs    []string
+	CloudConfig string
+}
+
+type Spec struct {
+	MachineSpec Machine
+}

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -1,0 +1,146 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/itchyny/gojq"
+	"github.com/jaypipes/ghw"
+	"github.com/jaypipes/ghw/pkg/block"
+	"github.com/kairos-io/kairos/pkg/machine"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	Active   Boot = "active_boot"
+	Passive  Boot = "passive_boot"
+	Recovery Boot = "recovery_boot"
+	LiveCD   Boot = "livecd_boot"
+	Unknown  Boot = "unknown"
+)
+
+type Boot string
+
+type PartitionState struct {
+	Mounted    bool   `yaml:"mounted" json:"mounted"`
+	Name       string `yaml:"name" json:"name"`
+	Label      string `yaml:"label" json:"label"`
+	MountPoint string `yaml:"mount_point" json:"mount_point"`
+	SizeBytes  uint64 `yaml:"size_bytes" json:"size_bytes"`
+	Type       string `yaml:"type" json:"type"`
+	IsReadOnly bool   `yaml:"read_only" json:"read_only"`
+	UUID       string `yaml:"uuid" json:"uuid"` // This would be volume UUID on macOS, PartUUID on linux, empty on Windows
+}
+
+type Runtime struct {
+	UUID       string         `yaml:"uuid" json:"uuid"`
+	Persistent PartitionState `yaml:"persistent" json:"persistent"`
+	Recovery   PartitionState `yaml:"recovery" json:"recovery"`
+	OEM        PartitionState `yaml:"oem" json:"oem"`
+	State      PartitionState `yaml:"state" json:"state"`
+	BootState  Boot           `yaml:"boot" json:"boot"`
+}
+
+func detectPartition(b *block.Partition) PartitionState {
+	return PartitionState{
+		Type:       b.Type,
+		IsReadOnly: b.IsReadOnly,
+		UUID:       b.UUID,
+		Name:       fmt.Sprintf("/dev/%s", b.Name),
+		SizeBytes:  b.SizeBytes,
+		Label:      b.Label,
+		MountPoint: b.MountPoint,
+		Mounted:    b.MountPoint != "",
+	}
+}
+
+func detectBoot() Boot {
+	cmdline, err := ioutil.ReadFile("/proc/cmdline")
+	if err != nil {
+		return Unknown
+	}
+	cmdlineS := string(cmdline)
+	switch {
+	case strings.Contains(cmdlineS, "COS_ACTIVE"):
+		return Active
+	case strings.Contains(cmdlineS, "COS_PASSIVE"):
+		return Passive
+	case strings.Contains(cmdlineS, "COS_RECOVERY"), strings.Contains(cmdlineS, "COS_SYSTEM"):
+		return Recovery
+	case strings.Contains(cmdlineS, "live:LABEL"), strings.Contains(cmdlineS, "live:CDLABEL"):
+		return LiveCD
+	default:
+		return Unknown
+	}
+}
+
+func detectRuntimeState(r *Runtime) error {
+	blockDevices, err := block.New(ghw.WithDisableTools(), ghw.WithDisableWarnings())
+	if err != nil {
+		return err
+	}
+	for _, d := range blockDevices.Disks {
+		for _, part := range d.Partitions {
+			switch part.Label {
+			case "COS_PERSISTENT":
+				r.Persistent = detectPartition(part)
+			case "COS_RECOVERY":
+				r.Recovery = detectPartition(part)
+			case "COS_OEM":
+				r.OEM = detectPartition(part)
+			case "COS_STATE":
+				r.State = detectPartition(part)
+			}
+		}
+	}
+	return nil
+}
+
+func NewRuntime() (Runtime, error) {
+	runtime := &Runtime{
+		BootState: detectBoot(),
+		UUID:      machine.UUID(),
+	}
+	err := detectRuntimeState(runtime)
+	return *runtime, err
+}
+
+func (r Runtime) String() string {
+	dat, err := yaml.Marshal(r)
+	if err == nil {
+		return string(dat)
+	}
+	return ""
+}
+
+func (r Runtime) Query(s string) (res string, err error) {
+	s = fmt.Sprintf(".%s", s)
+	jsondata := map[string]interface{}{}
+	var dat []byte
+	dat, err = json.Marshal(r)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(dat, &jsondata)
+	if err != nil {
+		return
+	}
+	query, err := gojq.Parse(s)
+	if err != nil {
+		return res, err
+	}
+	iter := query.Run(jsondata) // or query.RunWithContext
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, ok := v.(error); ok {
+			return res, err
+		}
+		res += fmt.Sprint(v)
+	}
+	return
+}

--- a/sdk/system/cloudconfig.go
+++ b/sdk/system/cloudconfig.go
@@ -1,0 +1,87 @@
+package system
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/kairos-io/kairos/pkg/machine"
+	"github.com/kairos-io/kairos/sdk/mounts"
+	"github.com/kairos-io/kairos/sdk/state"
+)
+
+// WriteCloudConfigData adds cloud config data in runtime.
+func WriteCloudConfigData(cloudConfig, filename string) Option {
+	return func(c *Changeset) error {
+		if len(cloudConfig) > 0 {
+			c.Add(func() error { return addCloudConfig(cloudConfig, filename) })
+		}
+		return nil
+	}
+}
+
+func addCloudConfig(cloudConfig, filename string) error {
+	runtime, err := state.NewRuntime()
+	if err != nil {
+		return err
+	}
+
+	oem := runtime.OEM
+	if runtime.OEM.Name == "" {
+		return addLocalCloudConfig(cloudConfig, filename)
+	}
+
+	return writeCloudConfig(oem, cloudConfig, "", filename)
+}
+
+func writeCloudConfig(oem state.PartitionState, cloudConfig, subpath, filename string) error {
+	mountPath := "/tmp/oem"
+
+	if err := mounts.PrepareWrite(oem, mountPath); err != nil {
+		return err
+	}
+	defer func() {
+		machine.Umount(mountPath) //nolint:errcheck
+	}()
+	_ = os.MkdirAll(filepath.Join(mountPath, subpath), 0650)
+	return ioutil.WriteFile(filepath.Join(mountPath, subpath, fmt.Sprintf("%s.yaml", filename)), []byte(cloudConfig), 0650)
+}
+
+// WriteCloudConfigData adds cloud config data to oem (/oem or /usr/local/cloud-config, depending if OEM partition exists).
+func WritePersistentCloudData(cloudConfig, filename string) Option {
+	return func(c *Changeset) error {
+		if len(cloudConfig) > 0 {
+			c.Add(func() error { return addPersistentCloudConfig(cloudConfig, filename) })
+		}
+		return nil
+	}
+}
+
+// WriteLocalCloudConfigData adds cloud config data to /usr/local/cloud-config.
+func WriteLocalPersistentCloudData(cloudConfig, filename string) Option {
+	return func(c *Changeset) error {
+		if len(cloudConfig) > 0 {
+			c.Add(func() error { return addLocalCloudConfig(cloudConfig, filename) })
+		}
+		return nil
+	}
+}
+
+func addPersistentCloudConfig(cloudConfig, filename string) error {
+	runtime, err := state.NewRuntime()
+	if err != nil {
+		return err
+	}
+
+	return writeCloudConfig(runtime.State, cloudConfig, "", filename)
+}
+
+func addLocalCloudConfig(cloudConfig, filename string) error {
+	runtime, err := state.NewRuntime()
+	if err != nil {
+		return err
+	}
+
+	return writeCloudConfig(runtime.Persistent, cloudConfig, "cloud-config", filename)
+}

--- a/sdk/system/grub.go
+++ b/sdk/system/grub.go
@@ -1,0 +1,47 @@
+package system
+
+import (
+	"fmt"
+
+	"github.com/kairos-io/kairos/pkg/machine"
+	"github.com/kairos-io/kairos/pkg/utils"
+	"github.com/kairos-io/kairos/sdk/mounts"
+	"github.com/kairos-io/kairos/sdk/state"
+)
+
+func SetGRUBOptions(opts map[string]string) Option {
+	return func(c *Changeset) error {
+		if len(opts) > 0 {
+			c.Add(func() error { return setGRUBOptions(opts) })
+		}
+		return nil
+	}
+}
+
+func setGRUBOptions(opts map[string]string) error {
+	runtime, err := state.NewRuntime()
+	if err != nil {
+		return err
+	}
+
+	oem := runtime.OEM
+	if runtime.OEM.Name == "" {
+		oem = runtime.Persistent
+	}
+
+	if err := mounts.PrepareWrite(oem, "/tmp/oem"); err != nil {
+		return err
+	}
+	defer func() {
+		machine.Umount("/tmp/oem") //nolint:errcheck
+	}()
+
+	for k, v := range opts {
+		out, err := utils.SH(fmt.Sprintf(`grub2-editenv /tmp/oem/grubenv set "%s=%s"`, k, v))
+		if err != nil {
+			fmt.Printf("could not set boot option: %s\n", out+err.Error())
+		}
+	}
+
+	return nil
+}

--- a/sdk/system/options.go
+++ b/sdk/system/options.go
@@ -1,0 +1,30 @@
+package system
+
+import (
+	"github.com/hashicorp/go-multierror"
+)
+
+type Changeset []func() error
+
+func (c *Changeset) Add(f func() error) {
+	*c = append(*c, f)
+}
+
+type Option func(c *Changeset) error
+
+func Apply(opts ...Option) error {
+
+	c := &Changeset{}
+	for _, o := range opts {
+		if err := o(c); err != nil {
+			return err
+		}
+	}
+
+	var err error
+	for _, f := range *c {
+		err = multierror.Append(f())
+	}
+
+	return err
+}

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -12,6 +12,13 @@ import (
 )
 
 var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
+
+	stateAssert := func(query, expected string) {
+		out, err := Sudo(fmt.Sprintf("kairos-agent state get %s", query))
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		ExpectWithOffset(1, out).To(ContainSubstring(expected))
+	}
+
 	BeforeEach(func() {
 		if os.Getenv("CLOUD_INIT") == "" || !filepath.IsAbs(os.Getenv("CLOUD_INIT")) {
 			Fail("CLOUD_INIT must be set and must be pointing to a file as an absolute path")
@@ -69,27 +76,29 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 					ContainSubstring("elemental install"),
 				))
 		})
+		It("reboots to active", func() {
+			Eventually(func() string {
+				out, _ := Sudo("kairos-agent state boot")
+				return out
+			}, 40*time.Minute, 10*time.Second).Should(
+				Or(
+					ContainSubstring("active_boot"),
+				))
+		})
 	})
 
 	Context("reboots and passes functional tests", func() {
 		It("has grubenv file", func() {
-			Eventually(func() string {
-				out, _ := Sudo("sudo cat /oem/grubenv")
-				return out
-			}, 40*time.Minute, 1*time.Second).Should(
-				Or(
-					ContainSubstring("foobarzz"),
-				))
+			out, err := Sudo("cat /oem/grubenv")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("foobarzz"))
+
 		})
 
 		It("has custom cmdline", func() {
-			Eventually(func() string {
-				out, _ := Sudo("sudo cat /proc/cmdline")
-				return out
-			}, 30*time.Minute, 1*time.Second).Should(
-				Or(
-					ContainSubstring("foobarzz"),
-				))
+			out, err := Sudo("cat /proc/cmdline")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("foobarzz"))
 		})
 
 		It("uses the dracut immutable module", func() {
@@ -118,6 +127,26 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(out).To(ContainSubstring("foo"))
+		})
+
+		It("has corresponding state", func() {
+			out, err := Sudo("kairos-agent state")
+			Expect(err).ToNot(HaveOccurred())
+			fmt.Println(out)
+			Expect(out).To(ContainSubstring("boot: active_boot"))
+
+			stateAssert("oem.mounted", "true")
+			stateAssert("persistent.mounted", "true")
+			stateAssert("state.mounted", "true")
+			stateAssert("oem.type", "ext4")
+			stateAssert("persistent.type", "ext4")
+			stateAssert("state.type", "ext4")
+			stateAssert("oem.mount_point", "/oem")
+			stateAssert("persistent.mount_point", "/usr/local")
+			stateAssert("state.mount_point", "/run/initramfs/cos-state")
+			stateAssert("oem.read_only", "false")
+			stateAssert("persistent.read_only", "false")
+			stateAssert("state.read_only", "true")
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for elemental process to have access to env variables set in Config.Install.Env in reset

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #259 
