### PR TITLE
🌱 Added support for Amazon SSM Agent

### DIFF
--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -9,6 +9,7 @@ stages:
         OVERLAY: "tmpfs:25%"
         RW_PATHS: "/var /etc /srv"
         PERSISTENT_STATE_PATHS: >-
+          /etc/amazon/ssm
           /etc/systemd
           /etc/modprobe.d
           /etc/rancher
@@ -19,6 +20,7 @@ stages:
           /etc/iscsi 
           /etc/cni
           /etc/kubernetes
+          /etc/defaults
           /home
           /opt
           /root
@@ -60,6 +62,7 @@ stages:
         OVERLAY: "tmpfs:25%"
         RW_PATHS: "/var /etc /srv"
         PERSISTENT_STATE_PATHS: >-
+          /etc/amazon/ssm
           /etc/systemd
           /etc/modprobe.d
           /etc/rancher
@@ -70,6 +73,7 @@ stages:
           /etc/iscsi 
           /etc/cni
           /etc/kubernetes
+          /etc/defaults
           /home
           /opt
           /root


### PR DESCRIPTION
Added support for Amazon SSM Agent config file persistence.

**What this PR does / why we need it**:

Users that are looking to add SSM support for their nodes need /etc/amazon/ssm to be persistent as this is where the connection information to AWS is stored.  Previously users could snap install amazon-ssm-agent but the configuration file is not stored in the snaps directory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A
