### PR TITLE
:book: Fix link pointing to missing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Kairos can be used to:
 - Manage the cluster lifecycle with Kubernetes—from building to provisioning, and upgrading :rocket:
 - Create a multiple—node, a single cluster that spans up across regions :earth_africa:
 
-For comprehensive docs, tutorials, and examples see our [documentation](https://kairos.io/quickstart).
+For comprehensive docs, tutorials, and examples see our [documentation](https://kairos.io/docs/getting-started/).
 
 ## Project status
 


### PR DESCRIPTION
The link before was pointing to a "quickstart" page, which I couldn't find in the new docs. I thought the "getting started" page was a good substitute, but it could also be linked to the home of the documentation, or even something else. Let me know what you think.
