### PR TITLE
🔧 Add earthlyignore file

### DIFF
--- a/.earthlyignore
+++ b/.earthlyignore
@@ -1,0 +1,3 @@
+build/*iso
+# this is created by the strat_vm_qemu.sh script
+disk.img

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -162,11 +162,17 @@ jobs:
       matrix:
        include:
          - flavor: "alpine-opensuse-leap"
+           port: 50001
          - flavor: "opensuse-leap"
+           port: 50002
          - flavor: "opensuse-tumbleweed"
+           port: 50003
          - flavor: "ubuntu"
+           port: 50004
          - flavor: "debian"
+           port: 50005
          - flavor: "ubuntu-20-lts"
+           port: 50006
          - flavor: "ubuntu-22-lts"
     steps:
     - uses: actions/checkout@v3
@@ -179,8 +185,9 @@ jobs:
             export ISO=$PWD/$(ls *.iso)
             mkdir build
             mv $ISO build/kairos.iso
+            sed  '/build.*/d' .earthlyignore
             ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
-            ./earthly.sh +run-qemu-datasource-tests --FLAVOR=${{ matrix.flavor }}
+            ./earthly.sh +run-qemu-datasource-tests --FLAVOR=${{ matrix.flavor }} --SSH_PORT=${{ matrix.port }}
 
   qemu-bundles-tests:
     needs: 

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -225,6 +225,7 @@ jobs:
           name: kairos-${{ matrix.flavor }}.iso.zip
     - run: |
             ls -liah
+            rm .earthlyignore
             export ISO=$PWD/$(ls *.iso)
             mkdir build
             mv $ISO build/kairos.iso
@@ -300,6 +301,7 @@ jobs:
         df -h
     - run: |
             ls -liah
+            rm .earthlyignore
             export ISO=$PWD/$(ls *.iso)
             sudo mkdir build
             sudo mv $ISO build/
@@ -363,6 +365,7 @@ jobs:
         df -h
     - run: |
             ls -liah
+            rm .earthlyignore
             export ISO=$PWD/$(ls kairos-${{matrix.flavor}}-*.iso)
             sudo mkdir build
             sudo mv $ISO build/

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -120,6 +120,7 @@ jobs:
             go-version: '^1.16'
       - run: |
               ls -liah
+              sed -i '/build.*/d' .earthlyignore
               export ISO=$PWD/$(ls *.iso)
               export GOPATH="/Users/runner/go"
               export PATH=$PATH:$GOPATH/bin
@@ -225,7 +226,7 @@ jobs:
           name: kairos-${{ matrix.flavor }}.iso.zip
     - run: |
             ls -liah
-            rm .earthlyignore
+            sed -i '/build.*/d' .earthlyignore
             export ISO=$PWD/$(ls *.iso)
             mkdir build
             mv $ISO build/kairos.iso
@@ -301,7 +302,7 @@ jobs:
         df -h
     - run: |
             ls -liah
-            rm .earthlyignore
+            sed -i '/build.*/d' .earthlyignore
             export ISO=$PWD/$(ls *.iso)
             sudo mkdir build
             sudo mv $ISO build/
@@ -365,7 +366,7 @@ jobs:
         df -h
     - run: |
             ls -liah
-            rm .earthlyignore
+            sed -i '/build.*/d' .earthlyignore
             export ISO=$PWD/$(ls kairos-${{matrix.flavor}}-*.iso)
             sudo mkdir build
             sudo mv $ISO build/


### PR DESCRIPTION


**What this PR does / why we need it**:
We need to add .earthlyfile to enhance build speed locally. Without this we are sending a lot of unneeded
files to buildkit, especially true for large ISOs under build/.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #693
