### PR TITLE
:bug: copy kairos agent during framework build

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -219,6 +219,8 @@ framework:
 
     RUN go run -ldflags "${LDFLAGS}" ./cmd/profile-build/main.go ${FLAVOR} $REPOSITORIES_FILE /framework
 
+    # Copy kairos binaries
+    COPY +build-kairos-agent/kairos-agent /framework/usr/bin/kairos-agent
     COPY +luet/luet /framework/usr/bin/luet
 
     RUN luet cleanup --system-target /framework
@@ -283,8 +285,6 @@ docker:
         COPY overlay/files-ubuntu/ /
     END
 
-    # Copy kairos binaries
-    COPY +build-kairos-agent/kairos-agent /usr/bin/kairos-agent
     # Enable services
     IF [ -f /sbin/openrc ]
      RUN mkdir -p /etc/runlevels/default && \


### PR DESCRIPTION

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Currently is done during docker image but it makes no sense, it should be during framework otherwise framework images do not contain the binary


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #777 
