### PR TITLE
🔧 Manage the version of Earthly with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,17 @@
         "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG\\s+.+_VERSION=(?<currentValue>.*?)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+    },
+    {
+      "fileMatch": [
+        "^earthly\\.(sh|ps1)$"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "earthly/earthly",
+      "matchStrings": [
+        "earthly\\/earthly:(?<currentValue>.*?)\\s"
+      ],
+      "versioningTemplate": "semver-coerced"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This ensures that `earthly.ps1` and `earthly.sh` are using a version of Earthly that is managed with renovate.

Filename regex tested here: https://regex101.com/r/eEtcqU/1
Version regex tested here: https://regex101.com/r/T8T9aL/1