### PR TITLE
:seedling: Keep current dir when installing runnable bundles

### DIFF
--- a/pkg/utils/sh.go
+++ b/pkg/utils/sh.go
@@ -8,6 +8,14 @@ import (
 	"github.com/joho/godotenv"
 )
 
+func SHInDir(c, dir string) (string, error) {
+	cmd := exec.Command("/bin/sh", "-c", c)
+	cmd.Env = os.Environ()
+	cmd.Dir = dir
+	o, err := cmd.CombinedOutput()
+	return string(o), err
+}
+
 func SH(c string) (string, error) {
 	cmd := exec.Command("/bin/sh", "-c", c)
 	cmd.Env = os.Environ()

--- a/sdk/bundles/bundles.go
+++ b/sdk/bundles/bundles.go
@@ -159,7 +159,8 @@ func (l *ContainerRunner) Install(config *BundleConfig) error {
 		return fmt.Errorf("could not unpack container: %w - %s", err, out)
 	}
 
-	out, err = utils.SH(fmt.Sprintf("CONTAINERDIR=%s %s/run.sh", tempDir, tempDir))
+	// We want to expect tempDir as context
+	out, err = utils.SHInDir(fmt.Sprintf("CONTAINERDIR=%s %s/run.sh", tempDir, tempDir), tempDir)
 	if err != nil {
 		return fmt.Errorf("could not execute container: %w - %s", err, out)
 	}


### PR DESCRIPTION
Signed-off-by: mudler <mudler@c3os.io>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: This is not _needed_, however, when running bundles we expect the context where we run to be where the bundle was extracted (this reduce verbosity when creating entrypoint scripts for bundles)
