### PR TITLE
✨ set env on agent run

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -69,7 +69,7 @@ jobs:
           TAG=latest
           cosign sign quay.io/kairos/core-$FLAVOR:$TAG
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.flavor }}-image
           path: build

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -49,33 +49,33 @@ jobs:
           ./earthly.sh +all --IMAGE=$IMAGE --FLAVOR=$FLAVOR
           sudo mv build/* .
           sudo rm -rf build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: kairos-${{ matrix.flavor }}.iso.zip
           path: |
             *.iso
             *.sha256
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: kairos-${{ matrix.flavor }}.initrd.zip
           path: |
             *-initrd
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: kairos-${{ matrix.flavor }}.squashfs.zip
           path: |
             *.squashfs
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: kairos-${{ matrix.flavor }}.kernel.zip
           path: |
             *-kernel
             *-initrd
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: kairos-${{ matrix.flavor }}.ipxe.zip
           path: |
@@ -124,7 +124,7 @@ jobs:
               export CREATE_VM=true 
               export FLAVOR=${{ matrix.flavor }}
               ./.github/run_test.sh "install-test"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ${{ matrix.flavor }}-vbox.logs.zip
@@ -142,7 +142,7 @@ jobs:
         repository: "kairos-io/kairos"
         fileName: "*"
         out-file-path: "last-release"
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
           name: latest-release.zip
           path: last-release
@@ -278,7 +278,7 @@ jobs:
             sudo mkdir build
             sudo mv $ISO build/
             ./earthly.sh +run-qemu-test --FLAVOR=${{ matrix.flavor }} --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h --TEST_SUITE=upgrade-with-cli
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: ${{ matrix.flavor }}-upgrade-test.logs.zip
@@ -341,7 +341,7 @@ jobs:
             sudo mkdir build
             sudo mv $ISO build/
             ./earthly.sh +run-qemu-test --FLAVOR=${{ matrix.flavor }} --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h --TEST_SUITE=upgrade-latest-with-cli
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: ${{ matrix.flavor }}-upgrade-test.logs.zip

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -112,7 +112,7 @@ jobs:
         run: |
           brew install cdrtools jq
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
             go-version: '^1.16'
       - run: |

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -105,7 +105,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: kairos-${{ matrix.flavor }}.iso.zip
       - name: Install deps
@@ -164,7 +164,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
           name: kairos-${{ matrix.flavor }}.iso.zip
     - run: |
@@ -187,7 +187,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
           name: kairos-${{ matrix.flavor }}.iso.zip
     - run: |
@@ -212,7 +212,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
           name: kairos-${{ matrix.flavor }}.iso.zip
     - run: |
@@ -237,7 +237,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: kairos-${{ matrix.flavor }}.iso.zip
     - name: Release space from worker
@@ -300,7 +300,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: latest-release.zip
     - name: Release space from worker

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '^1.18'
       - name: Run Lint checks

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -77,7 +77,7 @@ jobs:
           sudo -E docker load -i image.tar
           sudo -E docker push quay.io/kairos/core-${{ matrix.flavor }}:$VERSION.img
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.flavor }}-image
           path: build

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/setup-buildx-action@master
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
       - run: |
           sudo mv release/*.iso ./
           sudo mv release/*.sha256 ./
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: kairos-${{ matrix.flavor }}.iso.zip
           path: |

--- a/.github/workflows/release_bin.yaml
+++ b/.github/workflows/release_bin.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
       - name: Run GoReleaser

--- a/.github/workflows/release_bin.yaml
+++ b/.github/workflows/release_bin.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.17
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: '^1.18'
       - name: Run Build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.out
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: build.zip
           path: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           ./earthly.sh +test
       - name: Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.out
       - uses: actions/upload-artifact@v2

--- a/Earthfile
+++ b/Earthfile
@@ -442,8 +442,11 @@ run-qemu-datasource-tests:
     ELSE 
         ENV DATASOURCE=/test/build/datasource.iso
     END
-
-    RUN go install github.com/onsi/ginkgo/v2/ginkgo
+    RUN go get github.com/onsi/gomega/...
+    RUN go get github.com/onsi/ginkgo/v2/ginkgo/internal@v2.1.4
+    RUN go get github.com/onsi/ginkgo/v2/ginkgo/generators@v2.1.4
+    RUN go get github.com/onsi/ginkgo/v2/ginkgo/labels@v2.1.4
+    RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
     ENV CLOUD_INIT=/tests/tests/$CLOUD_CONFIG
 
@@ -466,8 +469,11 @@ run-qemu-test:
 
 
     COPY . .
-
-    RUN go install github.com/onsi/ginkgo/v2/ginkgo
+    RUN go get github.com/onsi/gomega/...
+    RUN go get github.com/onsi/ginkgo/v2/ginkgo/internal@v2.1.4
+    RUN go get github.com/onsi/ginkgo/v2/ginkgo/generators@v2.1.4
+    RUN go get github.com/onsi/ginkgo/v2/ginkgo/labels@v2.1.4
+    RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
     ARG ISO=$(ls /test/build/*.iso)
     ENV ISO=$ISO

--- a/go.sum
+++ b/go.sum
@@ -871,6 +871,7 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
+golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=
 golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/kairos-io/kairos/pkg/utils"
+
 	events "github.com/kairos-io/kairos/sdk/bus"
 
 	hook "github.com/kairos-io/kairos/internal/agent/hooks"
@@ -29,6 +31,8 @@ func Run(opts ...Option) error {
 	if err != nil {
 		return err
 	}
+
+	utils.SetEnv(c.Env)
 	bf := machine.BootFrom()
 	if c.Install != nil && c.Install.Auto && (bf == machine.NetBoot || bf == machine.LiveCDBoot) {
 		// Don't go ahead if we are asked to install from a booting live medium


### PR DESCRIPTION

This PR sets the env variables passed in the config on agent start so that sub processes/cmds triggered by kairos agent will have access to the environment variables through os.Environ()

Ex: If the proxy vars are passed in config env, then setting the environment variable will allow luet to have access to the set env variables.
