### PR TITLE
:arrow_up: update luet version to 0.33.0

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -4,7 +4,7 @@ ARG VARIANT=core # core, lite, framework
 ARG FLAVOR=opensuse
 ARG IMAGE=quay.io/kairos/${VARIANT}-${FLAVOR}:latest
 ARG ISO_NAME=kairos-${VARIANT}-${FLAVOR}
-ARG LUET_VERSION=0.32.4
+ARG LUET_VERSION=0.33.0
 ARG OS_ID=kairos
 ARG REPOSITORIES_FILE=repositories.yaml
 


### PR DESCRIPTION
The PR upgrades luet to version 0.33.0
this version of luet reads proxy variables for environment.

