### PR TITLE
:seedling: Start vmtools/qemu-useragent if we run on VMs

### DIFF
--- a/images/Dockerfile.alpine
+++ b/images/Dockerfile.alpine
@@ -111,8 +111,7 @@ RUN rc-update add sshd boot && \
     rc-update add udev sysinit && \
     rc-update add udev-trigger sysinit && \
     rc-update add openntpd boot && \
-    rc-update add fail2ban \
-    rc-update add open-vm-tools boot
+    rc-update add fail2ban
 
 # Symlinks to make elemental installer work
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install && \

--- a/overlay/files/system/oem/26_vm.yaml
+++ b/overlay/files/system/oem/26_vm.yaml
@@ -1,0 +1,23 @@
+name: "Enable QEMU tools"
+stages:
+   boot:
+     - name: "Enable QEMU"
+       if: |
+           grep -iE "qemu|kvm|Virtual Machine" /sys/class/dmi/id/product_name && [ -e /sbin/rc-service ]
+       commands:
+       - rc-service qemu-guest-agent start
+     - name: "Enable QEMU"
+       if: |
+           grep -iE "qemu|kvm|Virtual Machine" /sys/class/dmi/id/product_name && ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
+       commands:
+       - systemctl start qemu-guest-agent
+     - name: "Enable VBOX"
+       if: |
+           grep -iE "Virtualbox" /sys/class/dmi/id/product_name && [ -e /sbin/rc-service ]
+       commands:
+       - rc-service open-vm-tools start
+     - name: "Enable V"
+       if: |
+           grep -iE "Virtualbox" /sys/class/dmi/id/product_name && ( [ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] )
+       commands:
+       - systemctl start vmtoolsd


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: Fixes master failures, and besides avoid to have all services enabled on boot, but dynamically loaded depending on the activation context.
