### PR TITLE
:sparkles: Add reset hook

### DIFF
--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -8,12 +8,16 @@ type Interface interface {
 	Run(c config.Config) error
 }
 
-var All = []Interface{
+var AfterInstall = []Interface{
 	&RunStage{},    // Shells out to stages defined from the container image
 	&GrubOptions{}, // Set custom GRUB options
 	&BundleOption{},
 	&Kcrypt{},
 	&Lifecycle{}, // Handles poweroff/reboot by config options
+}
+
+var AfterReset = []Interface{
+	&Kcrypt{},
 }
 
 var FirstBoot = []Interface{

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -286,7 +286,7 @@ func RunInstall(options map[string]string) error {
 		os.Exit(1)
 	}
 
-	if err := hook.Run(*c, hook.All...); err != nil {
+	if err := hook.Run(*c, hook.AfterInstall...); err != nil {
 		return err
 	}
 

--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	hook "github.com/kairos-io/kairos/internal/agent/hooks"
 	"github.com/kairos-io/kairos/internal/bus"
 	"github.com/kairos-io/kairos/internal/cmd"
 	"github.com/kairos-io/kairos/pkg/config"
@@ -86,6 +87,10 @@ func Reset(dir ...string) error {
 	if err := cmd.Run(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
+	}
+
+	if err := hook.Run(*c, hook.AfterReset...); err != nil {
+		return err
 	}
 
 	bus.Manager.Publish(sdk.EventAfterReset, sdk.EventPayload{}) //nolint:errcheck


### PR DESCRIPTION
Signed-off-by: mudler <mudler@c3os.io>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

During reset, we might need to re-apply some deployment logic, such as `kcrypt` to re-encrypt partitions, but others might benefit from this as well. This PR adds reset hooks, and also changes the name of the default one to fit properly the usage in the code.