### PR TITLE
:art: Move from io/ioutil to io and os packages

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -46,7 +45,7 @@ func Run(opts ...Option) error {
 
 	// Create if not exist
 	if _, err := os.Stat(fileName); err != nil {
-		err = ioutil.WriteFile(fileName, []byte{}, os.ModePerm)
+		err = os.WriteFile(fileName, []byte{}, os.ModePerm)
 		if err != nil {
 			return err
 		}

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -1,7 +1,7 @@
 package agent
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/kairos-io/kairos/internal/kairos"
 
@@ -29,35 +29,35 @@ func LoadConfig(path ...string) (*Config, error) {
 	cfg := &Config{}
 
 	for _, p := range path {
-		f, err := ioutil.ReadFile(p)
+		f, err := os.ReadFile(p)
 		if err == nil {
 			yaml.Unmarshal(f, cfg) //nolint:errcheck
 		}
 	}
 
 	if cfg.Branding.InteractiveInstall == "" {
-		f, err := ioutil.ReadFile(kairos.BrandingFile("interactive_install_text"))
+		f, err := os.ReadFile(kairos.BrandingFile("interactive_install_text"))
 		if err == nil {
 			cfg.Branding.InteractiveInstall = string(f)
 		}
 	}
 
 	if cfg.Branding.Install == "" {
-		f, err := ioutil.ReadFile(kairos.BrandingFile("install_text"))
+		f, err := os.ReadFile(kairos.BrandingFile("install_text"))
 		if err == nil {
 			cfg.Branding.Install = string(f)
 		}
 	}
 
 	if cfg.Branding.Recovery == "" {
-		f, err := ioutil.ReadFile(kairos.BrandingFile("recovery_text"))
+		f, err := os.ReadFile(kairos.BrandingFile("recovery_text"))
 		if err == nil {
 			cfg.Branding.Recovery = string(f)
 		}
 	}
 
 	if cfg.Branding.Reset == "" {
-		f, err := ioutil.ReadFile(kairos.BrandingFile("reset_text"))
+		f, err := os.ReadFile(kairos.BrandingFile("reset_text"))
 		if err == nil {
 			cfg.Branding.Reset = string(f)
 		}

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"syscall"
@@ -40,7 +39,7 @@ func optsToArgs(options map[string]string) (res []string) {
 }
 
 func ManualInstall(config string, options map[string]string) error {
-	dat, err := ioutil.ReadFile(config)
+	dat, err := os.ReadFile(config)
 	if err != nil {
 		return err
 	}
@@ -195,7 +194,7 @@ func RunInstall(options map[string]string) error {
 	utils.SH("elemental run-stage kairos-install.pre")             //nolint:errcheck
 	events.RunHookScript("/usr/bin/kairos-agent.install.pre.hook") //nolint:errcheck
 
-	f, _ := ioutil.TempFile("", "xxxx")
+	f, _ := os.CreateTemp("", "xxxx")
 	defer os.RemoveAll(f.Name())
 
 	device, ok := options["device"]
@@ -232,7 +231,7 @@ func RunInstall(options map[string]string) error {
 	env := append(c.Install.Env, c.Env...)
 	utils.SetEnv(env)
 
-	err := ioutil.WriteFile(f.Name(), []byte(cloudInit), os.ModePerm)
+	err := os.WriteFile(f.Name(), []byte(cloudInit), os.ModePerm)
 	if err != nil {
 		fmt.Printf("could not write cloud init: %s\n", err.Error())
 		os.Exit(1)

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/kairos-io/kairos/internal/kairos"
@@ -19,7 +18,7 @@ func PrintText(f string, banner string) {
 func PrintBranding(b []byte) {
 	brandingFile := kairos.BrandingFile("banner")
 	if _, err := os.Stat(brandingFile); err == nil {
-		f, err := ioutil.ReadFile(brandingFile)
+		f, err := os.ReadFile(brandingFile)
 		if err == nil {
 			fmt.Println(string(f))
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -141,7 +141,7 @@ func Scan(opts ...Option) (c *Config, err error) {
 			//fmt.Println("warning: Skipping file ", f, "as exceeds 1 MB in size")
 			continue
 		}
-		b, err := ioutil.ReadFile(f)
+		b, err := os.ReadFile(f)
 		if err == nil {
 			// best effort. skip lint checks
 			yaml.Unmarshal(b, c) //nolint:errcheck
@@ -164,7 +164,7 @@ func Scan(opts ...Option) (c *Config, err error) {
 
 	// use last recorded if no config is found valid
 	if !configFound && lastYamlFileFound != "" {
-		b, err := ioutil.ReadFile(lastYamlFileFound)
+		b, err := os.ReadFile(lastYamlFileFound)
 		if err == nil {
 			yaml.Unmarshal(b, c) //nolint:errcheck
 			c.location = lastYamlFileFound
@@ -196,7 +196,7 @@ func Scan(opts ...Option) (c *Config, err error) {
 				}
 				defer resp.Body.Close()
 
-				body, err = ioutil.ReadAll(resp.Body)
+				body, err = io.ReadAll(resp.Body)
 				if err != nil {
 					return err
 				}
@@ -266,7 +266,7 @@ func SaveCloudConfig(name Stage, yc yip.YipConfig) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join("usr", "local", "cloud-config", fmt.Sprintf("100_%s.yaml", name)), dnsYAML, 0700)
+	return os.WriteFile(filepath.Join("usr", "local", "cloud-config", fmt.Sprintf("100_%s.yaml", name)), dnsYAML, 0700)
 }
 
 func FromString(s string, o interface{}) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,7 +16,6 @@
 package config_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -40,12 +39,12 @@ baz: bar
 kairos:
   network_token: foo
 `
-			d, _ := ioutil.TempDir("", "xxxx")
+			d, _ := os.MkdirTemp("", "xxxx")
 			defer os.RemoveAll(d)
 
-			err := ioutil.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
+			err := os.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
-			err = ioutil.WriteFile(filepath.Join(d, "b"), []byte(`
+			err = os.WriteFile(filepath.Join(d, "b"), []byte(`
 fooz:
 			`), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
@@ -70,12 +69,12 @@ kairos:
 bb: 
   nothing: "foo"
 `
-			d, _ := ioutil.TempDir("", "xxxx")
+			d, _ := os.MkdirTemp("", "xxxx")
 			defer os.RemoveAll(d)
 
-			err := ioutil.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
+			err := os.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
-			err = ioutil.WriteFile(filepath.Join(d, "b"), []byte(`zz.foo="baa" options.foo=bar`), os.ModePerm)
+			err = os.WriteFile(filepath.Join(d, "b"), []byte(`zz.foo="baa" options.foo=bar`), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
 			c, err := Scan(Directories(d), MergeBootLine, WithBootCMDLineFile(filepath.Join(d, "b")))
@@ -96,10 +95,10 @@ bb:
 			var cc string = `
 config_url: "https://gist.githubusercontent.com/mudler/ab26e8dd65c69c32ab292685741ca09c/raw/bafae390eae4e6382fb1b68293568696823b3103/test.yaml"
 `
-			d, _ := ioutil.TempDir("", "xxxx")
+			d, _ := os.MkdirTemp("", "xxxx")
 			defer os.RemoveAll(d)
 
-			err := ioutil.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
+			err := os.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
 			c, err := Scan(Directories(d))

--- a/pkg/machine/bootcmdline.go
+++ b/pkg/machine/bootcmdline.go
@@ -1,7 +1,7 @@
 package machine
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/google/shlex"
@@ -12,7 +12,7 @@ func DotToYAML(file string) ([]byte, error) {
 	if file == "" {
 		file = "/proc/cmdline"
 	}
-	dat, err := ioutil.ReadFile(file)
+	dat, err := os.ReadFile(file)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/pkg/machine/bootcmdline_test.go
+++ b/pkg/machine/bootcmdline_test.go
@@ -1,7 +1,6 @@
 package machine_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	. "github.com/kairos-io/kairos/pkg/machine"
@@ -13,11 +12,11 @@ var _ = Describe("BootCMDLine", func() {
 	Context("parses data", func() {
 
 		It("returns cmdline if provided", func() {
-			f, err := ioutil.TempFile("", "test")
+			f, err := os.CreateTemp("", "test")
 			Expect(err).ToNot(HaveOccurred())
 			defer os.RemoveAll(f.Name())
 
-			err = ioutil.WriteFile(f.Name(), []byte(`config_url="foo bar" baz.bar=""`), os.ModePerm)
+			err = os.WriteFile(f.Name(), []byte(`config_url="foo bar" baz.bar=""`), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
 			b, err := DotToYAML(f.Name())

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -2,7 +2,6 @@ package machine
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -118,7 +117,7 @@ func UUID() string {
 }
 
 func CreateSentinel(f string) error {
-	return ioutil.WriteFile(fmt.Sprintf("/usr/local/.kairos/sentinel_%s", f), []byte{}, os.ModePerm)
+	return os.WriteFile(fmt.Sprintf("/usr/local/.kairos/sentinel_%s", f), []byte{}, os.ModePerm)
 }
 
 func SentinelExist(f string) bool {

--- a/pkg/machine/openrc/unit.go
+++ b/pkg/machine/openrc/unit.go
@@ -2,7 +2,7 @@ package openrc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -51,7 +51,7 @@ func NewService(opts ...ServiceOpts) (ServiceUnit, error) {
 func (s ServiceUnit) WriteUnit() error {
 	uname := s.name
 
-	if err := ioutil.WriteFile(filepath.Join(s.rootdir, fmt.Sprintf("/etc/init.d/%s", uname)), []byte(s.content), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(s.rootdir, fmt.Sprintf("/etc/init.d/%s", uname)), []byte(s.content), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/machine/systemd/unit.go
+++ b/pkg/machine/systemd/unit.go
@@ -2,7 +2,6 @@ package systemd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,7 +67,7 @@ func (s ServiceUnit) WriteUnit() error {
 		uname = fmt.Sprintf("%s@", s.name)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(s.rootdir, fmt.Sprintf("/etc/systemd/system/%s.service", uname)), []byte(s.content), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(s.rootdir, fmt.Sprintf("/etc/systemd/system/%s.service", uname)), []byte(s.content), 0600); err != nil {
 		return err
 	}
 
@@ -80,7 +79,7 @@ func (s ServiceUnit) OverrideCmd(cmd string) error {
 	svcDir := filepath.Join(s.rootdir, fmt.Sprintf("/etc/systemd/system/%s.service.d/", s.name))
 	os.MkdirAll(svcDir, 0600) //nolint:errcheck
 
-	return ioutil.WriteFile(filepath.Join(svcDir, "override.conf"), []byte(fmt.Sprintf(overrideCmdTemplate, cmd)), 0600)
+	return os.WriteFile(filepath.Join(svcDir, "override.conf"), []byte(fmt.Sprintf(overrideCmdTemplate, cmd)), 0600)
 }
 
 func (s ServiceUnit) Start() error {

--- a/pkg/utils/sh.go
+++ b/pkg/utils/sh.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -17,7 +16,7 @@ func SH(c string) (string, error) {
 }
 
 func WriteEnv(envFile string, config map[string]string) error {
-	content, _ := ioutil.ReadFile(envFile)
+	content, _ := os.ReadFile(envFile)
 	env, _ := godotenv.Unmarshal(string(content))
 
 	for key, val := range config {

--- a/sdk/bundles/bundle_test.go
+++ b/sdk/bundles/bundle_test.go
@@ -1,7 +1,6 @@
 package bundles_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -13,7 +12,7 @@ import (
 var _ = Describe("Bundle", func() {
 	Context("install", func() {
 		PIt("installs packages from luet repos", func() {
-			dir, err := ioutil.TempDir("", "test")
+			dir, err := os.MkdirTemp("", "test")
 			Expect(err).ToNot(HaveOccurred())
 			defer os.RemoveAll(dir)
 			os.MkdirAll(filepath.Join(dir, "var", "tmp", "luet"), os.ModePerm)
@@ -23,7 +22,7 @@ var _ = Describe("Bundle", func() {
 		})
 
 		It("installs from container images", func() {
-			dir, err := ioutil.TempDir("", "test")
+			dir, err := os.MkdirTemp("", "test")
 			Expect(err).ToNot(HaveOccurred())
 			defer os.RemoveAll(dir)
 			err = RunBundles([]BundleOption{WithDBPath(dir), WithRootFS(dir), WithTarget("container://quay.io/mocaccino/extra:edgevpn-utils-0.15.0")})

--- a/sdk/bundles/bundles.go
+++ b/sdk/bundles/bundles.go
@@ -2,7 +2,6 @@ package bundles
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -143,7 +142,7 @@ type ContainerRunner struct{}
 
 func (l *ContainerRunner) Install(config *BundleConfig) error {
 
-	tempDir, err := ioutil.TempDir("", "containerrunner")
+	tempDir, err := os.MkdirTemp("", "containerrunner")
 	if err != nil {
 		return err
 	}

--- a/sdk/profile/build.go
+++ b/sdk/profile/build.go
@@ -2,7 +2,7 @@ package profile
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/kairos-io/kairos/pkg/utils"
@@ -19,7 +19,7 @@ type profileFileStruct struct {
 }
 
 func BuildFlavor(flavor string, profileFile string, directory string) error {
-	dat, err := ioutil.ReadFile(profileFile)
+	dat, err := os.ReadFile(profileFile)
 
 	if err != nil {
 		return fmt.Errorf("error while reading profile: %w", err)
@@ -55,7 +55,7 @@ func BuildFlavor(flavor string, profileFile string, directory string) error {
 
 func readProfilePackages(profile string, profileFile string) ([]string, error) {
 	res := []string{}
-	dat, err := ioutil.ReadFile(profileFile)
+	dat, err := os.ReadFile(profileFile)
 	if err != nil {
 		return res, fmt.Errorf("error while reading profile: %w", err)
 	}
@@ -86,7 +86,7 @@ func readProfilePackages(profile string, profileFile string) ([]string, error) {
 
 func readCommonPackages(profileFile string) ([]string, error) {
 	res := []string{}
-	dat, err := ioutil.ReadFile(profileFile)
+	dat, err := os.ReadFile(profileFile)
 	if err != nil {
 		return res, fmt.Errorf("error while reading profile: %w", err)
 	}

--- a/sdk/state/state.go
+++ b/sdk/state/state.go
@@ -3,7 +3,7 @@ package state
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/itchyny/gojq"
@@ -59,7 +59,7 @@ func detectPartition(b *block.Partition) PartitionState {
 }
 
 func detectBoot() Boot {
-	cmdline, err := ioutil.ReadFile("/proc/cmdline")
+	cmdline, err := os.ReadFile("/proc/cmdline")
 	if err != nil {
 		return Unknown
 	}

--- a/sdk/system/cloudconfig.go
+++ b/sdk/system/cloudconfig.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -45,7 +44,7 @@ func writeCloudConfig(oem state.PartitionState, cloudConfig, subpath, filename s
 		machine.Umount(mountPath) //nolint:errcheck
 	}()
 	_ = os.MkdirAll(filepath.Join(mountPath, subpath), 0650)
-	return ioutil.WriteFile(filepath.Join(mountPath, subpath, fmt.Sprintf("%s.yaml", filename)), []byte(cloudConfig), 0650)
+	return os.WriteFile(filepath.Join(mountPath, subpath, fmt.Sprintf("%s.yaml", filename)), []byte(cloudConfig), 0650)
 }
 
 // WriteCloudConfigData adds cloud config data to oem (/oem or /usr/local/cloud-config, depending if OEM partition exists).

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -3,7 +3,6 @@ package mos_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -29,11 +28,11 @@ var _ = Describe("kairos install test", Label("install-test"), func() {
 	testInstall := func(cloudConfig string, actual interface{}, m types.GomegaMatcher) {
 		stateAssert("persistent.found", "false")
 
-		t, err := ioutil.TempFile("", "test")
+		t, err := os.CreateTemp("", "test")
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 		defer os.RemoveAll(t.Name())
-		err = ioutil.WriteFile(t.Name(), []byte(cloudConfig), os.ModePerm)
+		err = os.WriteFile(t.Name(), []byte(cloudConfig), os.ModePerm)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = Machine.SendFile(t.Name(), "/tmp/config.yaml", "0770")

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -3,7 +3,6 @@ package mos_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -77,7 +76,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	if os.Getenv("CREATE_VM") == "true" {
-		t, err := ioutil.TempDir("", "")
+		t, err := os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 
 		sshPort = "2222"
@@ -92,8 +91,8 @@ var _ = BeforeSuite(func() {
 			types.WithSSHUser(user()),
 			types.WithSSHPass(pass()),
 			types.OnFailure(func(p *process.Process) {
-				out, _ := ioutil.ReadFile(p.StdoutPath())
-				err, _ := ioutil.ReadFile(p.StderrPath())
+				out, _ := os.ReadFile(p.StdoutPath())
+				err, _ := os.ReadFile(p.StderrPath())
 				status, _ := p.ExitCode()
 				Fail(fmt.Sprintf("VM Aborted: %s %s Exit status: %s", out, err, status))
 			}),


### PR DESCRIPTION
**What this PR does / why we need it**:

Recently we have upgraded to Go 1.19 in #318. The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

