### PR TITLE
:robot: Don't run installation twice on installation tests

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -107,6 +107,8 @@ jobs:
          - flavor: "opensuse-leap"
     steps:
       - uses: actions/checkout@v3
+      - run: |
+          git fetch --prune --unshallow
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
@@ -176,6 +178,8 @@ jobs:
          - flavor: "ubuntu-22-lts"
     steps:
     - uses: actions/checkout@v3
+    - run: |
+        git fetch --prune --unshallow
     - name: Download artifacts
       uses: actions/download-artifact@v3
       with:
@@ -200,6 +204,8 @@ jobs:
          - flavor: "opensuse-leap"
     steps:
     - uses: actions/checkout@v3
+    - run: |
+        git fetch --prune --unshallow
     - name: Download artifacts
       uses: actions/download-artifact@v3
       with:
@@ -245,6 +251,8 @@ jobs:
    #      - flavor: "ubuntu"
     steps:
     - uses: actions/checkout@v3
+    - run: |
+        git fetch --prune --unshallow
     - name: Download artifacts
       uses: actions/download-artifact@v3
       with:
@@ -274,6 +282,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: |
+        git fetch --prune --unshallow
+    - run: |
             ./earthly.sh +run-qemu-netboot-test --TEST_SUITE=netboot-test --FLAVOR=${{ matrix.flavor }}
 
   upgrade-with-cli-test:
@@ -289,6 +299,8 @@ jobs:
     #     - flavor: "ubuntu"
     steps:
     - uses: actions/checkout@v3
+    - run: |
+        git fetch --prune --unshallow
     - name: Download artifacts
       uses: actions/download-artifact@v3
       with:
@@ -353,6 +365,8 @@ jobs:
     #     - flavor: "ubuntu"
     steps:
     - uses: actions/checkout@v3
+    - run: |
+        git fetch --prune --unshallow
     - name: Download artifacts
       uses: actions/download-artifact@v3
       with:

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -25,10 +25,7 @@ func testInstall(cloudConfig string, actual interface{}, m types.GomegaMatcher, 
 	err = Machine.SendFile(t.Name(), "/tmp/config.yaml", "0770")
 	Expect(err).ToNot(HaveOccurred())
 
-	out, err := Sudo("sudo mv /tmp/config.yaml /oem/")
-	Expect(err).ToNot(HaveOccurred(), out)
-
-	out, err = Sudo("kairos-agent install")
+	out, err := Sudo(`kairos-agent manual-install --device "auto" /tmp/config.yaml`)
 	Expect(err).ToNot(HaveOccurred(), out)
 	Expect(out).Should(ContainSubstring("Running after-install hook"))
 	Sudo("sync")
@@ -59,9 +56,6 @@ var _ = Describe("kairos install test", Label("install-test"), func() {
 
 		It("with bundles", func() {
 			testInstall(`
-install:
-  auto: true
-  device: auto
 stages:
   initramfs:
   - name: "Set user and password"
@@ -80,9 +74,6 @@ bundles:
 		})
 		It("cloud-config syntax mixed with extended syntax", func() {
 			testInstall(`#cloud-config
-install:
-  auto: true
-  device: auto
 users:
 - name: "kairos"
   passwd: "kairos"
@@ -101,9 +92,6 @@ stages:
 		})
 		It("with config_url", func() {
 			testInstall(`
-install:
-  auto: true
-  device: auto
 config_url: "https://gist.githubusercontent.com/mudler/6db795bad8f9e29ebec14b6ae331e5c0/raw/01137c458ad62cfcdfb201cae2f8814db702c6f9/testgist.yaml"`, func() string {
 				var out string
 				out, _ = Sudo("/usr/local/bin/usr/bin/edgevpn --help")


### PR DESCRIPTION
Signed-off-by: mudler <mudler@c3os.io>

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: Attempt to fix #781 by making the test explicit. we do run the install manually, so no need to specify automatic installation in the cloud configs. That is tested by autoinstall tests (https://github.com/kairos-io/kairos/blob/master/tests/assets/autoinstall.yaml)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #781 
