### PR TITLE
:seedling: Glob all configs found

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -276,14 +276,15 @@ func FindYAMLWithKey(s string, opts ...Option) ([]string, error) {
 			fmt.Printf("warning: skipping file '%s' - %s\n", f, err.Error())
 		}
 
-		data, err := unstructured.YQ(s, dat)
-		fmt.Println(data)
+		found, err := unstructured.YAMLHasKey(s, dat)
 		if err != nil {
 			fmt.Printf("warning: skipping file '%s' - %s\n", f, err.Error())
 		}
-		if len(data) > 0 {
+
+		if found {
 			result = append(result, f)
 		}
+
 	}
 
 	return result, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,7 +33,6 @@ type Config struct {
 	Install *Install `yaml:"install,omitempty"`
 	//cloudFileContent string
 	originalData       map[string]interface{}
-	location           string
 	header             string
 	ConfigURL          string            `yaml:"config_url,omitempty"`
 	Options            map[string]string `yaml:"options,omitempty"`
@@ -87,10 +86,6 @@ func (c Config) Unmarshal(o interface{}) error {
 	return yaml.Unmarshal([]byte(c.String()), o)
 }
 
-func (c Config) Location() string {
-	return c.location
-}
-
 func (c Config) Data() map[string]interface{} {
 	return c.originalData
 }
@@ -110,12 +105,6 @@ func (c Config) String() string {
 	return string(dat)
 }
 
-func (c Config) IsValid() bool {
-	return c.Install != nil ||
-		c.ConfigURL != "" ||
-		len(c.Bundles) != 0
-}
-
 func Scan(opts ...Option) (c *Config, err error) {
 
 	o := &Options{}
@@ -126,7 +115,6 @@ func Scan(opts ...Option) (c *Config, err error) {
 
 	dir := o.ScanDir
 
-	c = &Config{}
 	files := []string{}
 	for _, d := range dir {
 		if f, err := listFiles(d); err == nil {
@@ -134,46 +122,7 @@ func Scan(opts ...Option) (c *Config, err error) {
 		}
 	}
 
-	configFound := false
-	lastYamlFileFound := ""
-
-	// Scanning happens as best-effort, therefore unmarshalling skips errors here.
-	for _, f := range files {
-		if fileSize(f) > 1.0 {
-			//fmt.Println("warning: Skipping file ", f, "as exceeds 1 MB in size")
-			continue
-		}
-		b, err := os.ReadFile(f)
-		if err == nil {
-			// best effort. skip lint checks
-			yaml.Unmarshal(b, c)               //nolint:errcheck
-			yaml.Unmarshal(b, &c.originalData) //nolint:errcheck
-			if exists, header := HasHeader(string(b), ""); c.IsValid() || exists {
-				c.location = f
-				yaml.Unmarshal(b, &c.originalData) //nolint:errcheck
-				configFound = true
-				if exists {
-					c.header = header
-				}
-				break
-			}
-
-			// record back the only yaml file found (if any)
-			if strings.HasSuffix(strings.ToLower(f), "yaml") || strings.HasSuffix(strings.ToLower(f), "yml") {
-				lastYamlFileFound = f
-			}
-		}
-	}
-
-	// use last recorded if no config is found valid
-	if !configFound && lastYamlFileFound != "" {
-		b, err := os.ReadFile(lastYamlFileFound)
-		if err == nil {
-			yaml.Unmarshal(b, c) //nolint:errcheck
-			c.location = lastYamlFileFound
-			yaml.Unmarshal(b, &c.originalData) //nolint:errcheck
-		}
-	}
+	c = parseConfig(files)
 
 	if o.MergeBootCMDLine {
 		d, err := machine.DotToYAML(o.BootCMDLineFile)
@@ -307,4 +256,27 @@ func MergeYAML(objs ...interface{}) ([]byte, error) {
 
 func AddHeader(header, data string) string {
 	return fmt.Sprintf("%s\n%s", header, data)
+}
+
+// parseConfig merges all config back in one structure.
+func parseConfig(files []string) *Config {
+	c := &Config{}
+	for _, f := range files {
+		if fileSize(f) > 1.0 {
+			fmt.Printf("warning: skipping %s. too big (>1MB)\n", f)
+			continue
+		}
+		b, err := os.ReadFile(f)
+		if err != nil {
+			fmt.Printf("warning: skipping %s. %s\n", f, err.Error())
+			continue
+		}
+		yaml.Unmarshal(b, c)               //nolint:errcheck
+		yaml.Unmarshal(b, &c.originalData) //nolint:errcheck
+		if exists, header := HasHeader(string(b), ""); exists {
+			c.header = header
+		}
+	}
+
+	return c
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,7 +146,8 @@ func Scan(opts ...Option) (c *Config, err error) {
 		b, err := os.ReadFile(f)
 		if err == nil {
 			// best effort. skip lint checks
-			yaml.Unmarshal(b, c) //nolint:errcheck
+			yaml.Unmarshal(b, c)               //nolint:errcheck
+			yaml.Unmarshal(b, &c.originalData) //nolint:errcheck
 			if exists, header := HasHeader(string(b), ""); c.IsValid() || exists {
 				c.location = f
 				yaml.Unmarshal(b, &c.originalData) //nolint:errcheck

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -207,7 +207,7 @@ b:
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		FIt("can find a top level key", func() {
+		It("can find a top level key", func() {
 			r, err := FindYAMLWithKey("a", Directories(d))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(r).To(Equal([]string{c1Path}))

--- a/sdk/unstructured/yaml.go
+++ b/sdk/unstructured/yaml.go
@@ -9,6 +9,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func YQ(query string, content []byte) (map[string]interface{}, error) {
+	data := map[string]interface{}{}
+
+	err := yaml.Unmarshal([]byte(content), &data)
+	if err != nil {
+		return data, err
+	}
+	fmt.Printf("data = %+v\n", data)
+
+	return jq(fmt.Sprintf(".%s", query), data)
+}
+
 func jq(command string, data map[string]interface{}) (map[string]interface{}, error) {
 	query, err := gojq.Parse(command)
 	if err != nil {
@@ -22,7 +34,7 @@ func jq(command string, data map[string]interface{}) (map[string]interface{}, er
 
 	v, ok := iter.Next()
 	if !ok {
-		return nil, errors.New("failed getting rsult from gojq")
+		return nil, errors.New("failed getting result from gojq")
 	}
 	if err, ok := v.(error); ok {
 		return nil, err


### PR DESCRIPTION
This allows to read all the configs found during scanning - this is especially useful in first boot as it allows to have separate config file logic split into several files

Signed-off-by: Ettore Di Giacinto <mudler@users.noreply.github.com>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: Fixes up failures in https://github.com/kairos-io/provider-kairos/pull/103