### PR TITLE
admin group is admin not admins

### DIFF
--- a/docs/content/en/docs/Reference/configuration.md
+++ b/docs/content/en/docs/Reference/configuration.md
@@ -112,7 +112,7 @@ users:
 - name: "kairos"
   passwd: "kairos"
   lock_passwd: true
-  groups: "admins"
+  groups: "admin"
   ssh_authorized_keys:
   - github:mudler
 


### PR DESCRIPTION
I took this snippet as sample for my config and it took me a while that although I changed config from cloud-config to initramfs/networg stage with different syntax, I copied the wrong group name all the time.. :)

Signed-off-by: Stefan Le Breton <stelb@users.noreply.github.com>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
documentation bug

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
