### PR TITLE
:bug: Remove duplicated list of upgradable releases

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -64,8 +64,10 @@ See https://kairos.io/docs/upgrade/manual/ for documentation.
 				Description: `List all available releases versions`,
 				Action: func(c *cli.Context) error {
 					releases := agent.ListReleases()
-					fmt.Println("Releases: ", len(releases))
-					utils.ListOutput(releases, c.String("output"))
+					list := utils.ListOutput(releases, c.String("output"))
+					for _, i := range list {
+						fmt.Println(i)
+					}
 
 					return nil
 				},

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -49,7 +49,7 @@ To retrieve all the available versions, use "kairos upgrade list-releases"
 
 $ kairos upgrade list-releases
 
-See https://kairos.io/after_install/upgrades/#manual for documentation.
+See https://kairos.io/docs/upgrade/manual/ for documentation.
 
 `,
 		Subcommands: []cli.Command{
@@ -64,10 +64,8 @@ See https://kairos.io/after_install/upgrades/#manual for documentation.
 				Description: `List all available releases versions`,
 				Action: func(c *cli.Context) error {
 					releases := agent.ListReleases()
-					releases = utils.ListOutput(releases, c.String("output"))
-					for _, r := range releases {
-						fmt.Println(r)
-					}
+					fmt.Println("Releases: ", len(releases))
+					utils.ListOutput(releases, c.String("output"))
 
 					return nil
 				},

--- a/docs/content/en/docs/Upgrade/manual.md
+++ b/docs/content/en/docs/Upgrade/manual.md
@@ -8,7 +8,7 @@ description: >
 
 Upgrades can be run manually from the terminal.
 
-Kairos images are released on [quay.io](https://quay.io/repository/kairos/kairos).
+Kairos images are released on [quay.io](https://quay.io/organization/kairos).
 
 ## List available versions
 

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/rand"
 	"strings"
 	"time"
@@ -33,9 +32,6 @@ func ListOutput(rels []string, output string) []string {
 		d, _ := json.Marshal(rels)
 		return []string{string(d)}
 	default:
-		for _, r := range rels {
-			fmt.Println(r)
-		}
 		return rels
 	}
 }


### PR DESCRIPTION
Signed-off-by: Mauro Morales <mauro.morales@spectrocloud.com>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
The list of possible releases when doing an upgrade is duplicated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
relates to  #684
