### PR TITLE
🐧 Upgrade Alpine to latest Tag

### DIFF
--- a/images/Dockerfile.alpine-opensuse-leap
+++ b/images/Dockerfile.alpine-opensuse-leap
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.16.3
+ARG BASE_IMAGE=alpine
 FROM $BASE_IMAGE
 ARG K3S_VERSION
 
@@ -16,7 +16,6 @@ RUN apk --no-cache add  \
       parted \
       e2fsprogs \
       logrotate \
-      busybox-initscripts \
       dosfstools \
       coreutils \
       which \
@@ -28,7 +27,7 @@ RUN apk --no-cache add  \
       rsync \
       bash-completion \
       blkid \
-      busybox-initscripts \
+      busybox-openrc \
       ca-certificates \
       conntrack-tools \
       coreutils \


### PR DESCRIPTION
`busybox-initscripts` was removed from alpine v3.17 and mostly replaced with `busybox-openrc`.

Signed-off-by: Christian Prim <christian.prim@gmx.ch>

**What this PR does / why we need it**:
Keep up with the latest alpine images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
