### PR TITLE
🐧 Support for LLDP

### DIFF
--- a/images/Dockerfile.opensuse-leap
+++ b/images/Dockerfile.opensuse-leap
@@ -29,6 +29,7 @@ RUN zypper in -y \
     kernel-default \
     kernel-firmware-all \
     less \
+    lldpd \
     logrotate \
     lsscsi \
     lvm2 \


### PR DESCRIPTION
Added support for LLDP

**What this PR does / why we need it**:

Users wishing to use network attributes like LLDP-MED attributes need LLDP to do this.  This enables LLDP and the dependency packages.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A
