### PR TITLE
Upgrade to latest release if one is not specified and ask user to confirm

### DIFF
--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -51,8 +52,12 @@ func Upgrade(version, image string, force, debug bool, dirs []string) error {
 			return fmt.Errorf("no releases found")
 		}
 
-		version = releases[0]
-		fmt.Println("latest release is ", version)
+		version = releases[len(releases)-1]
+		fmt.Println("Latest release is ", version)
+		fmt.Printf("Are you sure you want to upgrade to this release? (y/n) ")
+		if !askConfirmation() {
+			return nil
+		}
 	}
 
 	if utils.Version() == version && !force {
@@ -108,4 +113,21 @@ func Upgrade(version, image string, force, debug bool, dirs []string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func askConfirmation() bool {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		s, _ := reader.ReadString('\n')
+		s = strings.TrimSpace(strings.ToLower(s))
+		if strings.Compare(s, "n") == 0 {
+			return false
+		} else if strings.Compare(s, "y") == 0 {
+			break
+		} else {
+			fmt.Printf("Please enter y or n: ")
+			continue
+		}
+	}
+	return true
 }

--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -53,9 +52,12 @@ func Upgrade(version, image string, force, debug bool, dirs []string) error {
 		}
 
 		version = releases[len(releases)-1]
-		fmt.Println("Latest release is ", version)
-		fmt.Printf("Are you sure you want to upgrade to this release? (y/n) ")
-		if !askConfirmation() {
+		msg := fmt.Sprintf("Latest release is %s\nAre you sure you want to upgrade to this release? (y/n)", version)
+		reply, err := promptBool(events.YAMLPrompt{Prompt: msg, Default: "y"})
+		if err != nil {
+			return err
+		}
+		if reply == "false" {
 			return nil
 		}
 	}
@@ -113,21 +115,4 @@ func Upgrade(version, image string, force, debug bool, dirs []string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
-}
-
-func askConfirmation() bool {
-	reader := bufio.NewReader(os.Stdin)
-	for {
-		s, _ := reader.ReadString('\n')
-		s = strings.TrimSpace(strings.ToLower(s))
-		if strings.Compare(s, "n") == 0 {
-			return false
-		} else if strings.Compare(s, "y") == 0 {
-			break
-		} else {
-			fmt.Printf("Please enter y or n: ")
-			continue
-		}
-	}
-	return true
 }


### PR DESCRIPTION
Signed-off-by: Dimitris Karakasilis <dimitris@karakasilis.me>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
If not release was specified, the code picked the first one returned by the provider which was not the latest. We now choose the last one. In combination with [this PR](https://github.com/kairos-io/provider-kairos/pull/77/files), it should now be the latest release.

This PR is also asks the user for confirmation. We could add a new flag `no-prompt` or something like that, to avoid the confirmation dialog but:

- we already have a `force` flag which will may confuse users on which one does what
- the code needs refactoring to avoid passing boolean arguments to functions (quite some of them actually)

Maybe it's not worth the effort and we should skip the confirmation altogether?

Fixes #249
