### PR TITLE
:robot: Exclude go.mod from spelling checker

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -3,6 +3,7 @@
 (?:^|/)(?i)LICEN[CS]E
 (?:^|/)3rdparty/
 (?:^|/)go\.sum$
+(?:^|/)go\.mod$
 (?:^|/)package(?:-lock|)\.json$
 (?:^|/)vendor/
 (?:^|/)tests/


### PR DESCRIPTION
Signed-off-by: Ettore Di Giacinto <mudler@users.noreply.github.com>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: Otherwise any new PR from renovate would be signaled as invalid, and we grow our includes with hashes