### PR TITLE
:bug: Add default_path oem file

### DIFF
--- a/overlay/files/system/oem/25_default_paths.yaml
+++ b/overlay/files/system/oem/25_default_paths.yaml
@@ -1,0 +1,6 @@
+name: "default-paths"
+stages:
+   fs.before:
+     - name: "Default system dirs"
+       directories:
+       - path: /var/lib/longhorn

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -135,6 +135,12 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 			Expect(out).To(ContainSubstring("bpf"))
 		})
 
+		It("has additional mount specified, with no dir in rootfs", func() {
+			out, err := Sudo("mount")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("/var/lib/longhorn"))
+		})
+
 		It("has corresponding state", func() {
 			out, err := Sudo("kairos-agent state")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: This has the purpose to create default paths that are needed by the rootfs in order to be overlayed correctly by the initramfs. Note this is a workaround until a better solution with #210 is found, which manipulates directly the initramfs configuration for the mounts

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #292 
