### PR TITLE
:bug: Fix dhcp not able to set hostname

### DIFF
--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -32,6 +32,7 @@ RUN apt install -y \
     open-vm-tools \
     openssh-server \
     parted dracut \
+    polkitd \
     rsync \
     snapd \
     squashfs-tools \
@@ -55,4 +56,4 @@ RUN chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo
 
 
 # Clear cache
-RUN apt-get clean && rm -rf /var/cache/* && journalctl --vacuum-size=1K && rm /etc/machine-id && rm /var/lib/dbus/machine-id
+RUN apt-get clean && rm -rf /var/cache/* && journalctl --vacuum-size=1K && rm /etc/machine-id && rm /var/lib/dbus/machine-id && rm /etc/hostname

--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -33,6 +33,7 @@ RUN apt install -y \
     open-vm-tools \
     openssh-server \
     parted dracut \
+    policykit-1 \
     rsync \
     snapd \
     snmpd \
@@ -57,4 +58,4 @@ RUN chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo
 
 
 # Clear cache
-RUN apt-get clean && rm -rf /var/cache/* && journalctl --vacuum-size=1K && rm /etc/machine-id && rm /var/lib/dbus/machine-id
+RUN apt-get clean && rm -rf /var/cache/* && journalctl --vacuum-size=1K && rm /etc/machine-id && rm /var/lib/dbus/machine-id && rm /etc/hostname

--- a/images/Dockerfile.ubuntu-22-lts
+++ b/images/Dockerfile.ubuntu-22-lts
@@ -33,6 +33,7 @@ RUN apt install -y \
     open-vm-tools \
     openssh-server \
     parted dracut \
+    polkitd \
     rsync \
     snapd \
     snmpd \
@@ -57,4 +58,4 @@ RUN chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo
 
 
 # Clear cache
-RUN apt-get clean && rm -rf /var/cache/* && journalctl --vacuum-size=1K && rm /etc/machine-id && rm /var/lib/dbus/machine-id
+RUN apt-get clean && rm -rf /var/cache/* && journalctl --vacuum-size=1K && rm /etc/machine-id && rm /var/lib/dbus/machine-id && rm /etc/hostname


### PR DESCRIPTION
**What this PR does / why we need it**:
Ubuntu flavors were missing the polkitd service so systemd-networkd was not able to send the set-hostname command to systemd-hostnamed due to permissions.

Also once that was fixed, the system defaulted to the localhost.localdomain static name.

This patch add the polkitd package to ubuntu flavors and removes the existing /etc/hostname file which prevents systemd-networkd from setting the hostname via dhcp


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially #280 
