### PR TITLE
:bug: Fix job "Push latest ARM images" caused by docs target

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - armdocsissue
 
 concurrency:
   group: ci-arm-${{ github.head_ref || github.ref }}-${{ github.repository }}

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - armdocsissue
 
 concurrency:
   group: ci-arm-${{ github.head_ref || github.ref }}-${{ github.repository }}

--- a/Earthfile
+++ b/Earthfile
@@ -685,6 +685,7 @@ docs:
           rm -r hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz
     RUN npm install postcss-cli
     RUN npm run prepare
+    RUN ls -las .
     RUN HUGO_ENV="production" ./hugo --gc -b "/local/" -d "public/local"
     SAVE ARTIFACT public /public AS LOCAL docs/public
 

--- a/Earthfile
+++ b/Earthfile
@@ -674,17 +674,19 @@ webui-deps:
 docs:
     FROM node:19-bullseye
     ARG USERARCH
+    RUN echo $USERARCH
     RUN apt install git
     # renovate: datasource=github-releases depName=gohugoio/hugo
     ARG HUGO_VERSION="0.110.0"
-    RUN wget --quiet "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz" && \
-          tar xzf hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz && \
-          rm -r hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz && \
-	  mv hugo /usr/bin
+    RUN wget --quiet "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz"
+    RUN ls -las .
+    RUN tar xzf hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz && \
+          rm -r hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz
+    RUN mv hugo /usr/bin
     COPY . .
     WORKDIR ./docs
     RUN npm install postcss-cli
-    RUN npm run prepare --verbose
+    RUN npm run prepare
     RUN HUGO_ENV="production" /usr/bin/hugo --gc -b "/local/" -d "public/local"
     SAVE ARTIFACT public /public AS LOCAL docs/public
 

--- a/Earthfile
+++ b/Earthfile
@@ -676,20 +676,16 @@ docs:
     ARG USERARCH
     RUN echo $USERARCH
     RUN apt install git
+    COPY . .
+    WORKDIR ./docs
     # renovate: datasource=github-releases depName=gohugoio/hugo
     ARG HUGO_VERSION="0.110.0"
     RUN wget --quiet "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz"
-    RUN ls -las .
     RUN tar xzf hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz && \
           rm -r hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz
-    RUN ls -las .
-    RUN mv hugo /usr/bin
-    RUN ls -las /usr/bin
-    COPY . .
-    WORKDIR ./docs
     RUN npm install postcss-cli
     RUN npm run prepare
-    RUN HUGO_ENV="production" /usr/bin/hugo --gc -b "/local/" -d "public/local"
+    RUN HUGO_ENV="production" ./hugo --gc -b "/local/" -d "public/local"
     SAVE ARTIFACT public /public AS LOCAL docs/public
 
 ## ./earthly.sh --push +temp-image --FLAVOR=ubuntu

--- a/Earthfile
+++ b/Earthfile
@@ -673,21 +673,15 @@ webui-deps:
 
 docs:
     FROM node:19-bullseye
-    ARG USERARCH
-    ARG MODEL
-    IF [ "$MODEL" = "rpi64" ] || [ "$USERARCH" = "arm64" ] || [ "$USERARCH" = "linux/arm64" ]
-      ARG ARCHI = "arm64"
-    ELSE
-      ARG ARCHI = "amd64"
-    END
+    ARG TARGETARCH
 
     # Install dependencies
     RUN apt install git
     # renovate: datasource=github-releases depName=gohugoio/hugo
     ARG HUGO_VERSION="0.110.0"
-    RUN wget --quiet "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${ARCHI}.tar.gz" && \
-        tar xzf hugo_extended_${HUGO_VERSION}_linux-${ARCHI}.tar.gz && \
-        rm -r hugo_extended_${HUGO_VERSION}_linux-${ARCHI}.tar.gz && \
+    RUN wget --quiet "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz" && \
+        tar xzf hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz && \
+        rm -r hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz && \
         mv hugo /usr/bin
 
     COPY . .

--- a/Earthfile
+++ b/Earthfile
@@ -682,7 +682,9 @@ docs:
     RUN ls -las .
     RUN tar xzf hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz && \
           rm -r hugo_extended_${HUGO_VERSION}_linux-${USERARCH}.tar.gz
+    RUN ls -las .
     RUN mv hugo /usr/bin
+    RUN ls -las /usr/bin
     COPY . .
     WORKDIR ./docs
     RUN npm install postcss-cli


### PR DESCRIPTION
The problem was caused because the outer target runs on arm64 but when it gets to the docs target the `USERARCH` was amd64. This change checks also for `MODEL` and in case the `USERARCH` is `linux/arm64` and not just `arm64`

you can see it working properly in this run https://github.com/mauromorales/kairos/actions/runs/4223111756/jobs/7332444446#step:9:1170 (cancelled manually after it passed, so ignore that it is red :tongue: )