### PR TITLE
set env vars in agent

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/kairos-io/kairos/pkg/utils"
+
 	events "github.com/kairos-io/kairos/sdk/bus"
 
 	hook "github.com/kairos-io/kairos/internal/agent/hooks"
@@ -29,6 +31,8 @@ func Run(opts ...Option) error {
 	if err != nil {
 		return err
 	}
+
+	utils.SetEnv(c.Env)
 	bf := machine.BootFrom()
 	if c.Install != nil && c.Install.Auto && (bf == machine.NetBoot || bf == machine.LiveCDBoot) {
 		// Don't go ahead if we are asked to install from a booting live medium


### PR DESCRIPTION
This PR sets the env variables passed in the config on agent start so that sub processes/cmds triggered by kairos agent will have access to the environment variables through os.Environ()

Ex: If the proxy vars are passed in config env, then setting the environment variable will allow luet to have access to the set env variables.