### PR TITLE
🐛  Enable Open VM Tools on boot

### DIFF
--- a/images/Dockerfile.alpine
+++ b/images/Dockerfile.alpine
@@ -111,7 +111,8 @@ RUN rc-update add sshd boot && \
     rc-update add udev sysinit && \
     rc-update add udev-trigger sysinit && \
     rc-update add openntpd boot && \
-    rc-update add fail2ban
+    rc-update add fail2ban \
+    rc-update add open-vm-tools boot
 
 # Symlinks to make elemental installer work
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install && \


### PR DESCRIPTION

Signed-off-by: Justin Barksdale <3pings@users.noreply.github.com>

**What this PR does / why we need it**:

Open VM Tools is installed but it is not enabled.  This PR will enable open-vm-tools on boot.

Fixes # N/A
