### PR TITLE
✨  add env and cacerts attributes to clusterplugin.cluster object

### DIFF
--- a/sdk/clusterplugin/config.go
+++ b/sdk/clusterplugin/config.go
@@ -50,6 +50,12 @@ type Cluster struct {
 
 	// Options are arbitrary values the sdk may be interested in.  These values are not validated by Kairos and are simply forwarded to the sdk.
 	Options string `yaml:"config,omitempty" json:"config,omitempty"`
+
+	// Env contains the list of environment variables to be set on the cluster
+	Env map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+
+	// CACerts list of trust certificates.
+	CACerts []string `yaml:"ca_certs,omitempty" json:"ca_certs,omitempty"`
 }
 
 type Config struct {


### PR DESCRIPTION

**What this PR does / why we need it**:
adds support for proxy and cacert attributes to be set which then can be used by the provider to set the values explicitly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
[Fixes #](https://github.com/kairos-io/kairos/issues/555)
