### PR TITLE
:bug: Fix ownership of polkitd rules dir

### DIFF
--- a/overlay/files/system/oem/31_polkit.yaml
+++ b/overlay/files/system/oem/31_polkit.yaml
@@ -1,0 +1,14 @@
+# Workaround for COPY not keeping original owner
+# https://github.com/earthly/earthly/issues/2640
+# This causes https://github.com/kairos-io/kairos/issues/280
+name: "Fix ownership of polkit dirs"
+stages:
+  initramfs:
+    - name: "/usr/share/polkit-1/rules.d"
+      if: '[ -d /usr/share/polkit-1/rules.d ] && getent passwd polkitd'
+      commands:
+        - chown polkitd -R /usr/share/polkit-1/rules.d
+    - name: "/etc/polkit-1/rules.d"
+      if: '[ -d /etc/polkit-1/rules.d ] && getent passwd polkitd'
+      commands:
+        - chown polkitd -R /etc/polkit-1/rules.d


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

Due to a bug on earthly it seems that some of the directories for polkitd are not being copied under the proper user. This results into polkit not being able to read the dir properly and the rules that come with it.

This patch works around it by installing an oem file that wil restore the proper ownership of those dirs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partial #280 
