### PR TITLE
✨ directories added to support - update-ca-certificates

### DIFF
--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -15,6 +15,7 @@ stages:
           /etc/sysconfig
           /etc/runlevels
           /etc/ssh
+          /etc/ssl/certs
           /etc/iscsi 
           /etc/cni
           /etc/kubernetes
@@ -28,6 +29,9 @@ stages:
           /var/lib/wicked
           /var/lib/longhorn
           /var/lib/cni
+          /usr/share/pki/trust
+          /usr/share/pki/trust/anchors
+          /var/lib/ca-certificates
         PERSISTENT_STATE_BIND: "true"
     - if: |
         cat /proc/cmdline | grep -q "kairos.boot_live_mode"


### PR DESCRIPTION
Typically _update-ca-certificates_ is executed to update the list of root CA certificates.  update-ca-certificates reads the added source certificates from _/usr/share/pki/trust, /usr/share/pki/trust/anchors_ and updates the files in _/var/lib/ca-certificates and /etc/ssl/certs_

