### PR TITLE
🐧 Added lldp support

### DIFF
--- a/images/Dockerfile.ubuntu-22-lts
+++ b/images/Dockerfile.ubuntu-22-lts
@@ -37,6 +37,8 @@ RUN apt install -y \
     snapd \
     conntrack \
     iptables \
+    lldpd \
+    snmpd \
     linux-image-generic-hwe-22.04 && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install


### PR DESCRIPTION
Signed-off-by: Justin Barksdale [3pings@users.noreply.github.com](mailto:3pings@users.noreply.github.com)

What this PR does / why we need it:
Adding lldpd and snmpd packages to base image for lldp support. LLDP allows us to gather attributes about the location of a device as an example without hardcoding details into images individually.