### PR TITLE
:book: Rename references from kairos to p2p

### DIFF
--- a/docs/content/en/docs/Installation/manual.md
+++ b/docs/content/en/docs/Installation/manual.md
@@ -29,7 +29,7 @@ Where the configuration can be a `cloud-init` file or a URL to it:
 ```yaml
 #cloud-init
 
-kairos:
+p2p:
   network_token: ....
 # extra configuration
 ```

--- a/docs/content/en/docs/Reference/configuration.md
+++ b/docs/content/en/docs/Reference/configuration.md
@@ -166,9 +166,9 @@ write_files:
   owner: "bar"
 ```
 
-The `kairos` block is used to enable the p2p full-mesh functionalities of Kairos. If you do not want to use these functionalities, simply don't specify a kairos block in your configuration file.
+The `p2p` block is used to enable the p2p full-mesh functionalities of Kairos. If you do not want to use these functionalities, simply don't specify a kairos block in your configuration file.
 
-Inside the `kairos` block, you can specify the network_token field, which is used to establish the p2p full meshed network. If you do not want to use the full-mesh functionalities, don't specify a network_token value.
+Inside the `p2p` block, you can specify the network_token field, which is used to establish the p2p full meshed network. If you do not want to use the full-mesh functionalities, don't specify a network_token value.
 
 The role field allows you to manually set the node role for your Kairos installation. The available options are `master` and `worker`, and the default value is auto (which means no role is set).
 
@@ -482,7 +482,7 @@ localhost:~$
 
 ## P2P configuration
 
-P2P functionalities are experimental Kairos features and disabled by default. In order to enable them, just use the `kairos` configuration block.
+P2P functionalities are experimental Kairos features and disabled by default. In order to enable them, just use the `p2p` configuration block.
 
 ### `p2p.network_token`
 


### PR DESCRIPTION
Leftover from the transition, kairos block is called p2p now

Signed-off-by: Itxaka <itxaka@spectrocloud.com>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

Less confusion on docs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #680 
