### PR TITLE
✨ add iptables and conntrack to ubuntu images

### DIFF
--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -34,6 +34,8 @@ RUN apt install -y \
     jq \
     neovim \
     open-vm-tools \
+    conntrack \
+    iptables \
     linux-image-generic-hwe-22.04 && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install

--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -34,6 +34,8 @@ RUN apt install -y \
     jq \
     neovim \
     open-vm-tools \
+    conntrack \
+    iptables \
     linux-image-generic-hwe-20.04 && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install

--- a/images/Dockerfile.ubuntu-22-lts
+++ b/images/Dockerfile.ubuntu-22-lts
@@ -34,6 +34,8 @@ RUN apt install -y \
     jq \
     neovim \
     open-vm-tools \
+    conntrack \
+    iptables \
     linux-image-generic-hwe-22.04 && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds iptables and conntrack tools to ubuntu images. This is needed as a requirement of kubeadm to deploy k8s clusters using provider. 