### PR TITLE
:seedling: Drop references to node-config

### DIFF
--- a/docs/content/en/docs/Advanced/livelayering.md
+++ b/docs/content/en/docs/Advanced/livelayering.md
@@ -30,7 +30,7 @@ luet util unpack <image> /usr/local/lib/extensions/<extension_name>
 To load an extension during installation of a Kairos node, it can be supplied as a bundle in the `install` block in the node configuration:
 
 ```yaml
-#node-config
+#cloud-config
 
 # Set username and password
 stages:

--- a/docs/content/en/docs/Advanced/networking.md
+++ b/docs/content/en/docs/Advanced/networking.md
@@ -57,7 +57,7 @@ Bonding setup with Ubuntu can be configured via systemd-networkd (Ubuntu based i
 {{< tabpane text=true right=true  >}}
 {{% tab header="systemd-networkd" %}}
 ```yaml
-#node-config
+#cloud-config
 name: "My Deployment"
 stages:
   boot:

--- a/docs/content/en/docs/Installation/automated.md
+++ b/docs/content/en/docs/Installation/automated.md
@@ -35,7 +35,7 @@ To supply your Kairos configuration file, you can create an ISO that contains bo
 Here's an example `user-data` configuration that is set up to automatically install Kairos onto /dev/sda and reboot after installation:
 
 ```yaml
-#node-config
+#cloud-config
 
 install:
   device: "/dev/sda"

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -181,8 +181,8 @@ func Install(dir ...string) error {
 	// now merge cloud config from system and the one received from the agent-provider
 	ccData := map[string]interface{}{}
 
-	// make sure the config we write has at least the #node-config header, if any other was defined beforeahead
-	header := "#node-config"
+	// make sure the config we write has at least the #cloud-config header, if any other was defined beforeahead
+	header := "#cloud-config"
 	if hasHeader, head := config.HasHeader(cc.String(), ""); hasHeader {
 		header = head
 	}

--- a/internal/agent/interactive_install.go
+++ b/internal/agent/interactive_install.go
@@ -256,7 +256,7 @@ func InteractiveInstall(spawnShell bool) error {
 		return err
 	}
 
-	finalCloudConfig := config.AddHeader("#node-config", string(dat))
+	finalCloudConfig := config.AddHeader("#cloud-config", string(dat))
 
 	pterm.Info.Println("Starting installation")
 	pterm.Info.Println(finalCloudConfig)


### PR DESCRIPTION
Signed-off-by: mudler <mudler@c3os.io>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

We have still traces of  `#node-config` that causes confusion among our users, this tries to be consistent by dropping the last reference (I cound find)