### PR TITLE
:penguin: Add support for snapd

### DIFF
--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -34,6 +34,7 @@ RUN apt install -y \
     jq \
     neovim \
     open-vm-tools \
+    snapd \
     conntrack \
     iptables \
     linux-image-generic-hwe-22.04 && apt-get clean

--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -35,6 +35,7 @@ RUN apt install -y \
     neovim \
     open-vm-tools \
     conntrack \
+    snapd \
     iptables \
     linux-image-generic-hwe-20.04 && apt-get clean
 

--- a/images/Dockerfile.ubuntu-22-lts
+++ b/images/Dockerfile.ubuntu-22-lts
@@ -34,6 +34,7 @@ RUN apt install -y \
     jq \
     neovim \
     open-vm-tools \
+    snapd \
     conntrack \
     iptables \
     linux-image-generic-hwe-22.04 && apt-get clean

--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -13,7 +13,6 @@ stages:
           /etc/modprobe.d
           /etc/rancher
           /etc/sysconfig
-          /etc/profile.d
           /etc/runlevels
           /etc/ssh
           /etc/ssl/certs

--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -45,23 +45,30 @@ stages:
         RW_PATHS: "/var /etc /srv"
         PERSISTENT_STATE_PATHS: >-
           /etc/systemd
+          /etc/modprobe.d
           /etc/rancher
           /etc/sysconfig
           /etc/runlevels
           /etc/ssh
+          /etc/ssl/certs
           /etc/iscsi 
           /etc/cni
           /etc/kubernetes
           /home
           /opt
           /root
+          /snap
           /usr/libexec
           /var/log
           /var/lib/rancher
           /var/lib/kubelet
+          /var/lib/snapd
           /var/lib/wicked
           /var/lib/longhorn
           /var/lib/cni
+          /usr/share/pki/trust
+          /usr/share/pki/trust/anchors
+          /var/lib/ca-certificates
         PERSISTENT_STATE_BIND: "true"
     - if: '[ ! -f /run/cos/recovery_mode ] && [ ! -f /run/cos/live_mode ]'
       name: "Grow persistent"

--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -13,6 +13,7 @@ stages:
           /etc/modprobe.d
           /etc/rancher
           /etc/sysconfig
+          /etc/profile.d
           /etc/runlevels
           /etc/ssh
           /etc/ssl/certs
@@ -22,10 +23,12 @@ stages:
           /home
           /opt
           /root
+          /snap
           /usr/libexec
           /var/log
           /var/lib/rancher
           /var/lib/kubelet
+          /var/lib/snapd
           /var/lib/wicked
           /var/lib/longhorn
           /var/lib/cni

--- a/overlay/files/system/oem/25_default_paths.yaml
+++ b/overlay/files/system/oem/25_default_paths.yaml
@@ -4,3 +4,6 @@ stages:
      - name: "Default system dirs"
        directories:
        - path: /var/lib/longhorn
+       # TODO: create dir and set persistent path only when snapd is detected as installed
+       - path: /var/lib/snapd
+       - path: /snap


### PR DESCRIPTION
Signed-off-by: Ettore Di Giacinto <mudler@users.noreply.github.com>

Note: This is creating snap folders for all flavors (`/var/lib/snap` and `/snapd`) - I'd prefer we inject persistent paths if we detect snapd but we don't have #210 yet, so it would get quite hairy. Once we get #210 we can get back at that and programmatically add mount points/paths if we detect bins

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #401 
