### PR TITLE
:penguin: Add bonding and bridge to alpine x86_64 images

### DIFF
--- a/images/Dockerfile.alpine
+++ b/images/Dockerfile.alpine
@@ -7,6 +7,8 @@ RUN apk --no-cache add  \
       grub-efi \
       grub-bios \
       bash \
+      bonding \
+      bridge \
       connman \
       gettext \
       squashfs-tools \


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: Add bonding/bridge packages to core images (see https://wiki.alpinelinux.org/wiki/Bonding )
