### PR TITLE
:sparkles: enhancements

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -184,7 +184,7 @@ E.g. kairos-agent install-bundle container:quay.io/kairos/kairos...
 	{
 		Name:        "state",
 		Usage:       "get machine state",
-		Description: "Print machine state information, e.g. `state get .uuid` returns the machine uuid",
+		Description: "Print machine state information, e.g. `state get uuid` returns the machine uuid",
 		Aliases:     []string{"s"},
 		Action: func(c *cli.Context) error {
 			runtime, err := state.NewRuntime()
@@ -199,7 +199,7 @@ E.g. kairos-agent install-bundle container:quay.io/kairos/kairos...
 			{
 				Name:        "apply",
 				Usage:       "Applies a machine state",
-				Description: "Set runtime machine configuration",
+				Description: "Applies machine configuration in runtimes",
 				Aliases:     []string{"a"},
 				Action: func(c *cli.Context) error {
 					// TODO

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,10 +8,10 @@ import (
 
 	events "github.com/kairos-io/kairos/sdk/bus"
 
+	hook "github.com/kairos-io/kairos/internal/agent/hooks"
 	"github.com/kairos-io/kairos/internal/bus"
 	config "github.com/kairos-io/kairos/pkg/config"
 	machine "github.com/kairos-io/kairos/pkg/machine"
-	bundles "github.com/kairos-io/kairos/sdk/bundles"
 	"github.com/nxadm/tail"
 )
 
@@ -60,16 +60,15 @@ func Run(opts ...Option) error {
 		}
 	}()
 
-	if !machine.SentinelExist("bundles") {
-		opts := c.Bundles.Options()
-		err := bundles.RunBundles(opts...)
-		if c.FailOnBundleErrors && err != nil {
+	if !machine.SentinelExist("firstboot") {
+
+		if err := hook.Run(*c, hook.FirstBoot...); err != nil {
 			return err
 		}
 
 		// Re-load providers
 		bus.Reload()
-		err = machine.CreateSentinel("bundles")
+		err = machine.CreateSentinel("firstboot")
 		if c.FailOnBundleErrors && err != nil {
 			return err
 		}

--- a/internal/agent/hooks/bundles.go
+++ b/internal/agent/hooks/bundles.go
@@ -28,3 +28,14 @@ func (b BundleOption) Run(c config.Config) error {
 
 	return nil
 }
+
+type BundlePostInstall struct{}
+
+func (b BundlePostInstall) Run(c config.Config) error {
+	opts := c.Bundles.Options()
+	err := bundles.RunBundles(opts...)
+	if c.FailOnBundleErrors && err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -16,3 +16,13 @@ func (b GrubOptions) Run(c config.Config) error {
 	}
 	return nil
 }
+
+type GrubPostInstallOptions struct{}
+
+func (b GrubPostInstallOptions) Run(c config.Config) error {
+	err := system.Apply(system.SetGRUBOptions(c.GrubOptions))
+	if err != nil {
+		fmt.Println(err)
+	}
+	return nil
+}

--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -16,6 +16,11 @@ var All = []Interface{
 	&Lifecycle{}, // Handles poweroff/reboot by config options
 }
 
+var FirstBoot = []Interface{
+	&BundlePostInstall{},
+	&GrubPostInstallOptions{},
+}
+
 func Run(c config.Config, hooks ...Interface) error {
 	for _, h := range hooks {
 		if err := h.Run(c); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	Options            map[string]string `yaml:"options,omitempty"`
 	FailOnBundleErrors bool              `yaml:"fail_on_bundles_errors,omitempty"`
 	Bundles            Bundles           `yaml:"bundles,omitempty"`
+	GrubOptions        map[string]string `yaml:"grub_options,omitempty"`
 }
 
 type Bundles []Bundle

--- a/sdk/state/machine.go
+++ b/sdk/state/machine.go
@@ -1,7 +1,6 @@
 package state
 
 type Machine struct {
-	UUID        string
 	BootArgs    []string
 	CloudConfig string
 }

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -37,6 +37,7 @@ type PartitionState struct {
 type Runtime struct {
 	UUID       string         `yaml:"uuid" json:"uuid"`
 	Persistent PartitionState `yaml:"persistent" json:"persistent"`
+	Recovery   PartitionState `yaml:"recovery" json:"recovery"`
 	OEM        PartitionState `yaml:"oem" json:"oem"`
 	State      PartitionState `yaml:"state" json:"state"`
 	BootState  Boot           `yaml:"boot" json:"boot"`
@@ -85,6 +86,8 @@ func detectRuntimeState(r *Runtime) error {
 			switch part.Label {
 			case "COS_PERSISTENT":
 				r.Persistent = detectPartition(part)
+			case "COS_RECOVERY":
+				r.Recovery = detectPartition(part)
 			case "COS_OEM":
 				r.OEM = detectPartition(part)
 			case "COS_STATE":

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -113,6 +113,7 @@ func (r Runtime) String() string {
 }
 
 func (r Runtime) Query(s string) (res string, err error) {
+	s = fmt.Sprintf(".%s", s)
 	jsondata := map[string]interface{}{}
 	var dat []byte
 	dat, err = json.Marshal(r)

--- a/sdk/system/cloudconfig.go
+++ b/sdk/system/cloudconfig.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kairos-io/kairos/sdk/state"
 )
 
-// WriteCloudConfigData adds cloud config data in runtime
+// WriteCloudConfigData adds cloud config data in runtime.
 func WriteCloudConfigData(cloudConfig, filename string) Option {
 	return func(c *Changeset) error {
 		if len(cloudConfig) > 0 {
@@ -44,11 +44,11 @@ func writeCloudConfig(oem state.PartitionState, cloudConfig, subpath, filename s
 	defer func() {
 		machine.Umount(mountPath) //nolint:errcheck
 	}()
-	os.MkdirAll(filepath.Join(mountPath, subpath), 0650)
+	_ = os.MkdirAll(filepath.Join(mountPath, subpath), 0650)
 	return ioutil.WriteFile(filepath.Join(mountPath, subpath, fmt.Sprintf("%s.yaml", filename)), []byte(cloudConfig), 0650)
 }
 
-// WriteCloudConfigData adds cloud config data to oem (/oem or /usr/local/cloud-config, depending if OEM partition exists)
+// WriteCloudConfigData adds cloud config data to oem (/oem or /usr/local/cloud-config, depending if OEM partition exists).
 func WritePersistentCloudData(cloudConfig, filename string) Option {
 	return func(c *Changeset) error {
 		if len(cloudConfig) > 0 {
@@ -58,7 +58,7 @@ func WritePersistentCloudData(cloudConfig, filename string) Option {
 	}
 }
 
-// WriteLocalCloudConfigData adds cloud config data to /usr/local/cloud-config
+// WriteLocalCloudConfigData adds cloud config data to /usr/local/cloud-config.
 func WriteLocalPersistentCloudData(cloudConfig, filename string) Option {
 	return func(c *Changeset) error {
 		if len(cloudConfig) > 0 {

--- a/sdk/system/cloudconfig.go
+++ b/sdk/system/cloudconfig.go
@@ -1,0 +1,87 @@
+package system
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/kairos-io/kairos/pkg/machine"
+	"github.com/kairos-io/kairos/sdk/mounts"
+	"github.com/kairos-io/kairos/sdk/state"
+)
+
+// WriteCloudConfigData adds cloud config data in runtime
+func WriteCloudConfigData(cloudConfig, filename string) Option {
+	return func(c *Changeset) error {
+		if len(cloudConfig) > 0 {
+			c.Add(func() error { return addCloudConfig(cloudConfig, filename) })
+		}
+		return nil
+	}
+}
+
+func addCloudConfig(cloudConfig, filename string) error {
+	runtime, err := state.NewRuntime()
+	if err != nil {
+		return err
+	}
+
+	oem := runtime.OEM
+	if runtime.OEM.Name == "" {
+		return addLocalCloudConfig(cloudConfig, filename)
+	}
+
+	return writeCloudConfig(oem, cloudConfig, "", filename)
+}
+
+func writeCloudConfig(oem state.PartitionState, cloudConfig, subpath, filename string) error {
+	mountPath := "/tmp/oem"
+
+	if err := mounts.PrepareWrite(oem, mountPath); err != nil {
+		return err
+	}
+	defer func() {
+		machine.Umount(mountPath) //nolint:errcheck
+	}()
+	os.MkdirAll(filepath.Join(mountPath, subpath), 0650)
+	return ioutil.WriteFile(filepath.Join(mountPath, subpath, fmt.Sprintf("%s.yaml", filename)), []byte(cloudConfig), 0650)
+}
+
+// WriteCloudConfigData adds cloud config data to oem (/oem or /usr/local/cloud-config, depending if OEM partition exists)
+func WritePersistentCloudData(cloudConfig, filename string) Option {
+	return func(c *Changeset) error {
+		if len(cloudConfig) > 0 {
+			c.Add(func() error { return addPersistentCloudConfig(cloudConfig, filename) })
+		}
+		return nil
+	}
+}
+
+// WriteLocalCloudConfigData adds cloud config data to /usr/local/cloud-config
+func WriteLocalPersistentCloudData(cloudConfig, filename string) Option {
+	return func(c *Changeset) error {
+		if len(cloudConfig) > 0 {
+			c.Add(func() error { return addLocalCloudConfig(cloudConfig, filename) })
+		}
+		return nil
+	}
+}
+
+func addPersistentCloudConfig(cloudConfig, filename string) error {
+	runtime, err := state.NewRuntime()
+	if err != nil {
+		return err
+	}
+
+	return writeCloudConfig(runtime.State, cloudConfig, "", filename)
+}
+
+func addLocalCloudConfig(cloudConfig, filename string) error {
+	runtime, err := state.NewRuntime()
+	if err != nil {
+		return err
+	}
+
+	return writeCloudConfig(runtime.Persistent, cloudConfig, "cloud-config", filename)
+}

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 
 	stateAssert := func(query, expected string) {
-		out, err := Sudo(fmt.Sprintf("kairos-agent state get .%s", query))
+		out, err := Sudo(fmt.Sprintf("kairos-agent state get %s", query))
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		ExpectWithOffset(1, out).To(ContainSubstring(expected))
 	}

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -76,27 +76,29 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 					ContainSubstring("elemental install"),
 				))
 		})
+		It("reboots to active", func() {
+			Eventually(func() string {
+				out, _ := Sudo("kairos-agent state boot")
+				return out
+			}, 40*time.Minute, 10*time.Second).Should(
+				Or(
+					ContainSubstring("active_boot"),
+				))
+		})
 	})
 
 	Context("reboots and passes functional tests", func() {
 		It("has grubenv file", func() {
-			Eventually(func() string {
-				out, _ := Sudo("sudo cat /oem/grubenv")
-				return out
-			}, 40*time.Minute, 1*time.Second).Should(
-				Or(
-					ContainSubstring("foobarzz"),
-				))
+			out, err := Sudo("cat /oem/grubenv")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("foobarzz"))
+
 		})
 
 		It("has custom cmdline", func() {
-			Eventually(func() string {
-				out, _ := Sudo("sudo cat /proc/cmdline")
-				return out
-			}, 30*time.Minute, 1*time.Second).Should(
-				Or(
-					ContainSubstring("foobarzz"),
-				))
+			out, err := Sudo("cat /proc/cmdline")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("foobarzz"))
 		})
 
 		It("uses the dracut immutable module", func() {


### PR DESCRIPTION
**What this PR does / why we need it**: 

- Avoids to add '.' as a query prefix to state api
- Adds recovery to state api
- Adds cloudconfig SDK commands to add cloud configs in runtime
- Refactors hook so that they use the same interface - a different set is used for firstboot and the sentinel file for bundles has changed to a more generic name