### PR TITLE
🐧 Install ubuntu-advantage-tools

### DIFF
--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -62,6 +62,7 @@ RUN apt-get update \
     systemd \
     systemd-timesyncd \
     thermald \
+    ubuntu-advantage-tools \
     unattended-upgrades \
     xdg-user-dirs \
     xxd \


### PR DESCRIPTION
Ubuntu advantage tools allows for users to register their node with Canonical.  Since Snaps are supported this will allow them to enable Live Kernel Patches.

**What this PR does / why we need it**:

Ubuntu Advantage Tools enables registration with Canonical for support and things like Live Kernel Patches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A
