### PR TITLE
:bug: Fix wrong IF line in Earthfile

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -263,7 +263,7 @@ docker:
 	    RUN rm -rf /boot/initrd.img-*
     END
     # Regenerate initrd if necessary
-    IF [ "$FLAVOR" = "opensuse-leap" ] || [ "$FLAVOR" = "opensuse-leap-arm-rpi" ] || [ "$FLAVOR" = "opensuse-tumbleweed-arm-rpi" || [ "$FLAVOR" = "opensuse-tumbleweed" ]
+    IF [ "$FLAVOR" = "opensuse-leap" ] || [ "$FLAVOR" = "opensuse-leap-arm-rpi" ] || [ "$FLAVOR" = "opensuse-tumbleweed-arm-rpi" ] || [ "$FLAVOR" = "opensuse-tumbleweed" ]
      RUN mkinitrd
     ELSE IF [ "$FLAVOR" = "fedora" ] || [ "$FLAVOR" = "rockylinux" ]
      RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && \


### PR DESCRIPTION
Looks like a ] was missing and instead of crashing and burning, earthly continued happily, which meant that on v1.5.0 ARM tumbleweed images the initrd is missing as earthly failed to parse the check but did not errored out.

Signed-off-by: Itxaka <itxaka@spectrocloud.com>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #784 
