### PR TITLE
:robot: Only download needed release

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -134,6 +134,7 @@ jobs:
           path: tests/**/logs/*
           if-no-files-found: warn
 
+  # This job is used to download the latest release and then used by the upgrade-latest-* jobs
   latest-release:
     runs-on: ubuntu-latest
     steps:
@@ -143,7 +144,7 @@ jobs:
       # The default value is 'false'
         latest: true
         repository: "kairos-io/kairos"
-        fileName: "*"
+        fileName: "*opensuse-leap*.iso"
         out-file-path: "last-release"
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
On the download release action we only need to download the opensuse-leap artifacts for the subsequent tests. Otherwise we are downloading the whole release with all the artifacts for no reason.

Signed-off-by: Itxaka <itxaka@spectrocloud.com>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #756 
