### PR TITLE
✨ add env to config to use across all stages 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ docs/public
 docs/.vscode
 
 .DS_Store
+
+# editor and IDE paraphernalia
+.idea

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -15,6 +15,8 @@ import (
 	"github.com/urfave/cli"
 )
 
+var configScanDir = []string{"/oem", "/usr/local/cloud-config", "/run/initramfs/live"}
+
 var cmds = []cli.Command{
 	{
 		Name: "upgrade",
@@ -74,8 +76,7 @@ See https://kairos.io/after_install/upgrades/#manual for documentation.
 			if len(args) == 1 {
 				v = args[0]
 			}
-
-			return agent.Upgrade(v, c.String("image"), c.Bool("force"), c.Bool("debug"))
+			return agent.Upgrade(v, c.String("image"), c.Bool("force"), c.Bool("debug"), configScanDir)
 		},
 	},
 
@@ -294,7 +295,7 @@ See also https://kairos.io/installation/device_pairing/ for documentation.
 This command is meant to be used from the boot GRUB menu, but can be started manually`,
 		Aliases: []string{"i"},
 		Action: func(c *cli.Context) error {
-			return agent.Install("/oem", "/usr/local/cloud-config", "/run/initramfs/live")
+			return agent.Install(configScanDir...)
 		},
 	},
 	{
@@ -318,7 +319,7 @@ This command is meant to be used from the boot GRUB menu, but can likely be used
 	{
 		Name: "reset",
 		Action: func(c *cli.Context) error {
-			return agent.Reset()
+			return agent.Reset(configScanDir...)
 		},
 		Usage: "Starts kairos reset mode",
 		Description: `

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 	"time"
 
@@ -227,14 +226,8 @@ func RunInstall(options map[string]string) error {
 		c.Install.Reboot = true
 	}
 
-	for _, e := range c.Install.Env {
-		pair := strings.SplitN(e, "=", 2)
-		if len(pair) >= 2 {
-			os.Setenv(pair[0], pair[1])
-		}
-	}
-
-	envs := os.Environ()
+	env := append(c.Install.Env, c.Env...)
+	utils.SetEnv(env)
 
 	err := ioutil.WriteFile(f.Name(), []byte(cloudInit), os.ModePerm)
 	if err != nil {
@@ -246,7 +239,7 @@ func RunInstall(options map[string]string) error {
 	args = append(args, "-c", f.Name(), device)
 
 	cmd := exec.Command("elemental", args...)
-	cmd.Env = envs
+	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr

--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kairos-io/kairos/internal/bus"
 	"github.com/kairos-io/kairos/internal/cmd"
+	"github.com/kairos-io/kairos/pkg/config"
 	"github.com/kairos-io/kairos/pkg/machine"
 	"github.com/kairos-io/kairos/pkg/utils"
 	sdk "github.com/kairos-io/kairos/sdk/bus"
@@ -18,7 +19,7 @@ import (
 	"github.com/pterm/pterm"
 )
 
-func Reset() error {
+func Reset(dir ...string) error {
 	bus.Manager.Initialize()
 
 	options := map[string]string{}
@@ -69,6 +70,13 @@ func Reset() error {
 	} else {
 		args = append(args, "--reset-persistent")
 	}
+
+	c, err := config.Scan(config.Directories(dir...))
+	if err != nil {
+		return err
+	}
+
+	utils.SetEnv(c.Env)
 
 	cmd := exec.Command("elemental", args...)
 	cmd.Env = os.Environ()

--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/kairos-io/kairos/pkg/config"
 	events "github.com/kairos-io/kairos/sdk/bus"
 
 	"github.com/kairos-io/kairos/internal/bus"
@@ -40,7 +41,7 @@ func ListReleases() []string {
 	return releases
 }
 
-func Upgrade(version, image string, force, debug bool) error {
+func Upgrade(version, image string, force, debug bool, dirs []string) error {
 	bus.Manager.Initialize()
 
 	if version == "" && image == "" {
@@ -87,6 +88,13 @@ func Upgrade(version, image string, force, debug bool) error {
 	if debug {
 		fmt.Printf("Upgrading to image: '%s'\n", img)
 	}
+
+	c, err := config.Scan(config.Directories(dirs...))
+	if err != nil {
+		return err
+	}
+
+	utils.SetEnv(c.Env)
 
 	args := []string{"upgrade", "--system.uri", fmt.Sprintf("docker:%s", img)}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	FailOnBundleErrors bool              `yaml:"fail_on_bundles_errors,omitempty"`
 	Bundles            Bundles           `yaml:"bundles,omitempty"`
 	GrubOptions        map[string]string `yaml:"grub_options,omitempty"`
+	Env                []string          `yaml:"env,omitempty"`
 }
 
 type Bundles []Bundle

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"os"
+	"strings"
+)
+
+func SetEnv(env []string) {
+
+	for _, e := range env {
+		pair := strings.SplitN(e, "=", 2)
+		if len(pair) >= 2 {
+			os.Setenv(pair[0], pair[1])
+		}
+	}
+}


### PR DESCRIPTION
What this PR does / why we need it:
Adds support for elemental process to have access to env variables set in Config.Install.Env in reset

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes https://github.com/kairos-io/kairos/issues/259

linking the earlier PR here [260](https://github.com/kairos-io/kairos/pull/260)
