### PR TITLE
🐧 Remove `RUN` commands that change `/etc/network/interfaces`

### DIFF
--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -44,8 +44,6 @@ RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh
-RUN echo "auto lo" > /etc/network/interfaces
-RUN echo "iface lo inet loopback" >> /etc/network/interfaces
 
 # workaround https://github.com/systemd/systemd/issues/12231
 # see also: https://github.com/OSInside/kiwi/issues/1015

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -44,8 +44,6 @@ RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh
-RUN echo "auto lo" > /etc/network/interfaces
-RUN echo "iface lo inet loopback" >> /etc/network/interfaces
 
 # Enable tmp
 RUN cp -v /usr/share/systemd/tmp.mount /etc/systemd/system/ 

--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -46,8 +46,6 @@ RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh
-RUN echo "auto lo" > /etc/network/interfaces
-RUN echo "iface lo inet loopback" >> /etc/network/interfaces
 
 # Enable tmp
 RUN cp -v /usr/share/systemd/tmp.mount /etc/systemd/system/ 

--- a/images/Dockerfile.ubuntu-22-lts
+++ b/images/Dockerfile.ubuntu-22-lts
@@ -46,8 +46,6 @@ RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh
-RUN echo "auto lo" > /etc/network/interfaces
-RUN echo "iface lo inet loopback" >> /etc/network/interfaces
 
 # Enable tmp
 RUN cp -v /usr/share/systemd/tmp.mount /etc/systemd/system/ 


### PR DESCRIPTION
**What this PR does / why we need it**:
This file is not used by `systemd-networkd`, but these images enable `systemd-networkd`.  This change removes the `RUN` commands since the file should be unused.

This was originally identified in #821.