### PR TITLE
✨  import the images to any CRI on start from the local filesystem

### DIFF
--- a/sdk/clusterplugin/config.go
+++ b/sdk/clusterplugin/config.go
@@ -56,6 +56,12 @@ type Cluster struct {
 
 	// CACerts list of trust certificates.
 	CACerts []string `yaml:"ca_certs,omitempty" json:"ca_certs,omitempty"`
+
+	// ImportLocalImages import local archive images to containerd on start.
+	ImportLocalImages bool `yaml:"import_local_images,omitempty" json:"import_local_images,omitempty"`
+
+	// LocalImagesPath path to local archive images to load into containerd from the filesystem  start
+	LocalImagesPath string `yaml:"local_images_path,omitempty" json:"local_images_path,omitempty"`
 }
 
 type Config struct {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
To add support in the providers to have a conditional check to load the archive images from the local filesystem to containerd or another other CRI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kairos-io/kairos/issues/858
