### PR TITLE
:gear: Update grubmenu during reset and upgrade

### DIFF
--- a/overlay/files/system/oem/21_grub.yaml
+++ b/overlay/files/system/oem/21_grub.yaml
@@ -1,7 +1,8 @@
 name: "Additional grub menu entries"
 stages:
     after-install:
-    - name: "Mount state"
+    - &grubinstall
+      name: "Mount state"
       if: '[ -e "/etc/kairos/branding/grubmenu.cfg" ]'
       commands:
       - |
@@ -11,3 +12,7 @@ stages:
           mount ${STATE} $STATEDIR
           cp -rfv /etc/kairos/branding/grubmenu.cfg /tmp/mnt/STATE/grubmenu
           umount /tmp/mnt/STATE
+    after-upgrade:
+    - <<: *grubinstall
+    after-reset:
+    - <<: *grubinstall


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->



**What this PR does / why we need it**:

During resets otherwise the state gets pruned - this means the additional grub menu entries get lost

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
