### PR TITLE
Add Rocky Linux and Debian to docs matrix

### DIFF
--- a/docs/content/en/docs/Reference/image_matrix.md
+++ b/docs/content/en/docs/Reference/image_matrix.md
@@ -37,6 +37,8 @@ Base images are tagged with specific upstream versions (e.g. Ubuntu 20 LTS is pi
 | **openSUSE Leap based (RaspberryPi 3 and 4, arm64)**     	              | https://quay.io/repository/kairos/core-opensuse-leap-arm-rpi 	          | https://quay.io/repository/kairos/kairos-opensuse-leap-arm-rpi 	          |
 | **openSUSE Tumbleweed based (RaspberryPi 3 and 4, arm64)**     	        | https://quay.io/repository/kairos/core-opensuse-tumbleweed-arm-rpi 	    | https://quay.io/repository/kairos/kairos-opensuse-tumbleweed-arm-rpi 	        |
 | **Alpine Linux based (RaspberryPi 3 and 4, arm64)** 	                   | https://quay.io/repository/kairos/core-alpine-arm-rpi   	               | https://quay.io/repository/kairos/kairos-alpine-arm-rpi   	               |
+| **Rocky Linux based** 	                   | https://quay.io/repository/kairos/core-rockylinux   	               |                |
+| **Debian Linux based** 	                   | https://quay.io/repository/kairos/core-debian   	               | https://quay.io/repository/kairos/kairos-debian   	               |
 
 {{% alert title="Note" color="info" %}}
 


### PR DESCRIPTION
Signed-off-by: Mauro Morales <mauro.morales@spectrocloud.com>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

We recently added Rocky Linux and Debian but they are not reflected in the documentation Image Matrix.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a
