### PR TITLE
:penguin: Remove nohang from core images

### DIFF
--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -13,7 +13,6 @@ RUN apt install -y \
     grub-efi-amd64-bin \
     grub2 \
     grub2-common \
-    nohang \
     sudo \
     iproute2 \
     squashfs-tools \
@@ -41,7 +40,6 @@ RUN apt install -y \
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
-RUN systemctl enable nohang-desktop.service
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh
 RUN echo "auto lo" > /etc/network/interfaces

--- a/images/Dockerfile.opensuse-leap
+++ b/images/Dockerfile.opensuse-leap
@@ -2,8 +2,6 @@ ARG BASE_IMAGE=opensuse/leap:15.4
 
 FROM $BASE_IMAGE
 
-RUN zypper ar -G https://download.opensuse.org/repositories/utilities/15.4/utilities.repo && zypper ref
-
 RUN zypper in -y \
     bash-completion \
     conntrack-tools \
@@ -21,7 +19,6 @@ RUN zypper in -y \
     grub2-i386-pc \
     logrotate \
     grub2-x86_64-efi \
-    nohang \
     fail2ban \
     haveged \
     htop \

--- a/images/Dockerfile.opensuse-leap-arm-rpi
+++ b/images/Dockerfile.opensuse-leap-arm-rpi
@@ -3,8 +3,6 @@ ARG BASE_IMAGE=opensuse/leap:15.4
 
 FROM $BASE_IMAGE
 
-RUN zypper ar -G https://download.opensuse.org/repositories/utilities/15.4/utilities.repo && zypper ref
-
 RUN zypper in -y \
     raspberrypi-eeprom \
     bcm43xx-firmware \
@@ -40,7 +38,6 @@ RUN zypper in -y \
     gptfdisk \
     grub2-i386-pc \
     grub2-x86_64-efi \
-    nohang \
     haveged \
     htop \
     fail2ban \

--- a/images/Dockerfile.opensuse-tumbleweed
+++ b/images/Dockerfile.opensuse-tumbleweed
@@ -2,8 +2,6 @@ ARG BASE_IMAGE=opensuse/tumbleweed
 
 FROM $BASE_IMAGE
 
-RUN zypper ar -G https://download.opensuse.org/repositories/utilities/openSUSE_Factory/utilities.repo && zypper ref
-
 RUN zypper in -y \
     bash-completion \
     conntrack-tools \
@@ -21,7 +19,6 @@ RUN zypper in -y \
     grub2-i386-pc \
     logrotate \
     grub2-x86_64-efi \
-    nohang \
     fail2ban \
     haveged \
     htop \

--- a/images/Dockerfile.opensuse-tumbleweed-arm-rpi
+++ b/images/Dockerfile.opensuse-tumbleweed-arm-rpi
@@ -3,8 +3,6 @@ ARG BASE_IMAGE=opensuse/tumbleweed
 
 FROM $BASE_IMAGE
 
-RUN zypper ar -G https://download.opensuse.org/repositories/utilities/openSUSE_Factory/utilities.repo && zypper ref
-
 RUN zypper in -y \
     raspberrypi-eeprom \
     bcm43xx-firmware \
@@ -38,7 +36,6 @@ RUN zypper in -y \
     findutils \
     gawk \
     gptfdisk \
-    nohang \
     haveged \
     htop \
     fail2ban \

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -14,7 +14,6 @@ RUN apt install -y \
     grub-efi-amd64-bin \
     grub2 \
     grub2-common \
-    nohang \
     sudo \
     iproute2 \
     squashfs-tools \
@@ -41,7 +40,6 @@ RUN apt install -y \
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
-RUN systemctl enable nohang-desktop.service
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh
 RUN echo "auto lo" > /etc/network/interfaces

--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -14,7 +14,6 @@ RUN apt install -y \
     grub-efi-amd64-bin \
     grub2 \
     grub2-common \
-    nohang \
     sudo \
     iproute2 \
     squashfs-tools \
@@ -43,7 +42,6 @@ RUN apt install -y \
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
-RUN systemctl enable nohang-desktop.service
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh
 RUN echo "auto lo" > /etc/network/interfaces

--- a/images/Dockerfile.ubuntu-22-lts
+++ b/images/Dockerfile.ubuntu-22-lts
@@ -14,7 +14,6 @@ RUN apt install -y \
     grub-efi-amd64-bin \
     grub2 \
     grub2-common \
-    nohang \
     sudo \
     iproute2 \
     squashfs-tools \
@@ -43,7 +42,6 @@ RUN apt install -y \
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
-RUN systemctl enable nohang-desktop.service
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh
 RUN echo "auto lo" > /etc/network/interfaces


### PR DESCRIPTION
Providers, or downstream images should add it instead

Signed-off-by: mudler <mudler@c3os.io>

This needs a PR in provider-kairos, to add it in there instead. Potential fix for #265 
