### PR TITLE
:seedling: Return configuration data from the agent

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Config", func() {
 			ExpectWithOffset(1, header).To(Equal(DefaultHeader))
 		}
 
-		It("reads from bootargs", func() {
+		It("reads from bootargs and can query", func() {
 			err := os.WriteFile(filepath.Join(d, "b"), []byte(`zz.foo="baa" options.foo=bar`), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -58,6 +58,8 @@ var _ = Describe("Config", func() {
 			Expect(err).ToNot(HaveOccurred())
 			headerCheck(c)
 			Expect(c.Options["foo"]).To(Equal("bar"))
+			Expect(c.Query("options")).To(Equal("foo: bar\n"))
+			Expect(c.Query("options.foo")).To(Equal("bar\n"))
 		})
 
 		It("reads multiple config files", func() {
@@ -96,7 +98,7 @@ c: d
 			var cc string = `#kairos-config
 baz: bar
 kairos:
-  network_token: foo
+    network_token: foo
 `
 
 			err := os.WriteFile(filepath.Join(d, "test.yaml"), []byte(cc), os.ModePerm)
@@ -114,7 +116,8 @@ fooz:
 			Expect(err).ToNot(HaveOccurred())
 			Expect(providerCfg.Kairos).ToNot(BeNil())
 			Expect(providerCfg.Kairos.NetworkToken).To(Equal("foo"))
-			Expect(c.String()).To(Equal(cc))
+			Expect(c.String()).To(Equal(cc), c.String(), cc)
+
 		})
 
 		It("merges with bootargs", func() {

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -4,9 +4,15 @@ type Options struct {
 	ScanDir          []string
 	BootCMDLineFile  string
 	MergeBootCMDLine bool
+	NoLogs           bool
 }
 
 type Option func(o *Options) error
+
+var NoLogs Option = func(o *Options) error {
+	o.NoLogs = true
+	return nil
+}
 
 func (o *Options) Apply(opts ...Option) error {
 	for _, oo := range opts {


### PR DESCRIPTION
Signed-off-by: Ettore Di Giacinto <mudler@users.noreply.github.com>

**What this PR does / why we need it**: This PR allows to programmatically retrieve the node configuration from the CLI. For instance, in a Kairos node with k3s enabled would behave:

```
$ kairos-agent config get k3s.enabled
true
$ kairos-agent config get k3s
enabled: true`
```

### Why it is needed?

I'm trying to create bundles that extend the system by reading the main configuration file. I want a consolidated way to programmatically access it via commands (either that coming from cloud configs, or bundle themselves). In this way bundles can extend the main config file, keeping one-file-only strategy.
