### PR TITLE
Bump go version for goreleaser job

### DIFF
--- a/.github/workflows/release_bin.yaml
+++ b/.github/workflows/release_bin.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:


### PR DESCRIPTION
Deps now require at least go 1.18

Signed-off-by: Itxaka <itxaka@spectrocloud.com><!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Bumps go version used in the release job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #740 
