### PR TITLE
:book: fixed url for kairos tumbleweed rpi images

### DIFF
--- a/docs/content/en/docs/Reference/image_matrix.md
+++ b/docs/content/en/docs/Reference/image_matrix.md
@@ -35,7 +35,7 @@ Base images are tagged with specific upstream versions (e.g. Ubuntu 20 LTS is pi
 | **Alpine Linux based (openSUSE kernel)**                              	 | https://quay.io/repository/kairos/core-alpine-opensuse-leap           	 | https://quay.io/repository/kairos/kairos-alpine-opensuse-leap           	 |
 | **Alpine Linux based (Ubuntu kernel)**                              	   | https://quay.io/repository/kairos/core-alpine-ubuntu           	        | https://quay.io/repository/kairos/kairos-alpine-ubuntu           	        |
 | **openSUSE Leap based (RaspberryPi 3 and 4, arm64)**     	              | https://quay.io/repository/kairos/core-opensuse-leap-arm-rpi 	          | https://quay.io/repository/kairos/kairos-opensuse-leap-arm-rpi 	          |
-| **openSUSE Tumbleweed based (RaspberryPi 3 and 4, arm64)**     	        | https://quay.io/repository/kairos/core-opensuse-tumbleweed-arm-rpi 	    | https://quay.io/repository/kairos/kairos-opensuse-tumbleweed-rpi 	        |
+| **openSUSE Tumbleweed based (RaspberryPi 3 and 4, arm64)**     	        | https://quay.io/repository/kairos/core-opensuse-tumbleweed-arm-rpi 	    | https://quay.io/repository/kairos/kairos-opensuse-tumbleweed-arm-rpi 	        |
 | **Alpine Linux based (RaspberryPi 3 and 4, arm64)** 	                   | https://quay.io/repository/kairos/core-alpine-arm-rpi   	               | https://quay.io/repository/kairos/kairos-alpine-arm-rpi   	               |
 
 {{% alert title="Note" color="info" %}}


### PR DESCRIPTION
**What this PR does / why we need it**:  Corrected the URL of the kairos tumbleweed rpi images

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #758
