### PR TITLE
:seedling: Harden config path and make sure are not rootfs-dependant

### DIFF
--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -65,7 +65,7 @@ stages:
         expand_partition:
           # Size 0 is required to specify all remaining space
           size: 0
-  boot:
+  fs.after:
   - if: "[ ! -d /usr/local/cloud-config ]"
     commands:
     - mkdir /usr/local/cloud-config

--- a/overlay/files/system/oem/27_harderning.yaml
+++ b/overlay/files/system/oem/27_harderning.yaml
@@ -1,0 +1,13 @@
+name: "Security configuration hardening"
+stages:
+    initramfs:
+    - name: "Ensure runtime permission"
+      if: '[ -e "/oem" ]'
+      commands:
+      - chown -R root:admin /oem
+      - chmod 770 /oem
+    - name: "Ensure runtime permission"
+      if: '[ -e "/usr/local/cloud-config" ]'
+      commands:
+      - chown -R root:admin /usr/local/cloud-config
+      - chmod 770 /usr/local/cloud-config

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -134,6 +134,16 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 			Expect(out).To(ContainSubstring("bpf"))
 		})
 
+		It("has correct permissions", func() {
+			out, err := Sudo(`stat -c "%a" /oem`)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("770"))
+
+			out, err = Sudo(`stat -c "%a" /usr/local/cloud-config`)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("770"))
+		})
+
 		It("has grubmenu", func() {
 			out, err := Sudo("cat /run/initramfs/cos-state/grubmenu")
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/reset_test.go
+++ b/tests/reset_test.go
@@ -76,10 +76,10 @@ var _ = Describe("kairos reset test", Label("reset-test"), func() {
 		})
 
 		It("resets", func() {
-			_, err := Sudo("echo 'test' > /usr/local/test")
+			_, err := Sudo("touch /usr/local/test")
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = Sudo("echo 'testoem' > /oem/test")
+			_, err = Sudo("touch /oem/test")
 			Expect(err).ToNot(HaveOccurred())
 
 			HasFile("/oem/test")


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: Otherwise config paths permissions are dependant on the rootfs. This configuration make sure permissions are correctly set even if the rootfs doesn't set the proper bits
