### PR TITLE
:book: Switch to "latest" tag for osbuilder-tools

### DIFF
--- a/docs/content/en/docs/Installation/automated.md
+++ b/docs/content/en/docs/Installation/automated.md
@@ -90,7 +90,7 @@ $ docker pull $IMAGE
 # docker run --entrypoint /bin/bash --name changes -ti $IMAGE
 # docker commit changes $IMAGE
 # Build an ISO with $IMAGE
-$ docker run -v $PWD:/cOS -v /var/run/docker.sock:/var/run/docker.sock -i --rm quay.io/kairos/osbuilder-tools:v0.1.1 --name "custom-iso" --debug build-iso --date=false --local --overlay-iso /cOS/files-iso $IMAGE --output /cOS/
+$ docker run -v $PWD:/cOS -v /var/run/docker.sock:/var/run/docker.sock -i --rm quay.io/kairos/osbuilder-tools:latest --name "custom-iso" --debug build-iso --date=false --local --overlay-iso /cOS/files-iso $IMAGE --output /cOS/
 ```
 
 ### Kubernetes


### PR DESCRIPTION
Docs show quay.io/kairos/osbuilder-tools:v0.1.1, which no longer works all that well and will send the user down a rabbit hole of many wasted hours. Updating to :latest tag. 

Signed-off-by: Fred Loucks <77683877+cybernetic-mountaineer@users.noreply.github.com>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
