### PR TITLE
🔧 Have renovate manage image versions in `Earthfile`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -4,6 +4,7 @@ ARG VARIANT=core # core, lite, framework
 ARG FLAVOR=opensuse-leap
 ARG IMAGE=quay.io/kairos/${VARIANT}-${FLAVOR}:latest
 ARG ISO_NAME=kairos-${VARIANT}-${FLAVOR}
+# renovate: datasource=docker depName=quay.io/luet/base
 ARG LUET_VERSION=0.34.0
 ARG OS_ID=kairos
 ARG REPOSITORIES_FILE=framework-profile.yaml
@@ -19,8 +20,10 @@ ARG COSIGN_EXPERIMENTAL=0
 ARG CGO_ENABLED=0
 ARG OSBUILDER_IMAGE=quay.io/kairos/osbuilder-tools:v0.3.3
 ARG GOLINT_VERSION=1.47.3
+# renovate: datasource=docker depName=golang
 ARG GO_VERSION=1.18
-ARG HADOLINT_VERSION=2.12.0
+# renovate: datasource=docker depName=hadolint/hadolint versioning=docker
+ARG HADOLINT_VERSION=2.12.0-alpine
 
 all:
   BUILD +docker
@@ -153,7 +156,7 @@ golint:
 
 hadolint:
     ARG HADOLINT_VERSION
-    FROM hadolint/hadolint:$HADOLINT_VERSION-alpine
+    FROM hadolint/hadolint:$HADOLINT_VERSION
     WORKDIR /images
     COPY images .
     RUN ls

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^Earthfile$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG\\s+.+_VERSION=(?<currentValue>.*?)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+    }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds support for renovate to be able to update the versions of `quay.io/luet/base`, `golang`, and `hadolint`.

Tested with:
* `docker run --mount type=bind,source=$(pwd)/renovate.json,target=/usr/src/app/renovate.json -it renovate/renovate renovate-config-validator`
* https://regex101.com/r/Ax3iG9/1