### PR TITLE
:sparkles: custom user bind and ephemeral mounts

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -189,7 +189,7 @@ jobs:
             ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
             ./earthly.sh +run-qemu-datasource-tests --FLAVOR=${{ matrix.flavor }} --SSH_PORT=${{ matrix.port }}
 
-  qemu-install-tests:
+  qemu-custom-mount-tests:
     needs:
     - build
     runs-on: ubuntu-latest
@@ -197,9 +197,7 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         - flavor: "alpine-opensuse-leap"
          - flavor: "opensuse-leap"
-         - flavor: "ubuntu"
     steps:
     - uses: actions/checkout@v3
     - name: Download artifacts
@@ -207,7 +205,7 @@ jobs:
       with:
           name: kairos-${{ matrix.flavor }}.iso.zip
     - run: |
-            ./earthly.sh +run-qemu-install-tests --FLAVOR=${{ matrix.flavor }}
+            ./earthly.sh +run-qemu-custom-mount-tests --FLAVOR=${{ matrix.flavor }}
 
   qemu-bundles-tests:
     needs: 

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -189,6 +189,26 @@ jobs:
             ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
             ./earthly.sh +run-qemu-datasource-tests --FLAVOR=${{ matrix.flavor }} --SSH_PORT=${{ matrix.port }}
 
+  qemu-install-tests:
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+       include:
+         - flavor: "alpine-opensuse-leap"
+         - flavor: "opensuse-leap"
+         - flavor: "ubuntu"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+          name: kairos-${{ matrix.flavor }}.iso.zip
+    - run: |
+            ./earthly.sh +run-qemu-install-tests --FLAVOR=${{ matrix.flavor }}
+
   qemu-bundles-tests:
     needs: 
     - build

--- a/Earthfile
+++ b/Earthfile
@@ -447,13 +447,13 @@ linux-bench-scan:
 ###
 # usage e.g. ./earthly.sh +run-qemu-datasource-tests --FLAVOR=alpine-opensuse-leap --FROM_ARTIFACTS=true
 run-qemu-datasource-tests:
-    FROM opensuse/leap
+    FROM +ginkgo
+    RUN apt install -y qemu-system-x86 qemu-utils golang git
     WORKDIR /test
-    RUN zypper in -y qemu-x86 qemu-arm qemu-tools go git
     ARG FLAVOR
     ARG TEST_SUITE=autoinstall-test
     ENV FLAVOR=$FLAVOR
-    ENV SSH_PORT=60022
+    ENV SSH_PORT=60023
     ENV CREATE_VM=true
     ARG CLOUD_CONFIG="./tests/assets/autoinstall.yaml"
     ENV USE_QEMU=true
@@ -476,40 +476,34 @@ run-qemu-datasource-tests:
     ELSE 
         ENV DATASOURCE=/test/build/datasource.iso
     END
-    FROM +ginkgo
     ENV CLOUD_INIT=/tests/tests/$CLOUD_CONFIG
 
-    RUN PATH=$PATH:$GOPATH/bin ginkgo --label-filter "$TEST_SUITE" --fail-fast -r ./tests/
+    RUN PATH=$PATH:$GOPATH/bin ginkgo -v --label-filter "$TEST_SUITE" --fail-fast -r ./tests/
 
 run-qemu-custom-mount-tests:
-    FROM opensuse/leap
-    WORKDIR /test
-    RUN zypper in -y qemu-x86 qemu-arm qemu-tools go git
+    FROM +ginkgo
+    RUN apt install -y qemu-system-x86 qemu-utils golang git
     ARG FLAVOR
-    ARG TEST_SUITE=custom-mounts-test
-    ENV FLAVOR=$FLAVOR
-    ENV SSH_PORT=60022
-    ENV CREATE_VM=true
-    ENV USE_QEMU=true
-
-    ENV GOPATH="/go"
 
     COPY . .
     RUN ls -liah
-    IF [ -e /test/build/kairos.iso ]
-        ENV ISO=/test/build/kairos.iso
+    IF [ -e /build/kairos.iso ]
+        ENV ISO=/build/kairos.iso
     ELSE
         COPY +iso/kairos.iso kairos.iso
-        ENV ISO=/test/kairos.iso
+        ENV ISO=/build/kairos.iso
     END
 
-    FROM +ginkgo
-
-    RUN PATH=$PATH:$GOPATH/bin ginkgo --label-filter custom-mounts-test --fail-fast -r ./tests/
+    ENV GOPATH="/go"
+    ARG TEST_SUITE=custom-mounts-test
+    ENV SSH_PORT=60024
+    ENV CREATE_VM=true
+    ENV USE_QEMU=true
+    RUN pwd && ls -liah
+    RUN PATH=$PATH:$GOPATH/bin ginkgo -v --label-filter custom-mounts-test --fail-fast -r ./tests/
 
 run-qemu-netboot-test:
-    FROM ubuntu
-
+    FROM +ginkgo
     COPY . /test
     WORKDIR /test
 
@@ -536,7 +530,6 @@ run-qemu-netboot-test:
     ARG TEST_SUITE=netboot-test
     ENV GOPATH="/go"
 
-    FROM +ginkgo
 
     # TODO: use --pull or something to cache the python image in Earthly
     WITH DOCKER
@@ -546,9 +539,8 @@ run-qemu-netboot-test:
     END
 
 run-qemu-test:
-    FROM opensuse/leap
-    WORKDIR /test
-    RUN zypper in -y qemu-x86 qemu-arm qemu-tools go git
+    FROM +ginkgo
+    RUN apt install -y qemu-system-x86 qemu-utils golang git
     ARG FLAVOR
     ARG TEST_SUITE=upgrade-with-cli
     ARG CONTAINER_IMAGE
@@ -560,13 +552,15 @@ run-qemu-test:
 
     ENV GOPATH="/go"
 
-
     COPY . .
-    FROM +ginkgo
-    ARG ISO=$(ls /test/build/*.iso)
-    ENV ISO=$ISO
-
-    RUN PATH=$PATH:$GOPATH/bin ginkgo --label-filter "$TEST_SUITE" --fail-fast -r ./tests/
+    IF [ -e /build/kairos.iso ]
+        ENV ISO=/build/kairos.iso
+    ELSE
+        COPY +iso/kairos.iso kairos.iso
+        ENV ISO=/build/kairos.iso
+    END
+    RUN pwd && ls -l && ls -l build
+    RUN PATH=$PATH:$GOPATH/bin ginkgo -v --label-filter "$TEST_SUITE" --fail-fast -r ./tests/
 
 ###
 ### Artifacts targets

--- a/Earthfile
+++ b/Earthfile
@@ -476,12 +476,12 @@ run-qemu-datasource-tests:
 
     RUN PATH=$PATH:$GOPATH/bin ginkgo --label-filter "$TEST_SUITE" --fail-fast -r ./tests/
 
-run-qemu-install-tests:
+run-qemu-custom-mount-tests:
     FROM opensuse/leap
     WORKDIR /test
     RUN zypper in -y qemu-x86 qemu-arm qemu-tools go git
     ARG FLAVOR
-    ARG TEST_SUITE=install-test
+    ARG TEST_SUITE=custom-mounts-test
     ENV FLAVOR=$FLAVOR
     ENV SSH_PORT=60022
     ENV CREATE_VM=true

--- a/Earthfile
+++ b/Earthfile
@@ -482,7 +482,7 @@ run-qemu-datasource-tests:
 
 run-qemu-custom-mount-tests:
     FROM +ginkgo
-    RUN apt install -y qemu-system-x86 qemu-utils golang git
+    RUN apt install -y qemu-system-x86 qemu-utils git && apt clean
     ARG FLAVOR
 
     COPY . .
@@ -512,7 +512,7 @@ run-qemu-netboot-test:
     ARG VERSION=$(cat VERSION)
 
     RUN apt update
-    RUN apt install -y qemu qemu-utils qemu-system golang git
+    RUN apt install -y qemu qemu-utils qemu-system git && apt clean
 
     # This is the IP at which qemu vm can see the host
     ARG IP="10.0.2.2"
@@ -540,7 +540,7 @@ run-qemu-netboot-test:
 
 run-qemu-test:
     FROM +ginkgo
-    RUN apt install -y qemu-system-x86 qemu-utils golang git
+    RUN apt install -y qemu-system-x86 qemu-utils git && apt clean
     ARG FLAVOR
     ARG TEST_SUITE=upgrade-with-cli
     ARG CONTAINER_IMAGE

--- a/Earthfile
+++ b/Earthfile
@@ -42,8 +42,18 @@ go-deps:
     SAVE ARTIFACT go.mod AS LOCAL go.mod
     SAVE ARTIFACT go.sum AS LOCAL go.sum
 
-test:
+
+ginkgo:
     FROM +go-deps
+    WORKDIR /build
+    RUN go get github.com/onsi/gomega/...
+    RUN go get github.com/onsi/ginkgo/v2/ginkgo/internal@v2.1.4
+    RUN go get github.com/onsi/ginkgo/v2/ginkgo/generators@v2.1.4
+    RUN go get github.com/onsi/ginkgo/v2/ginkgo/labels@v2.1.4
+    RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+
+test:
+    FROM +ginkgo
     WORKDIR /build
     RUN go get github.com/onsi/gomega/...
     RUN go get github.com/onsi/ginkgo/v2/ginkgo/internal@v2.1.4
@@ -466,12 +476,7 @@ run-qemu-datasource-tests:
     ELSE 
         ENV DATASOURCE=/test/build/datasource.iso
     END
-    RUN go get github.com/onsi/gomega/...
-    RUN go get github.com/onsi/ginkgo/v2/ginkgo/internal@v2.1.4
-    RUN go get github.com/onsi/ginkgo/v2/ginkgo/generators@v2.1.4
-    RUN go get github.com/onsi/ginkgo/v2/ginkgo/labels@v2.1.4
-    RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
-
+    FROM +ginkgo
     ENV CLOUD_INIT=/tests/tests/$CLOUD_CONFIG
 
     RUN PATH=$PATH:$GOPATH/bin ginkgo --label-filter "$TEST_SUITE" --fail-fast -r ./tests/
@@ -499,11 +504,7 @@ run-qemu-custom-mount-tests:
         ENV ISO=/test/kairos.iso
     END
 
-    RUN go get github.com/onsi/gomega/...
-    RUN go get github.com/onsi/ginkgo/v2/ginkgo/internal@v2.1.4
-    RUN go get github.com/onsi/ginkgo/v2/ginkgo/generators@v2.1.4
-    RUN go get github.com/onsi/ginkgo/v2/ginkgo/labels@v2.1.4
-    RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+    FROM +ginkgo
 
     ENV CLOUD_INIT=/tests/tests/$CLOUD_CONFIG
 
@@ -537,7 +538,8 @@ run-qemu-netboot-test:
     ENV USE_QEMU=true
     ARG TEST_SUITE=netboot-test
     ENV GOPATH="/go"
-    RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
+
+    FROM +ginkgo
 
     # TODO: use --pull or something to cache the python image in Earthly
     WITH DOCKER
@@ -563,12 +565,7 @@ run-qemu-test:
 
 
     COPY . .
-    RUN go get github.com/onsi/gomega/...
-    RUN go get github.com/onsi/ginkgo/v2/ginkgo/internal@v2.1.4
-    RUN go get github.com/onsi/ginkgo/v2/ginkgo/generators@v2.1.4
-    RUN go get github.com/onsi/ginkgo/v2/ginkgo/labels@v2.1.4
-    RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
-
+    FROM +ginkgo
     ARG ISO=$(ls /test/build/*.iso)
     ENV ISO=$ISO
 

--- a/Earthfile
+++ b/Earthfile
@@ -494,7 +494,6 @@ run-qemu-custom-mount-tests:
 
     ENV GOPATH="/go"
 
-    ENV CLOUD_CONFIG=$CLOUD_CONFIG
     COPY . .
     RUN ls -liah
     IF [ -e /test/build/kairos.iso ]
@@ -506,9 +505,7 @@ run-qemu-custom-mount-tests:
 
     FROM +ginkgo
 
-    ENV CLOUD_INIT=/tests/tests/$CLOUD_CONFIG
-
-    RUN PATH=$PATH:$GOPATH/bin ginkgo --label-filter "$TEST_SUITE" --fail-fast -r ./tests/
+    RUN PATH=$PATH:$GOPATH/bin ginkgo --label-filter custom-mounts-test --fail-fast -r ./tests/
 
 run-qemu-netboot-test:
     FROM ubuntu

--- a/docs/content/en/docs/Advanced/customizing.md
+++ b/docs/content/en/docs/Advanced/customizing.md
@@ -115,3 +115,45 @@ If you are using an Alpine-based distribution, modifying the kernel is only poss
 {{% /alert %}}
 
 After you have modified the kernel and initrd, you can use the kairos-agent upgrade command to update your nodes, or [within Kubernetes](/docs/upgrade/kubernetes).
+
+
+## Customizing the file system hierarchy using custom mounts.
+
+
+### Bind mounts
+
+For clusters that needs to mount network block storage you might want to add
+custom mount point that bind mounted to your system. For example, when using
+Ceph file system, the OS mounts drives to `/var/lib/ceph` (for example).
+
+To achieve this you need to add the key `bind_mounts` to the `install` section
+you pass the install, and specify a list of one or more bind mounts path.
+
+```
+install:
+  auto: true
+  device: "auto"
+  # changes persist reboot  - mount as BIND
+  bind_mounts:
+  - /var/lib/ceph
+...
+```
+
+
+### Ephemeral mounts
+
+One can also specifying custom mounts which are ephemeral. These are writable,
+however changes are discarded at boot (like `/etc/` already does).
+```
+install:
+  auto: true
+  device: "auto"
+  # changes persist reboot  - mount as BIND
+  bind_mounts:
+  - /var/lib/ceph
+  ephemeral_mounts:
+  - /opt/scratch/
+...
+```
+Note, that these paths should exist in the container file-system used to create the ISO.
+See [ISO customization](/docs/Advanced/customizing/) above.

--- a/docs/content/en/docs/Reference/configuration.md
+++ b/docs/content/en/docs/Reference/configuration.md
@@ -50,6 +50,13 @@ install:
   # Environmental variable to set to the installer calls
   env:
   - foo=bar
+  # custom user mounts
+  # bind mounts, can be read and modified, changes persist reboots
+  bind_mounts:
+  - /mnt/bind1
+  - /mnt/bind2
+  # ephemeral mounts, can be read and modified, changed are discarded at reboot
+  ephemeral_mounts:
 
 k3s:
   # Additional env/args for k3s server instances

--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -12,6 +12,7 @@ var AfterInstall = []Interface{
 	&RunStage{},    // Shells out to stages defined from the container image
 	&GrubOptions{}, // Set custom GRUB options
 	&BundleOption{},
+	&CustomMounts{},
 	&Kcrypt{},
 	&Lifecycle{}, // Handles poweroff/reboot by config options
 }

--- a/internal/agent/hooks/mounts.go
+++ b/internal/agent/hooks/mounts.go
@@ -1,0 +1,59 @@
+package hook
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	config "github.com/kairos-io/kairos/pkg/config"
+	"github.com/kairos-io/kairos/pkg/machine"
+	"github.com/mudler/yip/pkg/schema"
+	yip "github.com/mudler/yip/pkg/schema"
+	"gopkg.in/yaml.v1"
+)
+
+type CustomMounts struct{}
+
+func saveCloudConfig(name config.Stage, yc yip.YipConfig) error {
+	yipYAML, err := yaml.Marshal(yc)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join("/oem", fmt.Sprintf("10_%s.yaml", name)), yipYAML, 0400)
+}
+
+// Read the keys sections ephemeral_mounts and bind mounts from install key in the cloud config.
+// If not empty write an environment file to /run/cos/custom-layout.env.
+// That env file is in turn read by /overlay/files/system/oem/11_persistency.yaml in fs.after stage.
+func (cm CustomMounts) Run(c config.Config) error {
+
+	//fmt.Println("Custom mounts hook")
+	//fmt.Println(strings.Join(c.Install.BindMounts, " "))
+	//fmt.Println(strings.Join(c.Install.EphemeralMounts, " "))
+
+	if len(c.Install.BindMounts) == 0 && len(c.Install.EphemeralMounts) == 0 {
+		return nil
+	}
+
+	machine.Mount("COS_OEM", "/oem") //nolint:errcheck
+	defer func() {
+		machine.Umount("/oem") //nolint:errcheck
+	}()
+
+	var mountsList = map[string]string{}
+
+	mountsList["CUSTOM_BIND_MOUNTS"] = strings.Join(c.Install.BindMounts, " ")
+	mountsList["CUSTOM_EPHEMERAL_MOUNTS"] = strings.Join(c.Install.EphemeralMounts, " ")
+
+	config := yip.YipConfig{Stages: map[string][]schema.Stage{
+		"rootfs": []yip.Stage{{
+			Name:            "user_custom_mounts",
+			EnvironmentFile: "/run/cos/custom-layout.env",
+			Environment:     mountsList,
+		}},
+	}}
+
+	saveCloudConfig("user_custom_mounts", config) //nolint:errcheck
+	return nil
+}

--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -41,7 +41,6 @@ stages:
       name: "append custom bind and ephemeral mounts to /run/cos/cos-layout.env"
       commands:
         - |
-          if [ -r /run/cos/custom-layout.env ]; then
              source /run/cos/cos-layout.env
              source /run/cos/custom-layout.env
              PERSISTENT_STATE_PATHS="${CUSTOM_EPHEMERAL_MOUNTS} ${PERSISTENT_STATE_PATHS}"
@@ -52,7 +51,6 @@ stages:
              echo RW_PATHS=\"${RW_PATHS}\" >> /run/cos/cos-layout.env
              echo "# persistent state paths with user ephemeral mounts" >> /run/cos/cos-layout.env
              echo PERSISTENT_STATE_PATHS=\"${PERSISTENT_STATE_PATHS}\" >> /run/cos/cos-layout.env
-          fi
     - if: |
         cat /proc/cmdline | grep -q "kairos.boot_live_mode"
       name: "Layout configuration"

--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -48,6 +48,10 @@ stages:
              RW_PATHS="${CUSTOM_BIND_MOUNTS} ${RW_PATHS}"
              echo CUSTOM_BIND_MOUNTS=\"${CUSTOM_BIND_MOUNTS}\" >> /run/cos/cos-layout.env
              echo CUSTOM_EPHEMERAL_MOUNTS=\"${CUSTOM_EPHEMERAL_MOUNTS}\" >> /run/cos/cos-layout.env
+             echo "# rw paths with user bind mounts" >> /run/cos/cos-layout.env
+             echo RW_PATHS=\"${RW_PATHS}\" >> /run/cos/cos-layout.env
+             echo "# persistent state paths with user ephemeral mounts" >> /run/cos/cos-layout.env
+             echo PERSISTENT_STATE_PATHS=\"${PERSISTENT_STATE_PATHS}\" >> /run/cos/cos-layout.env
           fi
     - if: |
         cat /proc/cmdline | grep -q "kairos.boot_live_mode"

--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -37,6 +37,19 @@ stages:
           /var/lib/ca-certificates
         PERSISTENT_STATE_BIND: "true"
     - if: |
+        [ -r /run/cos/custom-layout.env ]
+      name: "append custom bind and ephemeral mounts to /run/cos/cos-layout.env"
+      commands:
+        - |
+          if [ -r /run/cos/custom-layout.env ]; then
+             source /run/cos/cos-layout.env
+             source /run/cos/custom-layout.env
+             PERSISTENT_STATE_PATHS="${CUSTOM_EPHEMERAL_MOUNTS} ${PERSISTENT_STATE_PATHS}"
+             RW_PATHS="${CUSTOM_BIND_MOUNTS} ${RW_PATHS}"
+             echo CUSTOM_BIND_MOUNTS=\"${CUSTOM_BIND_MOUNTS}\" >> /run/cos/cos-layout.env
+             echo CUSTOM_EPHEMERAL_MOUNTS=\"${CUSTOM_EPHEMERAL_MOUNTS}\" >> /run/cos/cos-layout.env
+          fi
+    - if: |
         cat /proc/cmdline | grep -q "kairos.boot_live_mode"
       name: "Layout configuration"
       environment_file: /run/cos/cos-layout.env

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,15 +23,18 @@ import (
 const DefaultWebUIListenAddress = ":8080"
 
 type Install struct {
-	Auto        bool              `yaml:"auto,omitempty"`
-	Reboot      bool              `yaml:"reboot,omitempty"`
-	Device      string            `yaml:"device,omitempty"`
-	Poweroff    bool              `yaml:"poweroff,omitempty"`
-	GrubOptions map[string]string `yaml:"grub_options,omitempty"`
-	Bundles     Bundles           `yaml:"bundles,omitempty"`
-	Encrypt     []string          `yaml:"encrypted_partitions,omitempty"`
-	Env         []string          `yaml:"env,omitempty"`
-	Image       string            `yaml:"image,omitempty"`
+	Auto                   bool              `yaml:"auto,omitempty"`
+	Reboot                 bool              `yaml:"reboot,omitempty"`
+	Device                 string            `yaml:"device,omitempty"`
+	Poweroff               bool              `yaml:"poweroff,omitempty"`
+	GrubOptions            map[string]string `yaml:"grub_options,omitempty"`
+	Bundles                Bundles           `yaml:"bundles,omitempty"`
+	Encrypt                []string          `yaml:"encrypted_partitions,omitempty"`
+	SkipEncryptCopyPlugins bool              `yaml:"skip_copy_kcrypt_plugin,omitempty"`
+	Env                    []string          `yaml:"env,omitempty"`
+	Image                  string            `yaml:"image,omitempty"`
+	EphemeralMounts        []string          `yaml:"ephemeral_mounts,omitempty"`
+	BindMounts             []string          `yaml:"bind_mounts,omitempty"`
 }
 
 type Config struct {

--- a/tests/custom_mount_test.go
+++ b/tests/custom_mount_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/spectrocloud/peg/matcher"
 )
 
-var _ = Describe("kairos test custom user mounts", Label("custom-mounts-test"), func() {
+var _ = Describe("kairos test custom user mounts", Label("install-test"), func() {
 
 	BeforeEach(func() {
 		EventuallyConnects(1200)

--- a/tests/custom_mount_test.go
+++ b/tests/custom_mount_test.go
@@ -48,7 +48,7 @@ stages:
 				var out string
 				out, _ = Sudo("cat /run/cos/cos-layout.env")
 				return strings.Split(out, "\n")
-			}, ContainElements(ContainSubstring("/mnt/bind1"), ContainSubstring("/mnt/ephemeral2")), true)
+			}, ContainElements(ContainSubstring("/mnt/bind1"), ContainSubstring("/mnt/ephemeral")), true)
 		})
 
 	})

--- a/tests/custom_mount_test.go
+++ b/tests/custom_mount_test.go
@@ -2,14 +2,14 @@ package mos_test
 
 import (
 	"context"
-	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/spectrocloud/peg/matcher"
 )
 
-var _ = Describe("kairos test custom user mounts", Label("install-test"), func() {
+var _ = Describe("kairos test custom user mounts", Label("custom-mounts-test"), func() {
 
 	BeforeEach(func() {
 		EventuallyConnects(1200)
@@ -44,12 +44,11 @@ stages:
     users:
      kairos:
       passwd: "kairos"
-`, func() string {
+`, func() []string {
 				var out string
 				out, _ = Sudo("cat /run/cos/cos-layout.env")
-				fmt.Println(out)
-				return out
-			}, ContainElements(ContainSubstring("/mnt/bind1"), ContainSubstring("/mnt/ephemeral")), true)
+				return strings.Split(out, "\n")
+			}, ContainElements(ContainSubstring("/mnt/bind1"), ContainSubstring("/mnt/ephemeral2")), true)
 		})
 
 	})

--- a/tests/custom_mount_test.go
+++ b/tests/custom_mount_test.go
@@ -1,0 +1,118 @@
+package mos_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	. "github.com/spectrocloud/peg/matcher"
+)
+
+var _ = Describe("kairos test custom user mounts", Label("custom-mounts-test"), func() {
+
+	BeforeEach(func() {
+		EventuallyConnects(1200)
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			gatherLogs()
+		}
+		Machine.Clean()
+		Machine.Create(context.Background())
+		EventuallyConnects(1200)
+
+	})
+
+	testInstall := func(cloudConfig string, actual interface{}, m types.GomegaMatcher, should bool) {
+		stateAssert("persistent.found", "false")
+
+		t, err := os.CreateTemp("", "test")
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+		defer os.RemoveAll(t.Name())
+		err = os.WriteFile(t.Name(), []byte(cloudConfig), os.ModePerm)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = Machine.SendFile(t.Name(), "/tmp/config.yaml", "0770")
+		Expect(err).ToNot(HaveOccurred())
+
+		out, err := Sudo("sudo mv /tmp/config.yaml /oem/")
+		Expect(err).ToNot(HaveOccurred(), out)
+
+		out, _ = Sudo("cat /oem/config.yaml")
+		fmt.Println(out)
+		out, err = Sudo("kairos-agent install")
+		Expect(err).ToNot(HaveOccurred(), out)
+		Expect(out).Should(ContainSubstring("Running after-install hook"))
+		fmt.Println(out)
+		Sudo("sync")
+
+		detachAndReboot()
+
+		EventuallyConnects(1200)
+		if should {
+			fmt.Println("should ", should)
+			Eventually(actual, 5*time.Minute, 10*time.Second).Should(m)
+		} else {
+			Eventually(actual, 5*time.Minute, 10*time.Second).ShouldNot(m)
+		}
+
+	}
+
+	Context("Install with custom mounts", func() {
+
+		It("does not have wrong key", func() {
+			testInstall(`
+install:
+  auto: true
+  device: "auto"
+  bind_mounts:
+  - /mnt/bind1
+  - /mnt/bind2
+  ephemeral_mounts:
+  - /mnt/ephemeral
+  - /mnt/ephemeral2
+stages:
+  initramfs:
+  - name: "Set user and password"
+    users:
+     kairos:
+      passwd: "kairos"
+`, func() string {
+				var out string
+				out, _ = Sudo("cat /oem/90_custom.yaml")
+				return out
+			}, ContainSubstring("foo"), false)
+		})
+		FIt("bind_mounts", func() {
+			testInstall(`
+install:
+  auto: true
+  device: "auto"
+  bind_mounts:
+  - /mnt/bind1
+  - /mnt/bind2
+  ephemeral_mounts:
+  - /mnt/ephemeral
+  - /mnt/ephemeral2
+stages:
+  initramfs:
+  - name: "Set user and password"
+    users:
+     kairos:
+      passwd: "kairos"
+`, func() string {
+				var out string
+				out, _ = Sudo("cat /run/cos/custom-layout.env")
+				fmt.Println(out)
+				return out
+			}, ContainSubstring("/mnt/bind1 /mnt/bind2"), true)
+		})
+
+	})
+})

--- a/tests/custom_mount_test.go
+++ b/tests/custom_mount_test.go
@@ -3,12 +3,9 @@ package mos_test
 import (
 	"context"
 	"fmt"
-	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
 	. "github.com/spectrocloud/peg/matcher"
 )
 
@@ -28,45 +25,9 @@ var _ = Describe("kairos test custom user mounts", Label("custom-mounts-test"), 
 
 	})
 
-	testInstall := func(cloudConfig string, actual interface{}, m types.GomegaMatcher, should bool) {
-		stateAssert("persistent.found", "false")
-
-		t, err := os.CreateTemp("", "test")
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-		defer os.RemoveAll(t.Name())
-		err = os.WriteFile(t.Name(), []byte(cloudConfig), os.ModePerm)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = Machine.SendFile(t.Name(), "/tmp/config.yaml", "0770")
-		Expect(err).ToNot(HaveOccurred())
-
-		out, err := Sudo("sudo mv /tmp/config.yaml /oem/")
-		Expect(err).ToNot(HaveOccurred(), out)
-
-		out, _ = Sudo("cat /oem/config.yaml")
-		fmt.Println(out)
-		out, err = Sudo("kairos-agent install")
-		Expect(err).ToNot(HaveOccurred(), out)
-		Expect(out).Should(ContainSubstring("Running after-install hook"))
-		fmt.Println(out)
-		Sudo("sync")
-
-		detachAndReboot()
-
-		EventuallyConnects(1200)
-		if should {
-			fmt.Println("should ", should)
-			Eventually(actual, 5*time.Minute, 10*time.Second).Should(m)
-		} else {
-			Eventually(actual, 5*time.Minute, 10*time.Second).ShouldNot(m)
-		}
-
-	}
-
 	Context("Install with custom mounts", func() {
 
-		It("does not have wrong key", func() {
+		It("bind_mounts", func() {
 			testInstall(`
 install:
   auto: true
@@ -85,33 +46,10 @@ stages:
       passwd: "kairos"
 `, func() string {
 				var out string
-				out, _ = Sudo("cat /oem/90_custom.yaml")
-				return out
-			}, ContainSubstring("foo"), false)
-		})
-		FIt("bind_mounts", func() {
-			testInstall(`
-install:
-  auto: true
-  device: "auto"
-  bind_mounts:
-  - /mnt/bind1
-  - /mnt/bind2
-  ephemeral_mounts:
-  - /mnt/ephemeral
-  - /mnt/ephemeral2
-stages:
-  initramfs:
-  - name: "Set user and password"
-    users:
-     kairos:
-      passwd: "kairos"
-`, func() string {
-				var out string
-				out, _ = Sudo("cat /run/cos/custom-layout.env")
+				out, _ = Sudo("cat /run/cos/cos-layout.env")
 				fmt.Println(out)
 				return out
-			}, ContainSubstring("/mnt/bind1 /mnt/bind2"), true)
+			}, ContainElements(ContainSubstring("/mnt/bind1"), ContainSubstring("/mnt/ephemeral")), true)
 		})
 
 	})

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -2,7 +2,6 @@ package mos_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -32,14 +31,12 @@ func testInstall(cloudConfig string, actual interface{}, m types.GomegaMatcher, 
 	out, err = Sudo("kairos-agent install")
 	Expect(err).ToNot(HaveOccurred(), out)
 	Expect(out).Should(ContainSubstring("Running after-install hook"))
-	fmt.Println(out)
 	Sudo("sync")
 
 	detachAndReboot()
 
 	EventuallyConnects(1200)
 	if should {
-		fmt.Println("should ", should)
 		Eventually(actual, 5*time.Minute, 10*time.Second).Should(m)
 	} else {
 		Eventually(actual, 5*time.Minute, 10*time.Second).ShouldNot(m)

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -13,6 +13,39 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
+func testInstall(cloudConfig string, actual interface{}, m types.GomegaMatcher, should bool) {
+	stateAssert("persistent.found", "false")
+
+	t, err := os.CreateTemp("", "test")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	defer os.RemoveAll(t.Name())
+	err = os.WriteFile(t.Name(), []byte(cloudConfig), os.ModePerm)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = Machine.SendFile(t.Name(), "/tmp/config.yaml", "0770")
+	Expect(err).ToNot(HaveOccurred())
+
+	out, err := Sudo("sudo mv /tmp/config.yaml /oem/")
+	Expect(err).ToNot(HaveOccurred(), out)
+
+	out, err = Sudo("kairos-agent install")
+	Expect(err).ToNot(HaveOccurred(), out)
+	Expect(out).Should(ContainSubstring("Running after-install hook"))
+	fmt.Println(out)
+	Sudo("sync")
+
+	detachAndReboot()
+
+	EventuallyConnects(1200)
+	if should {
+		fmt.Println("should ", should)
+		Eventually(actual, 5*time.Minute, 10*time.Second).Should(m)
+	} else {
+		Eventually(actual, 5*time.Minute, 10*time.Second).ShouldNot(m)
+	}
+}
+
 var _ = Describe("kairos install test", Label("install-test"), func() {
 
 	BeforeEach(func() {
@@ -24,34 +57,6 @@ var _ = Describe("kairos install test", Label("install-test"), func() {
 		Machine.Create(context.Background())
 		EventuallyConnects(1200)
 	})
-
-	testInstall := func(cloudConfig string, actual interface{}, m types.GomegaMatcher) {
-		stateAssert("persistent.found", "false")
-
-		t, err := os.CreateTemp("", "test")
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-		defer os.RemoveAll(t.Name())
-		err = os.WriteFile(t.Name(), []byte(cloudConfig), os.ModePerm)
-		Expect(err).ToNot(HaveOccurred())
-
-		err = Machine.SendFile(t.Name(), "/tmp/config.yaml", "0770")
-		Expect(err).ToNot(HaveOccurred())
-
-		out, err := Sudo("sudo mv /tmp/config.yaml /oem/")
-		Expect(err).ToNot(HaveOccurred(), out)
-
-		out, err = Sudo("kairos-agent install")
-		Expect(err).ToNot(HaveOccurred(), out)
-		Expect(out).Should(ContainSubstring("Running after-install hook"))
-		fmt.Println(out)
-		Sudo("sync")
-
-		detachAndReboot()
-
-		EventuallyConnects(1200)
-		Eventually(actual, 5*time.Minute, 10*time.Second).Should(m)
-	}
 
 	Context("install", func() {
 
@@ -74,7 +79,7 @@ bundles:
 				var out string
 				out, _ = Sudo("/usr/local/bin/usr/bin/edgevpn --help")
 				return out
-			}, ContainSubstring("peerguard"))
+			}, ContainSubstring("peerguard"), true)
 		})
 		It("cloud-config syntax mixed with extended syntax", func() {
 			testInstall(`#cloud-config
@@ -93,7 +98,7 @@ stages:
 				var out string
 				out, _ = Sudo("cat /etc/foo")
 				return out
-			}, ContainSubstring("bar"))
+			}, ContainSubstring("bar"), true)
 
 			stateAssert("persistent.found", "true")
 		})
@@ -106,7 +111,7 @@ config_url: "https://gist.githubusercontent.com/mudler/6db795bad8f9e29ebec14b6ae
 				var out string
 				out, _ = Sudo("/usr/local/bin/usr/bin/edgevpn --help")
 				return out
-			}, ContainSubstring("peerguard"))
+			}, ContainSubstring("peerguard"), true)
 		})
 	})
 })

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -124,7 +124,7 @@ var _ = BeforeSuite(func() {
 		}
 		cpu := os.Getenv("CPU")
 		if cpu != "" {
-			opts = append(opts, types.WithCPU(os.Getenv("CPUS")))
+			opts = append(opts, types.WithCPU(cpu))
 		}
 
 		if os.Getenv("KVM") == "true" {


### PR DESCRIPTION
Users can now specify custom and ephemeral mounts in cloud-init under the `install` section, e.g.:

```
users:
 - name: kairos
...
install:
  auto: true
  device: "auto"
  bind_mounts:
  - /mnt/bind1
  - /mnt/bind2
  ephemeral_mounts:
  - /mnt/ephemeral
  - /mnt/ephemeral2
...
```
Ephemeral mounts are mounted as RW - but changes are discarded when the machine is restart.
Bind mounts will persist changes after restarted.

This is a fix for #210

Signed-off-by: Oz Tiram <oz@spectrocloud.com>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
