### PR TITLE
:sparkles: Web UI schema validations

### DIFF
--- a/internal/agent/validate.go
+++ b/internal/agent/validate.go
@@ -23,11 +23,11 @@ func JSONSchema(version string) (string, error) {
 }
 
 // Validate ensures that a given schema is Valid according to the Root Schema from the agent.
-func Validate(file string) error {
+func Validate(source string) error {
 	var yaml string
 
-	if strings.HasPrefix(file, "http") {
-		resp, err := http.Get(file)
+	if strings.HasPrefix(source, "http") {
+		resp, err := http.Get(source)
 		if err != nil {
 			return err
 		}
@@ -38,11 +38,16 @@ func Validate(file string) error {
 		//Convert the body to type string
 		yaml = string(body)
 	} else {
-		dat, err := os.ReadFile(file)
+		dat, err := os.ReadFile(source)
 		if err != nil {
-			return err
+			if strings.Contains(err.Error(), "no such file or directory") {
+				yaml = source
+			} else {
+				return err
+			}
+		} else {
+			yaml = string(dat)
 		}
-		yaml = string(dat)
 	}
 
 	config, err := schema.NewConfigFromYAML(yaml, schema.RootSchema{})

--- a/internal/webui/public/index.html
+++ b/internal/webui/public/index.html
@@ -69,7 +69,22 @@
                   try {
                     // Parse the YAML
                     const yaml = YAML.parse(this.content);
-                    this.valid=true
+                    const formData = new FormData()
+                    formData.append('cloud-config', this.content)
+                    const settings = {
+                        method: 'POST',
+                        body: formData,
+                    };
+                    fetch(`/validate`, settings)
+                      .then((response) => response.text())
+                      .then((text) => {
+                        if (text === '') {
+                          this.valid = true
+                        } else {
+                          this.error = text
+                          this.valid = false
+                        }
+                      })
                   } catch(error) {
                     this.error = error
                     this.valid = false

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -161,6 +161,21 @@ func Start(ctx context.Context) error {
 
 	ec.GET("/*", echo.WrapHandler(http.StripPrefix("/", assetHandler)))
 
+	ec.POST("/validate", func(c echo.Context) error {
+		formData := new(FormData)
+		if err := c.Bind(formData); err != nil {
+			return err
+		}
+		cloudConfig := formData.CloudConfig
+
+		err := agent.Validate(cloudConfig)
+		if err != nil {
+			return c.String(http.StatusOK, err.Error())
+		}
+
+		return c.String(http.StatusOK, "")
+	})
+
 	ec.POST("/install", func(c echo.Context) error {
 
 		s.Lock()


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

This PR integrates the schema validations on the WebUI

[Screencast from 2023-02-21 15-21-29.webm](https://user-images.githubusercontent.com/433958/220372220-2e693032-24be-4de4-8539-18cfe8c5fab8.webm)

**Not included**

This PR does not include the refactoring of the Web UI, neither does it include the values of the other form items besides the pure cloud config and it doesn't block the user from installing if the config is invalid. I thought this was ok since this first release will not enforce the validations


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #779
