### PR TITLE
:bug: Fix rockylinux build, curl-minimal is already shipped

### DIFF
--- a/images/Dockerfile.rockylinux
+++ b/images/Dockerfile.rockylinux
@@ -26,7 +26,6 @@ RUN dnf install -y \
     device-mapper \
     grub2 \
     which \
-    curl \
     nano \
     gawk \
     tar \


### PR DESCRIPTION
Signed-off-by: mudler <mudler@c3os.io>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: Currently CI is red on rockylinux. Seems now curl-minimal is shipped in the base image, previously we were installing `curl` and now are conflicting