### PR TITLE
:bug: Correctly detect default version in netboot

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -310,14 +310,16 @@ iso:
 netboot:
    ARG OSBUILDER_IMAGE
    FROM $OSBUILDER_IMAGE
-   ARG VERSION
+   COPY +version/VERSION ./
+   ARG VERSION=$(cat VERSION)
+   RUN echo "version ${VERSION}"
    ARG ISO_NAME=${OS_ID}
    ARG FROM_ARTIFACT
    WORKDIR /build
 
    COPY . .
    IF [ "$FROM_ARTIFACT" = "" ]
-   	COPY +iso/kairos.iso kairos.iso
+        COPY +iso/kairos.iso kairos.iso
         RUN /build/scripts/netboot.sh kairos.iso $ISO_NAME $VERSION
    ELSE
         RUN /build/scripts/netboot.sh $FROM_ARTIFACT $ISO_NAME $VERSION
@@ -358,6 +360,7 @@ ipxe-iso:
     ARG ISO_NAME=${OS_ID}        
     COPY +version/VERSION ./
     ARG VERSION=$(cat VERSION)
+    RUN echo "version ${VERSION}"
 
     RUN git clone https://github.com/ipxe/ipxe
     IF [ "$ipxe_script" = "" ]


### PR DESCRIPTION
The netboot target didn't had a default bound to the detected version, if nothing was specified it would result in an empty artifact.

Fixes: #501

Signed-off-by: Ettore Di Giacinto <mudler@users.noreply.github.com>
