### PR TITLE
🐧 `xz` Compress initrd Image

### DIFF
--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -38,6 +38,7 @@ RUN apt install -y \
     sudo \
     systemd \
     systemd-sysv \
+    xz-utils \
     && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install


### PR DESCRIPTION
**What this PR does / why we need it**:
In the logs for debian images, `dracut` provides this warning:
```
dracut: *** Creating image file '/boot/initrd-6.1.0-3-amd64' ***
dracut: Cannot execute compression command 'xz', falling back to default
dracut: Using auto-determined compression method 'pigz'
```

This change adds `xz-utils` to debian images so that it can use `xz` compression.  This was first discovered during the work in #821.