### PR TITLE
:penguin: Add polkit to openSUSE images

### DIFF
--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -44,6 +44,7 @@ RUN zypper in -y \
     open-vm-tools \
     openssh \
     parted \
+    polkit \
     pigz \
     policycoreutils \
     procps \

--- a/images/Dockerfile.opensuse-arm-rpi
+++ b/images/Dockerfile.opensuse-arm-rpi
@@ -66,6 +66,7 @@ RUN zypper in -y \
     procps \
     sudo \
     sysconfig \
+    polkit \
     sysconfig-netconfig \
     sysvinit-tools \
     systemd-network \


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: Adds polkit to openSUSE images. polkit is used by hostnamed to set hostname with systemd-networkd.

**Which issue(s) this PR fixes** :
Fixes #280 
