### PR TITLE
:bug: Setup / as shared mount on alpine

### DIFF
--- a/overlay/files-alpine/system/oem/23_rootfs.yaml
+++ b/overlay/files-alpine/system/oem/23_rootfs.yaml
@@ -3,3 +3,4 @@ stages:
   boot.before:
     - commands:
       - mount -o mode=1777,nosuid,nodev -t tmpfs tmpfs /tmp
+      - mount --make-rshared /

--- a/pkg/utils/system.go
+++ b/pkg/utils/system.go
@@ -52,7 +52,7 @@ func Flavor() string {
 
 func IsOpenRCBased() bool {
 	f := Flavor()
-	return f == "alpine" || f == "alpine-arm-rpi"
+	return strings.Contains(f, "alpine")
 }
 
 func GetInterfaceIP(in string) string {

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -157,6 +157,12 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 			Expect(out).To(ContainSubstring("/var/lib/longhorn"))
 		})
 
+		It("has rootfs shared mount", func() {
+			out, err := Sudo(`cat /proc/1/mountinfo | grep ' / / '`)
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("shared"))
+		})
+
 		It("has corresponding state", func() {
 			out, err := Sudo("kairos-agent state")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Since this is not handled in the boot process, we do this in our devoted file to setup the rootfs configuration. It also adds an e2e test to verify that the mounts are correctly set

Signed-off-by: Ettore Di Giacinto <mudler@kairos.io>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #440 

Thanks @christianprim for the finding!