### PR TITLE
Fix elemental grub with newer versions of elemental cli

### DIFF
--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -17,9 +17,7 @@ var AfterInstall = []Interface{
 	&Lifecycle{}, // Handles poweroff/reboot by config options
 }
 
-var AfterReset = []Interface{
-	&Kcrypt{},
-}
+var AfterReset []Interface
 
 var FirstBoot = []Interface{
 	&BundlePostInstall{},

--- a/internal/agent/interactive_install.go
+++ b/internal/agent/interactive_install.go
@@ -128,6 +128,8 @@ func detectDevice() string {
 }
 
 func InteractiveInstall(spawnShell bool) error {
+	releaseLock := acquireInstallLock()
+	defer releaseLock()
 	bus.Manager.Initialize()
 
 	cmd.PrintBranding(DefaultBanner)

--- a/overlay/files/system/oem/21_grub.yaml
+++ b/overlay/files/system/oem/21_grub.yaml
@@ -6,13 +6,18 @@ stages:
       if: '[ -e "/etc/kairos/branding/grubmenu.cfg" ]'
       commands:
         - |
-            STATEDIR=/tmp/mnt/STATE
-            STATE=$(blkid -L COS_STATE || true)
-            mkdir -p $STATEDIR || true
-            mount ${STATE} $STATEDIR
-            cp -rfv /etc/kairos/branding/grubmenu.cfg /tmp/mnt/STATE/grubmenu
-            umount /tmp/mnt/STATE
-  after-upgrade:
-    - <<: *grubinstall
+          STATEDIR=/tmp/mnt/STATE
+          STATE=$(blkid -L COS_STATE || true)
+          mkdir -p $STATEDIR || true
+          mount ${STATE} $STATEDIR
+          cp -rfv /etc/kairos/branding/grubmenu.cfg /tmp/mnt/STATE/grubmenu
+          
+          if [ -d /tmp/mnt/STATE/grub ]; then
+            echo "configfile (\$root)'/grub2/grub.cfg'" >> /tmp/mnt/STATE/grub/grub.cfg
+          fi
+
+          umount /tmp/mnt/STATE
   after-reset:
+    - <<: *grubinstall
+  after-upgrade:
     - <<: *grubinstall


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds a grub cfg to /boot/grub. Some distros still look in `/boot/grub` even with grub2. This change introduces a file that redirects grub to always use the grub 2 folder. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #733
