### PR TITLE
🔧 Add docker versioning for the `RENOVATE_VERSION`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -26,7 +26,7 @@ ARG GOLINT_VERSION=1.47.3
 ARG GO_VERSION=1.18
 # renovate: datasource=docker depName=hadolint/hadolint versioning=docker
 ARG HADOLINT_VERSION=2.12.0-alpine
-# renovate: datasource=docker depName=renovate/renovate
+# renovate: datasource=docker depName=renovate/renovate versioning=docker
 ARG RENOVATE_VERSION=34
 
 all:


### PR DESCRIPTION
**What this PR does / why we need it**:
This isn't being picked up in the dashboard (#310), and it might be because `34` isn't a proper semver.