### PR TITLE
:bug: Process only cloud configs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -299,15 +299,19 @@ func parseConfig(dir []string) *Config {
 			fmt.Printf("warning: skipping %s. too big (>1MB)\n", f)
 			continue
 		}
-		b, err := os.ReadFile(f)
-		if err != nil {
-			fmt.Printf("warning: skipping %s. %s\n", f, err.Error())
-			continue
-		}
-		yaml.Unmarshal(b, c)               //nolint:errcheck
-		yaml.Unmarshal(b, &c.originalData) //nolint:errcheck
-		if exists, header := HasHeader(string(b), ""); exists {
-			c.header = header
+		if strings.Contains(f, "userdata") || filepath.Ext(f) == ".yml" || filepath.Ext(f) == ".yaml" {
+			b, err := os.ReadFile(f)
+			if err != nil {
+				fmt.Printf("warning: skipping %s. %s\n", f, err.Error())
+				continue
+			}
+			yaml.Unmarshal(b, c)               //nolint:errcheck
+			yaml.Unmarshal(b, &c.originalData) //nolint:errcheck
+			if exists, header := HasHeader(string(b), ""); exists {
+				c.header = header
+			}
+		} else {
+			fmt.Printf("warning: skipping %s (extension).\n", f)
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -71,10 +71,10 @@ b: f
 c: d
 `
 
-			err := os.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
+			err := os.WriteFile(filepath.Join(d, "test.yaml"), []byte(cc), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = os.WriteFile(filepath.Join(d, "b"), []byte(c2), os.ModePerm)
+			err = os.WriteFile(filepath.Join(d, "b.yaml"), []byte(c2), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
 			c, err := Scan(Directories(d))
@@ -99,9 +99,9 @@ kairos:
   network_token: foo
 `
 
-			err := os.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
+			err := os.WriteFile(filepath.Join(d, "test.yaml"), []byte(cc), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
-			err = os.WriteFile(filepath.Join(d, "b"), []byte(`
+			err = os.WriteFile(filepath.Join(d, "b.yaml"), []byte(`
 fooz:
 			`), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
@@ -127,7 +127,7 @@ bb:
   nothing: "foo"
 `
 
-			err := os.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
+			err := os.WriteFile(filepath.Join(d, "test.yaml"), []byte(cc), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 			err = os.WriteFile(filepath.Join(d, "b"), []byte(`zz.foo="baa" options.foo=bar`), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
@@ -151,7 +151,7 @@ bb:
 config_url: "https://gist.githubusercontent.com/mudler/ab26e8dd65c69c32ab292685741ca09c/raw/bafae390eae4e6382fb1b68293568696823b3103/test.yaml"
 `
 
-			err := os.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
+			err := os.WriteFile(filepath.Join(d, "test.yaml"), []byte(cc), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
 			c, err := Scan(Directories(d))
@@ -168,7 +168,7 @@ config_url: "https://gist.githubusercontent.com/mudler/ab26e8dd65c69c32ab2926857
 config_url: "https://gist.githubusercontent.com/mudler/7e3d0426fce8bfaaeb2644f83a9bfe0c/raw/77ded58aab3ee2a8d4117db95e078f81fd08dfde/testgist.yaml"
 `
 
-			err := os.WriteFile(filepath.Join(d, "test"), []byte(cc), os.ModePerm)
+			err := os.WriteFile(filepath.Join(d, "test.yaml"), []byte(cc), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
 			c, err := Scan(Directories(d))

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -163,6 +163,13 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 			Expect(out).To(ContainSubstring("shared"))
 		})
 
+		It("doesn't has grub data into the cloud config", func() {
+			out, err := Sudo(`cat /oem/90_custom.yaml`)
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).ToNot(ContainSubstring("vga_text"))
+			Expect(out).ToNot(ContainSubstring("videotest"))
+		})
+
 		It("has corresponding state", func() {
 			out, err := Sudo("kairos-agent state")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Regression introduced in https://github.com/kairos-io/kairos/pull/502. Also files like .lst were incorrectly included inside /oem/90_custom.yaml

Signed-off-by: Ettore Di Giacinto <mudler@users.noreply.github.com>

