### PR TITLE
:seedling: Add option to preserve the VM used for testing

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -36,7 +36,7 @@ var sshPort string
 var machineID string = os.Getenv("MACHINE_ID")
 
 var _ = AfterSuite(func() {
-	if os.Getenv("CREATE_VM") == "true" {
+	if os.Getenv("CREATE_VM") == "true" && os.Getenv("KEEP_VM") != "true" {
 		if Machine != nil {
 			Machine.Stop()
 			Machine.Clean()
@@ -44,6 +44,9 @@ var _ = AfterSuite(func() {
 	}
 	if !CurrentSpecReport().Failure.IsZero() {
 		gatherLogs()
+	}
+	if os.Getenv("CREATE_VM") == "true" && os.Getenv("KEEP_VM") == "true" {
+		fmt.Println("WARNING: Not cleaning", Machine.Config().StateDir)
 	}
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow preseving the VM used for testing:
 - speed up tests locally
 - debug issues when needed
 - increase contributor\developer happiness :smiley: 

**Which issue(s) this PR fixes** 

Fixes #685

Signed-off-by: Oz Tiram <oz@spectrocloud.com>