### PR TITLE
:seedling: test VM configure RAM and CPUs

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -113,6 +113,15 @@ var _ = BeforeSuite(func() {
 			opts = append(opts, types.VBoxEngine)
 		}
 
+		memory := os.Getenv("MEMORY")
+		if memory != "" {
+			opts = append(opts, types.WithMemory(os.Getenv("MEMORY")))
+		}
+		cpu := os.Getenv("CPU")
+		if cpu != "" {
+			opts = append(opts, types.WithCPU(os.Getenv("CPUS")))
+		}
+
 		m, err := machine.New(opts...)
 		if err != nil {
 			Fail(err.Error())


### PR DESCRIPTION
Allow adding more CPU and RAM for the test machine. This improves perfomance of tests.

You can now run the suite with the following command to create a test VM with more CPUs and RAM:

```
MEMORY=9048 CPU=4 ISO=.../kairos/kairos-...iso CREATE_VM=true  ginkgo run tests/
```

Fix #689

Signed-off-by: Oz Tiram <oz@spectrocloud.com>


