### PR TITLE
:bug: Add record to hosts file when missing

### DIFF
--- a/overlay/files/system/oem/31_hosts.yaml
+++ b/overlay/files/system/oem/31_hosts.yaml
@@ -1,0 +1,11 @@
+stages:
+  initramfs.before:
+    # For debian based distributions, /etc/hosts is present but empty. This is because the file
+    # is populated when running the configuration. For those cases we insert a record so it can be
+    # manipulated later on by yip's hostname plugin
+    # Read more: https://wiki.debian.org/ConfigPackages
+    - name: "Make sure hosts file is present and includes a record for 127.0.0.1"
+      if: |
+        ! [[ -f /etc/hosts ]] || ! [[ $(grep '127.0.0.1' /etc/hosts) ]]
+      commands:
+        - echo '127.0.0.1\tlocalhost' >> /etc/hosts


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

For debian based distributions, /etc/hosts is present but empty. This is because the file is populated when running the configuration. [1] This PR inserts a record before initramfs so it can be manipulated later on by yip's hostname plugin


[1] https://wiki.debian.org/ConfigPackages

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #887
