### PR TITLE
🔧 sed != gsed in MacOS

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -113,14 +113,14 @@ jobs:
           name: kairos-${{ matrix.flavor }}.iso.zip
       - name: Install deps
         run: |
-          brew install cdrtools jq
+          brew install cdrtools jq gsed
       - name: Install Go
         uses: actions/setup-go@v3
         with:
             go-version: '^1.16'
       - run: |
               ls -liah
-              sed -i '/build.*/d' .earthlyignore
+              gsed -i '/build.*/d' .earthlyignore
               export ISO=$PWD/$(ls *.iso)
               export GOPATH="/Users/runner/go"
               export PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix for `sed: 1: ".earthlyignore": invalid command code .` in MacOS builds.

See 
![image](https://user-images.githubusercontent.com/1083045/216304358-8b4978c4-abd6-4c7c-8cb9-3699a57bb8ea.png)

In https://github.com/kairos-io/kairos/actions/runs/4072936610/jobs/7017039370

I believe that Mac's sed does not accept the syntax I used.


