### PR TITLE
:robot: No need to download jq and docker anymore

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -297,7 +297,6 @@ iso:
     ARG IMG=docker:$IMAGE
     ARG overlay=overlay/files-iso
     FROM $OSBUILDER_IMAGE
-    RUN zypper in -y jq docker
     WORKDIR /build
     COPY . ./
     COPY +docker-rootfs/rootfs /build/image


### PR DESCRIPTION
This occasionally leads to errors when repos are not available online, and now this should be also not necessary anymore.

Signed-off-by: Ettore Di Giacinto <mudler@users.noreply.github.com>

