### PR TITLE
Add a new category for commits and PR - toolings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ Create a branch with a descriptive name, such as ``fix/dns``.
         - ✨ (`:sparkles:`, feature additions)
         - 🐛 (`:bug:`, patch and bugfixes)
         - 📖 (`:book:`, documentation or proposals)
+        - 🔧 (`:wrenchIcon:`, toolings for developers)
         - :art: ( `:art`, for refactoring )
         - 🌱 (`:seedling:`, minor or other)
         - :penguin: (`:penguin:`, for Distribution or Dockerfile changes)


### PR DESCRIPTION
Some features we add are actually for maintainers\developers. Hence, a :wrench: icon is a better than :sparkels: or :seedling:

Signed-off-by: Oz Tiram <oz@spectrocloud.com>

