### PR TITLE
:🔧: Allow port forwarding for qemu script

### DIFF
--- a/scripts/start_vm_qemu.sh
+++ b/scripts/start_vm_qemu.sh
@@ -8,6 +8,8 @@ fi
 
 [[ -n ${ENABLE_SPICE} ]] && SPICE=(-vga qxl -spice port=5900,disable-ticketing)
 
+[[ -n ${PORT_FORWARD} ]] && PORT_FORWARD=(-net nic -net user,hostfwd=tcp::${PORT_FORWARD}-:22)
+
 qemu-system-x86_64 \
     -m ${MEMORY:=2096} \
     -smp cores=2 \
@@ -17,6 +19,7 @@ qemu-system-x86_64 \
     -rtc base=utc,clock=rt \
     -chardev socket,path=qga.sock,server,nowait,id=qga0 \
     "${SPICE[@]}" \
+    "${PORT_FORWARD[@]}" \
     -device virtio-serial \
     -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0 \
     -drive if=virtio,media=disk,file=disk.img \


### PR DESCRIPTION


**What this PR does / why we need it**:
This is similar to what happens when we create a VM with Vbox or with the Test suite.
Useful for developers who test with qemu.

Use with:
```
$ PORT_FORWARD=8222 ./scripts/start_vm_qemu.sh build/kairos.iso
```
When the machine is running you can then do:
```
$ ssh -l kairos -p 8222 127.0.0.1:8882
\# login with password kairos
```
