### PR TITLE
✨ unpack local image file

### DIFF
--- a/sdk/bundles/bundles.go
+++ b/sdk/bundles/bundles.go
@@ -10,11 +10,16 @@ import (
 	"github.com/kairos-io/kairos/pkg/utils"
 )
 
+const (
+	filePrefix = "file://"
+)
+
 type BundleConfig struct {
 	Target     string
 	Repository string
 	DBPath     string
 	RootPath   string
+	LocalFile  bool
 }
 
 // BundleOption defines a configuration option for a bundle.
@@ -148,10 +153,15 @@ func (l *ContainerRunner) Install(config *BundleConfig) error {
 	}
 	defer os.RemoveAll(tempDir)
 
+	target := config.Target
+	if config.LocalFile {
+		target = strings.Join([]string{filePrefix, target}, "")
+	}
+
 	out, err := utils.SH(
 		fmt.Sprintf(
 			`luet util unpack %s %s`,
-			config.Target,
+			target,
 			tempDir,
 		),
 	)
@@ -171,11 +181,16 @@ type ContainerInstaller struct{}
 
 func (l *ContainerInstaller) Install(config *BundleConfig) error {
 
+	target := config.Target
+	if config.LocalFile {
+		target = strings.Join([]string{filePrefix, target}, "")
+	}
+
 	//mkdir -p test/etc/luet/repos.conf.d
 	out, err := utils.SH(
 		fmt.Sprintf(
 			`luet util unpack %s %s`,
-			config.Target,
+			target,
 			config.RootPath,
 		),
 	)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
bundles.RunBundles currently does not support reading image tar files from the filesystem and unpacking it into target location. This PR adds support for it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #799 

Depends on - https://github.com/mudler/luet/pull/318 this PR also being merged.
And also the luet dependency will need to be updated.
