### PR TITLE
:bug: Blacklist bpfilter in Alpine

### DIFF
--- a/overlay/files/system/oem/29_blacklist.yaml
+++ b/overlay/files/system/oem/29_blacklist.yaml
@@ -1,0 +1,6 @@
+stages:
+   initramfs.before:
+     - name: "Blacklist bpfilter on Alpine ( bug: https://github.com/kairos-io/kairos/issues/277 )"
+       if: '[ -e /sbin/rc-service ]'
+       commands:
+       - echo "install bpfilter /bin/false" > /etc/modprobe.d/blacklist_bpfilter.conf


### PR DESCRIPTION
Fixes #277. We are not building our own kernel at the moment - and we can't either build everything in alpine yet. For the moment we can just disable until we have vanilla kernels from #116  which would allow us to cross-build.

Thanks to @christianprim for the investigation and the workaround.

Signed-off-by: Ettore Di Giacinto <mudler@users.noreply.github.com>
