### PR TITLE
🐛 Missing polkit packages and extra /etc/hostname files

### DIFF
--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -30,6 +30,7 @@ RUN apt install -y \
     open-vm-tools \
     openssh-server \
     parted dracut \
+    polkitd \
     patch \
     rsync \
     snapd \
@@ -61,4 +62,4 @@ RUN chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo
 
 
 # Clear cache
-RUN apt-get clean && rm -rf /var/cache/* && journalctl --vacuum-size=1K && rm /etc/machine-id && rm /var/lib/dbus/machine-id
+RUN apt-get clean && rm -rf /var/cache/* && journalctl --vacuum-size=1K && rm /etc/machine-id && rm /var/lib/dbus/machine-id && rm /etc/hostname

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -29,6 +29,7 @@ RUN dnf install -y \
     NetworkManager \
     openssh-server \
     parted \
+    polkit \
     rsync \
     shim-x64 \
     squashfs-tools \ 

--- a/images/Dockerfile.rockylinux
+++ b/images/Dockerfile.rockylinux
@@ -28,6 +28,7 @@ RUN dnf install -y \
     NetworkManager \
     openssh-server \
     parted \
+    polkit \
     rsync \
     shim-x64 \
     squashfs-tools \ 

--- a/overlay/files/system/oem/31_polkit.yaml
+++ b/overlay/files/system/oem/31_polkit.yaml
@@ -1,0 +1,14 @@
+# Workaround for COPY not keeping original owner
+# https://github.com/earthly/earthly/issues/2640
+# This causes https://github.com/kairos-io/kairos/issues/280
+name: "Fix ownership of polkit dirs"
+stages:
+  initramfs:
+    - name: "/usr/share/polkit-1/rules.d"
+      if: '[ -d /usr/share/polkit-1/rules.d ] && getent passwd polkitd'
+      commands:
+        - chown polkitd -R /usr/share/polkit-1/rules.d
+    - name: "/etc/polkit-1/rules.d"
+      if: '[ -d /etc/polkit-1/rules.d ] && getent passwd polkitd'
+      commands:
+        - chown polkitd -R /etc/polkit-1/rules.d


### PR DESCRIPTION
**What this PR does / why we need it**:

Add missing polkit package for fedora/debia/rockylinux

Also remove the extra /etc/hostname that we were bringing from the base container for debian which prevented setting a transient name

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partial #280 

Needs https://github.com/kairos-io/kairos/pull/805
