### PR TITLE
:bug: Remove systemd-resolved from initramfs

### DIFF
--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -78,7 +78,6 @@ ubuntu-kernel:
 systemd-latest:
   packages:
     - dracut/sysext
-    - dracut/systemd-resolved
 repositories:
   - &kairos
     name: "kairos"


### PR DESCRIPTION
because it prevents legacy network from working.

See also: https://github.com/dracutdevs/dracut/issues/1822

Signed-off-by: Dimitris Karakasilis <dimitris@karakasilis.me>
