### PR TITLE
:penguin: Disable squasfs compression for ISO building

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -314,7 +314,7 @@ iso:
     WORKDIR /build
     COPY . ./
     COPY +docker-rootfs/rootfs /build/image
-    RUN /entrypoint.sh --name $ISO_NAME --debug build-iso --date=false dir:/build/image --overlay-iso /build/${overlay} --output /build/
+    RUN /entrypoint.sh --name $ISO_NAME --debug build-iso --squash-no-compression --date=false dir:/build/image --overlay-iso /build/${overlay} --output /build/
     SAVE ARTIFACT /build/$ISO_NAME.iso kairos.iso AS LOCAL build/$ISO_NAME.iso
     SAVE ARTIFACT /build/$ISO_NAME.iso.sha256 kairos.iso.sha256 AS LOCAL build/$ISO_NAME.iso.sha256
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Space gained is negligible, just a few Kbs usually (with gzip as its currently) but the speed up improvements in building the ISO are really good, for 20 seconds to 40 seconds per ISO build, and that gets more accentuated on CI runs where the runners are more CPU constrained.

