### PR TITLE
🐧 Packages in docker files should be on a single line

### DIFF
--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -13,7 +13,9 @@ RUN apt install -y \
     curl \
     debianutils \
     dosfstools \
-    dracut-network dracut-live tar \
+    dracut \
+    dracut-live \
+    dracut-network \
     e2fsprogs \
     gawk \
     grub-efi-amd64-bin \
@@ -29,9 +31,9 @@ RUN apt install -y \
     neovim \
     open-vm-tools \
     openssh-server \
-    parted dracut \
-    polkitd \
+    parted \
     patch \
+    polkitd \
     rsync \
     snapd \
     squashfs-tools \
@@ -39,6 +41,7 @@ RUN apt install -y \
     systemd \
     systemd-sysv \
     systemd-timesyncd \
+    tar \
     xz-utils \
     && apt-get clean
 

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -22,7 +22,8 @@ RUN dnf install -y \
     grub2-efi-x64-modules \
     grub2-pc \
     haveged \
-    kernel kernel-modules \
+    kernel \
+    kernel-modules \
     kernel-modules-extra \
     livecd-tools \
     nano \

--- a/images/Dockerfile.rockylinux
+++ b/images/Dockerfile.rockylinux
@@ -22,7 +22,9 @@ RUN dnf install -y \
     grub2-efi-x64 \
     grub2-efi-x64-modules \
     grub2-pc \
-    kernel kernel-modules kernel-modules-extra \
+    kernel \
+    kernel-modules \
+    kernel-modules-extra \
     livecd-tools \
     nano \
     NetworkManager \

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -15,7 +15,9 @@ RUN apt install -y \
     curl \
     debianutils \
     dosfstools \
-    dracut-network dracut-live tar \
+    dracut \
+    dracut-live \
+    dracut-network \
     e2fsprogs \
     gawk \
     grub-efi-amd64-bin \
@@ -31,7 +33,7 @@ RUN apt install -y \
     neovim \
     open-vm-tools \
     openssh-server \
-    parted dracut \
+    parted \
     polkitd \
     rsync \
     snapd \
@@ -39,6 +41,7 @@ RUN apt install -y \
     sudo \
     systemd \
     systemd-timesyncd \
+    tar \
     && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install

--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -15,7 +15,8 @@ RUN apt install -y \
     curl \
     debianutils \
     dosfstools \
-    dracut-network tar \
+    dracut \
+    dracut-network \
     e2fsprogs \
     gawk \
     grub-efi-amd64-bin \
@@ -32,7 +33,7 @@ RUN apt install -y \
     neovim \
     open-vm-tools \
     openssh-server \
-    parted dracut \
+    parted \
     policykit-1 \
     rsync \
     snapd \
@@ -41,6 +42,7 @@ RUN apt install -y \
     sudo \
     systemd \
     systemd-timesyncd \
+    tar \
     && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install

--- a/images/Dockerfile.ubuntu-22-lts
+++ b/images/Dockerfile.ubuntu-22-lts
@@ -15,7 +15,9 @@ RUN apt install -y \
     curl \
     debianutils \
     dosfstools \
-    dracut-network dracut-live tar \
+    dracut \
+    dracut-live \
+    dracut-network \
     e2fsprogs \
     gawk \
     grub-efi-amd64-bin \
@@ -32,7 +34,7 @@ RUN apt install -y \
     neovim \
     open-vm-tools \
     openssh-server \
-    parted dracut \
+    parted \
     polkitd \
     rsync \
     snapd \
@@ -41,6 +43,7 @@ RUN apt install -y \
     sudo \
     systemd \
     systemd-timesyncd \
+    tar \
     && apt-get clean
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install


### PR DESCRIPTION
**What this PR does / why we need it**:
This is not something that hadolint checks (yet, see https://github.com/hadolint/hadolint/issues/445), but a good practice anyway.