### PR TITLE
:penguin: Added support for lldp

### DIFF
--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -37,6 +37,8 @@ RUN apt install -y \
     conntrack \
     snapd \
     iptables \
+    lldpd \
+    snmpd \
     linux-image-generic-hwe-20.04 && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install


### PR DESCRIPTION

Signed-off-by: Justin Barksdale <3pings@users.noreply.github.com>

**What this PR does / why we need it**:
Adding lldpd and snmpd packages to base image for lldp support.  LLDP allows us to gather attributes about the location of a device as an example without hardcoding details into images individually.
