### PR TITLE
:bug: Do not run kcrypt hook without a oem mount

### DIFF
--- a/overlay/files/system/oem/21_kcrypt.yaml
+++ b/overlay/files/system/oem/21_kcrypt.yaml
@@ -2,10 +2,11 @@ name: "Update discovery plugins"
 stages:
     after-upgrade:
     - name: "Update plugins"
+      if: "[ $(kairos-agent state get oem.found) == 'true' ]"
       commands:
       - |
           STATEDIR=/tmp/mnt/OEM
-          OEM=$(blkid -L COS_OEM || true)
+          OEM=$(kairos-agent state get oem.name)
           mkdir -p $STATEDIR || true
           mount ${OEM} $STATEDIR
           if [ -d "$STATEDIR/system/discovery" ]; then

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -171,6 +171,7 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 			stateAssert("state.type", "ext4")
 			stateAssert("oem.mount_point", "/oem")
 			stateAssert("persistent.mount_point", "/usr/local")
+			stateAssert("persistent.name", "/dev/vda")
 			stateAssert("state.mount_point", "/run/initramfs/cos-state")
 			stateAssert("oem.read_only", "false")
 			stateAssert("persistent.read_only", "false")


### PR DESCRIPTION
**What this PR does / why we need it**: It runs the hook only if there is a OEM partition accessible. It uses the state api to get the state and the device name programmatically

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #358 