### PR TITLE
:art: Refactoring of validator and config 1/n

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -212,7 +212,7 @@ E.g. kairos-agent install-bundle container:quay.io/kairos/kairos...
 				Description: "Show the runtime configuration of the machine. It will scan the machine for all the configuration and will return the config file processed and found.",
 				Aliases:     []string{"s"},
 				Action: func(c *cli.Context) error {
-					config, err := config.Scan(config.Directories(configScanDir...), config.NoLogs)
+					config, err := config.KScan(config.Directories(configScanDir...), config.NoLogs)
 					if err != nil {
 						return err
 					}
@@ -237,7 +237,7 @@ enabled: true`,
 				Description: "It allows to navigate the YAML config file by searching with 'yq' style keywords as `config get k3s` to retrieve the k3s config block",
 				Aliases:     []string{"g"},
 				Action: func(c *cli.Context) error {
-					config, err := config.Scan(config.Directories(configScanDir...), config.NoLogs, config.StrictValidation(c.Bool("strict-validation")))
+					config, err := config.KScan(config.Directories(configScanDir...), config.NoLogs, config.StrictValidation(c.Bool("strict-validation")))
 					if err != nil {
 						return err
 					}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -26,7 +26,6 @@ func Run(opts ...Option) error {
 	os.MkdirAll("/usr/local/.kairos", 0600) //nolint:errcheck
 
 	// Reads config
-	// c, err := config.Scan(config.Directories(o.Dir...))
 	c, err := config.KScan(config.Directories(o.Dir...))
 	if err != nil {
 		return err

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -26,14 +26,15 @@ func Run(opts ...Option) error {
 	os.MkdirAll("/usr/local/.kairos", 0600) //nolint:errcheck
 
 	// Reads config
-	c, err := config.Scan(config.Directories(o.Dir...))
+	// c, err := config.Scan(config.Directories(o.Dir...))
+	c, err := config.KScan(config.Directories(o.Dir...))
 	if err != nil {
 		return err
 	}
 
 	utils.SetEnv(c.Env)
 	bf := machine.BootFrom()
-	if c.Install != nil && c.Install.Auto && (bf == machine.NetBoot || bf == machine.LiveCDBoot) {
+	if c.Install.Auto && (bf == machine.NetBoot || bf == machine.LiveCDBoot) {
 		// Don't go ahead if we are asked to install from a booting live medium
 		fmt.Println("Agent run aborted. Installation being performed from live medium")
 		return nil
@@ -65,7 +66,7 @@ func Run(opts ...Option) error {
 
 	if !machine.SentinelExist("firstboot") {
 
-		if err := hook.Run(*c, hook.FirstBoot...); err != nil {
+		if err := hook.KRun(*c, hook.FirstBoot...); err != nil {
 			return err
 		}
 
@@ -77,7 +78,7 @@ func Run(opts ...Option) error {
 		}
 
 		// Re-read config files
-		c, err = config.Scan(config.Directories(o.Dir...))
+		c, err = config.KScan(config.Directories(o.Dir...))
 		if err != nil {
 			return err
 		}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -28,7 +28,6 @@ var _ = Describe("Bootstrap provider", func() {
 			defer os.RemoveAll(f)
 
 			wd, _ := os.Getwd()
-			fmt.Println(wd)
 			os.WriteFile(filepath.Join(wd, "agent-provider-test"), []byte(testProvider), 0655)
 
 			defer os.RemoveAll(filepath.Join(wd, "agent-provider-test"))

--- a/internal/agent/hooks/bundles.go
+++ b/internal/agent/hooks/bundles.go
@@ -30,6 +30,7 @@ func (b BundleOption) Run(c config.Config) error {
 	return nil
 }
 
+// KRun is a temporary function that does the same as Run. It will be removed as soon as the transition from config.Config to schema.KConfig is finished.
 func (b BundleOption) KRun(kc schema.KConfig) error {
 
 	machine.Mount("COS_PERSISTENT", "/usr/local") //nolint:errcheck
@@ -62,6 +63,7 @@ func (b BundlePostInstall) Run(c config.Config) error {
 	return nil
 }
 
+// KRun is a temporary function that does the same as Run. It will be removed as soon as the transition from config.Config to schema.KConfig is finished.
 func (b BundlePostInstall) KRun(kc schema.KConfig) error {
 	opts := kc.Bundles.Options()
 	err := bundles.RunBundles(opts...)

--- a/internal/agent/hooks/bundles.go
+++ b/internal/agent/hooks/bundles.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	config "github.com/kairos-io/kairos/pkg/config"
+	schema "github.com/kairos-io/kairos/pkg/config/schemas"
 	"github.com/kairos-io/kairos/pkg/machine"
 	"github.com/kairos-io/kairos/sdk/bundles"
 )
@@ -29,12 +30,42 @@ func (b BundleOption) Run(c config.Config) error {
 	return nil
 }
 
+func (b BundleOption) KRun(kc schema.KConfig) error {
+
+	machine.Mount("COS_PERSISTENT", "/usr/local") //nolint:errcheck
+	defer func() {
+		machine.Umount("/usr/local") //nolint:errcheck
+	}()
+
+	machine.Mount("COS_OEM", "/oem") //nolint:errcheck
+	defer func() {
+		machine.Umount("/oem") //nolint:errcheck
+	}()
+
+	opts := kc.Install.Bundles.Options()
+	err := bundles.RunBundles(opts...)
+	if kc.FailOnBundleErrors && err != nil {
+		return err
+	}
+
+	return nil
+}
+
 type BundlePostInstall struct{}
 
 func (b BundlePostInstall) Run(c config.Config) error {
 	opts := c.Bundles.Options()
 	err := bundles.RunBundles(opts...)
 	if c.FailOnBundleErrors && err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b BundlePostInstall) KRun(kc schema.KConfig) error {
+	opts := kc.Bundles.Options()
+	err := bundles.RunBundles(opts...)
+	if kc.FailOnBundleErrors && err != nil {
 		return err
 	}
 	return nil

--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	config "github.com/kairos-io/kairos/pkg/config"
+	schema "github.com/kairos-io/kairos/pkg/config/schemas"
 	"github.com/kairos-io/kairos/sdk/system"
 )
 
@@ -17,10 +18,26 @@ func (b GrubOptions) Run(c config.Config) error {
 	return nil
 }
 
+func (b GrubOptions) KRun(kc schema.KConfig) error {
+	err := system.Apply(system.SetGRUBOptions(kc.Install.GrubOptions()))
+	if err != nil {
+		fmt.Println(err)
+	}
+	return nil
+}
+
 type GrubPostInstallOptions struct{}
 
 func (b GrubPostInstallOptions) Run(c config.Config) error {
 	err := system.Apply(system.SetGRUBOptions(c.GrubOptions))
+	if err != nil {
+		fmt.Println(err)
+	}
+	return nil
+}
+
+func (b GrubPostInstallOptions) KRun(kc schema.KConfig) error {
+	err := system.Apply(system.SetGRUBOptions(kc.GrubOptions()))
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -19,7 +19,11 @@ func (b GrubOptions) Run(c config.Config) error {
 }
 
 func (b GrubOptions) KRun(kc schema.KConfig) error {
-	err := system.Apply(system.SetGRUBOptions(kc.Install.GrubOptions()))
+	grubOptions, err := kc.GrubOptions()
+	if err != nil {
+		fmt.Println(err)
+	}
+	err = system.Apply(system.SetGRUBOptions(grubOptions))
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -37,7 +41,11 @@ func (b GrubPostInstallOptions) Run(c config.Config) error {
 }
 
 func (b GrubPostInstallOptions) KRun(kc schema.KConfig) error {
-	err := system.Apply(system.SetGRUBOptions(kc.GrubOptions()))
+	grubOptions, err := kc.GrubOptions()
+	if err != nil {
+		fmt.Println(err)
+	}
+	err = system.Apply(system.SetGRUBOptions(grubOptions))
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/internal/agent/hooks/gruboptions.go
+++ b/internal/agent/hooks/gruboptions.go
@@ -18,6 +18,7 @@ func (b GrubOptions) Run(c config.Config) error {
 	return nil
 }
 
+// KRun is a temporary function that does the same as Run. It will be removed as soon as the transition from config.Config to schema.KConfig is finished.
 func (b GrubOptions) KRun(kc schema.KConfig) error {
 	grubOptions, err := kc.GrubOptions()
 	if err != nil {
@@ -40,6 +41,7 @@ func (b GrubPostInstallOptions) Run(c config.Config) error {
 	return nil
 }
 
+// KRun is a temporary function that does the same as Run. It will be removed as soon as the transition from config.Config to schema.KConfig is finished.
 func (b GrubPostInstallOptions) KRun(kc schema.KConfig) error {
 	grubOptions, err := kc.GrubOptions()
 	if err != nil {

--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -37,6 +37,7 @@ func Run(c config.Config, hooks ...Interface) error {
 	return nil
 }
 
+// KRun is a temporary function that does the same as Run. It will be removed as soon as the transition from config.Config to schema.KConfig is finished.
 func KRun(kc schema.KConfig, hooks ...Interface) error {
 	for _, h := range hooks {
 		if err := h.KRun(kc); err != nil {

--- a/internal/agent/hooks/hook.go
+++ b/internal/agent/hooks/hook.go
@@ -2,10 +2,12 @@ package hook
 
 import (
 	config "github.com/kairos-io/kairos/pkg/config"
+	schema "github.com/kairos-io/kairos/pkg/config/schemas"
 )
 
 type Interface interface {
 	Run(c config.Config) error
+	KRun(c schema.KConfig) error
 }
 
 var AfterInstall = []Interface{
@@ -29,6 +31,15 @@ var FirstBoot = []Interface{
 func Run(c config.Config, hooks ...Interface) error {
 	for _, h := range hooks {
 		if err := h.Run(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func KRun(kc schema.KConfig, hooks ...Interface) error {
+	for _, h := range hooks {
+		if err := h.KRun(kc); err != nil {
 			return err
 		}
 	}

--- a/internal/agent/hooks/kcrypt.go
+++ b/internal/agent/hooks/kcrypt.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	config "github.com/kairos-io/kairos/pkg/config"
+	schema "github.com/kairos-io/kairos/pkg/config/schemas"
 	"github.com/kairos-io/kairos/pkg/machine"
 	"github.com/kairos-io/kairos/pkg/utils"
 
@@ -58,6 +59,57 @@ func (k Kcrypt) Run(c config.Config) error {
 	if err != nil {
 		fmt.Println("Failed writing kcrypt partition mappings: ", err.Error())
 		if c.FailOnBundleErrors {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (k Kcrypt) KRun(kc schema.KConfig) error {
+
+	if len(kc.Install.EncryptedPartitions) == 0 {
+		return nil
+	}
+
+	machine.Mount("COS_OEM", "/oem") //nolint:errcheck
+	defer func() {
+		machine.Umount("/oem") //nolint:errcheck
+	}()
+
+	kcryptc, err := kcryptconfig.GetConfiguration(kcryptconfig.ConfigScanDirs)
+	if err != nil {
+		fmt.Println("Failed getting kcrypt configuration: ", err.Error())
+		if kc.FailOnBundleErrors {
+			return err
+		}
+	}
+
+	for _, p := range kc.Install.EncryptedPartitions {
+		out, err := utils.SH(fmt.Sprintf("kcrypt encrypt %s", p))
+		if err != nil {
+			fmt.Printf("could not encrypt partition: %s\n", out+err.Error())
+			if kc.FailOnBundleErrors {
+				return err
+			}
+			// Give time to show the error
+			time.Sleep(10 * time.Second)
+			return nil // do not error out
+		}
+
+		err = kcryptc.SetMapping(strings.TrimSpace(out))
+		if err != nil {
+			fmt.Println("Failed updating the kcrypt configuration file: ", err.Error())
+			if kc.FailOnBundleErrors {
+				return err
+			}
+		}
+	}
+
+	err = kcryptc.WriteMappings(kcryptconfig.MappingsFile)
+	if err != nil {
+		fmt.Println("Failed writing kcrypt partition mappings: ", err.Error())
+		if kc.FailOnBundleErrors {
 			return err
 		}
 	}

--- a/internal/agent/hooks/lifecycle.go
+++ b/internal/agent/hooks/lifecycle.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	config "github.com/kairos-io/kairos/pkg/config"
+	schema "github.com/kairos-io/kairos/pkg/config/schemas"
 	"github.com/kairos-io/kairos/pkg/utils"
 )
 
@@ -13,6 +14,17 @@ func (s Lifecycle) Run(c config.Config) error {
 	}
 
 	if c.Install.Poweroff {
+		utils.PowerOFF()
+	}
+	return nil
+}
+
+func (s Lifecycle) KRun(c schema.KConfig) error {
+	if c.Install.Foo().Reboot {
+		utils.Reboot()
+	}
+
+	if c.Install.Foo().Poweroff {
 		utils.PowerOFF()
 	}
 	return nil

--- a/internal/agent/hooks/lifecycle.go
+++ b/internal/agent/hooks/lifecycle.go
@@ -19,12 +19,13 @@ func (s Lifecycle) Run(c config.Config) error {
 	return nil
 }
 
+// KRun is a temporary function that does the same as Run. It will be removed as soon as the transition from config.Config to schema.KConfig is finished.
 func (s Lifecycle) KRun(c schema.KConfig) error {
-	if c.Install.Foo().Reboot {
+	if c.Install.Power().Reboot {
 		utils.Reboot()
 	}
 
-	if c.Install.Foo().Poweroff {
+	if c.Install.Power().Poweroff {
 		utils.PowerOFF()
 	}
 	return nil

--- a/internal/agent/hooks/mounts.go
+++ b/internal/agent/hooks/mounts.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	config "github.com/kairos-io/kairos/pkg/config"
+	schema "github.com/kairos-io/kairos/pkg/config/schemas"
 	"github.com/kairos-io/kairos/pkg/machine"
-	"github.com/mudler/yip/pkg/schema"
 	yip "github.com/mudler/yip/pkg/schema"
 	"gopkg.in/yaml.v1"
 )
@@ -46,8 +46,40 @@ func (cm CustomMounts) Run(c config.Config) error {
 	mountsList["CUSTOM_BIND_MOUNTS"] = strings.Join(c.Install.BindMounts, " ")
 	mountsList["CUSTOM_EPHEMERAL_MOUNTS"] = strings.Join(c.Install.EphemeralMounts, " ")
 
-	config := yip.YipConfig{Stages: map[string][]schema.Stage{
-		"rootfs": []yip.Stage{{
+	config := yip.YipConfig{Stages: map[string][]yip.Stage{
+		"rootfs": {{
+			Name:            "user_custom_mounts",
+			EnvironmentFile: "/run/cos/custom-layout.env",
+			Environment:     mountsList,
+		}},
+	}}
+
+	saveCloudConfig("user_custom_mounts", config) //nolint:errcheck
+	return nil
+}
+
+func (cm CustomMounts) KRun(kc schema.KConfig) error {
+
+	//fmt.Println("Custom mounts hook")
+	//fmt.Println(strings.Join(c.Install.BindMounts, " "))
+	//fmt.Println(strings.Join(c.Install.EphemeralMounts, " "))
+
+	if len(kc.Install.BindMounts) == 0 && len(kc.Install.EphemeralMounts) == 0 {
+		return nil
+	}
+
+	machine.Mount("COS_OEM", "/oem") //nolint:errcheck
+	defer func() {
+		machine.Umount("/oem") //nolint:errcheck
+	}()
+
+	var mountsList = map[string]string{}
+
+	mountsList["CUSTOM_BIND_MOUNTS"] = strings.Join(kc.Install.BindMounts, " ")
+	mountsList["CUSTOM_EPHEMERAL_MOUNTS"] = strings.Join(kc.Install.EphemeralMounts, " ")
+
+	config := yip.YipConfig{Stages: map[string][]yip.Stage{
+		"rootfs": {{
 			Name:            "user_custom_mounts",
 			EnvironmentFile: "/run/cos/custom-layout.env",
 			Environment:     mountsList,

--- a/internal/agent/hooks/runstage.go
+++ b/internal/agent/hooks/runstage.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	config "github.com/kairos-io/kairos/pkg/config"
+	schema "github.com/kairos-io/kairos/pkg/config/schemas"
 	"github.com/kairos-io/kairos/pkg/utils"
 
 	events "github.com/kairos-io/kairos/sdk/bus"
@@ -10,6 +11,12 @@ import (
 type RunStage struct{}
 
 func (r RunStage) Run(c config.Config) error {
+	utils.SH("elemental run-stage kairos-install.after")             //nolint:errcheck
+	events.RunHookScript("/usr/bin/kairos-agent.install.after.hook") //nolint:errcheck
+	return nil
+}
+
+func (r RunStage) KRun(kc schema.KConfig) error {
 	utils.SH("elemental run-stage kairos-install.after")             //nolint:errcheck
 	events.RunHookScript("/usr/bin/kairos-agent.install.after.hook") //nolint:errcheck
 	return nil

--- a/internal/agent/hooks/runstage.go
+++ b/internal/agent/hooks/runstage.go
@@ -16,6 +16,7 @@ func (r RunStage) Run(c config.Config) error {
 	return nil
 }
 
+// KRun is a temporary function that does the same as Run. It will be removed as soon as the transition from config.Config to schema.KConfig is finished.
 func (r RunStage) KRun(kc schema.KConfig) error {
 	utils.SH("elemental run-stage kairos-install.after")             //nolint:errcheck
 	events.RunHookScript("/usr/bin/kairos-agent.install.after.hook") //nolint:errcheck

--- a/internal/agent/install.go
+++ b/internal/agent/install.go
@@ -78,7 +78,7 @@ func ManualInstall(c string, options map[string]string, strictValidations bool) 
 		return err
 	}
 
-	cc, err := config.Scan(config.Directories(dir), config.MergeBootLine, config.StrictValidation(strictValidations))
+	cc, err := config.KScan(config.Directories(dir), config.MergeBootLine, config.StrictValidation(strictValidations))
 	if err != nil {
 		return err
 	}
@@ -123,8 +123,8 @@ func Install(dir ...string) error {
 
 	// Reads config, and if present and offline is defined,
 	// runs the installation
-	cc, err := config.Scan(config.Directories(dir...), config.MergeBootLine, config.NoLogs)
-	if err == nil && cc.Install != nil && cc.Install.Auto {
+	cc, err := config.KScan(config.Directories(dir...), config.MergeBootLine, config.NoLogs)
+	if err == nil && cc.Install.Auto {
 		r["cc"] = cc.String()
 		r["device"] = cc.Install.Device
 		mergeOption(cc.String())

--- a/internal/agent/notify.go
+++ b/internal/agent/notify.go
@@ -12,7 +12,7 @@ import (
 func Notify(event string, dirs []string) error {
 	bus.Manager.Initialize()
 
-	c, err := config.Scan(config.Directories(dirs...))
+	c, err := config.KScan(config.Directories(dirs...))
 	if err != nil {
 		return err
 	}

--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -72,7 +72,7 @@ func Reset(dir ...string) error {
 		args = append(args, "--reset-persistent")
 	}
 
-	c, err := config.Scan(config.Directories(dir...))
+	c, err := config.KScan(config.Directories(dir...))
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func Reset(dir ...string) error {
 		os.Exit(1)
 	}
 
-	if err := hook.Run(*c, hook.AfterReset...); err != nil {
+	if err := hook.KRun(*c, hook.AfterReset...); err != nil {
 		return err
 	}
 

--- a/internal/agent/upgrade.go
+++ b/internal/agent/upgrade.go
@@ -96,7 +96,7 @@ func Upgrade(version, image string, force, debug, strictValidations bool, dirs [
 		fmt.Printf("Upgrading to image: '%s'\n", img)
 	}
 
-	c, err := config.Scan(config.Directories(dirs...), config.StrictValidation(strictValidations))
+	c, err := config.KScan(config.Directories(dirs...), config.StrictValidation(strictValidations))
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,24 @@ type Config struct {
 	Env                []string          `yaml:"env,omitempty"`
 }
 
+func (c Config) HasEncryptedPartitions() bool {
+	return len(c.Install.Encrypt) > 0
+}
+
+func (c Config) EncryptedPartitions() []string {
+	return c.Install.Encrypt
+}
+
+func (c Config) FOBE() bool {
+	return c.FailOnBundleErrors
+}
+
+type Configuration interface {
+	EncryptedPartitions() []string
+	HasEncryptedPartitions() bool
+	FOBE() bool
+}
+
 type Bundles []Bundle
 
 type Bundle struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,18 +52,22 @@ type Config struct {
 	Env                []string          `yaml:"env,omitempty"`
 }
 
+// HasEncryptedPartitions is a temporary function introduced to bridge the gap between Config and KConfg. It will be removed as soon as the transition is finished.
 func (c Config) HasEncryptedPartitions() bool {
 	return len(c.Install.Encrypt) > 0
 }
 
+// EncryptedPartitions is a temporary function introduced to bridge the gap between Config and KConfg. It will be removed as soon as the transition is finished.
 func (c Config) EncryptedPartitions() []string {
 	return c.Install.Encrypt
 }
 
+// FOBE is a temporary function introduced to bridge the gap between Config and KConfg. It will be removed as soon as the transition is finished.
 func (c Config) FOBE() bool {
 	return c.FailOnBundleErrors
 }
 
+// Configuration is a temporary interface introduced to bridge the gap between Config and KConfg. It will be removed as soon as the transition is finished.
 type Configuration interface {
 	EncryptedPartitions() []string
 	HasEncryptedPartitions() bool
@@ -210,11 +214,13 @@ func scan(opts ...Option) (c *Config, kc *schema.KConfig, err error) {
 	return c, kc, nil
 }
 
+// KScan is a temporary function that does the same as Scan. It will be removed as soon as the transition from config.Config to schema.KConfig is finished.
 func KScan(opts ...Option) (kc *schema.KConfig, err error) {
 	_, kc, err = scan(opts...)
 	return kc, err
 }
 
+// Scan is used to scan cloud config yaml files into a Config type.
 func Scan(opts ...Option) (c *Config, err error) {
 	c, _, err = scan(opts...)
 	return c, err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kairos-io/kairos/pkg/machine"
 	"github.com/kairos-io/kairos/sdk/bundles"
 	"github.com/kairos-io/kairos/sdk/unstructured"
-	yip "github.com/mudler/yip/pkg/schema"
 
 	"gopkg.in/yaml.v3"
 )
@@ -275,18 +274,6 @@ const (
 
 func (n Stage) String() string {
 	return string(n)
-}
-
-func SaveCloudConfig(name Stage, yc yip.YipConfig) error {
-	dnsYAML, err := yaml.Marshal(yc)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join("usr", "local", "cloud-config", fmt.Sprintf("100_%s.yaml", name)), dnsYAML, 0700)
-}
-
-func FromString(s string, o interface{}) error {
-	return yaml.Unmarshal([]byte(s), o)
 }
 
 func MergeYAML(objs ...interface{}) ([]byte, error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -46,13 +46,7 @@ var _ = Describe("Config", func() {
 	})
 
 	Context("directory", func() {
-		headerCheck := func(c *Config) {
-			ok, header := HasHeader(c.String(), DefaultHeader)
-			ExpectWithOffset(1, ok).To(BeTrue())
-			ExpectWithOffset(1, header).To(Equal(DefaultHeader))
-		}
-
-		kHeaderCheck := func(kc *schema.KConfig) {
+		headerCheck := func(kc *schema.KConfig) {
 			ok, header := HasHeader(kc.String(), DefaultHeader)
 			ExpectWithOffset(1, ok).To(BeTrue())
 			ExpectWithOffset(1, header).To(Equal(DefaultHeader))
@@ -64,7 +58,7 @@ var _ = Describe("Config", func() {
 
 			c, err := KScan(MergeBootLine, WithBootCMDLineFile(filepath.Join(d, "b")), NoLogs, StrictValidation(false))
 			Expect(err).ToNot(HaveOccurred())
-			kHeaderCheck(c)
+			headerCheck(c)
 			Expect(c.Options("foo")).To(Equal("bar"))
 			Expect(c.Query("options")).To(Equal("foo: bar\n"))
 			Expect(c.Query("options.foo")).To(Equal("bar\n"))
@@ -179,11 +173,11 @@ config_url: "https://gist.githubusercontent.com/mudler/ab26e8dd65c69c32ab2926857
 			err := os.WriteFile(filepath.Join(d, "test.yaml"), []byte(cc), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
-			c, err := Scan(Directories(d), NoLogs, StrictValidation(false))
+			c, err := KScan(Directories(d), NoLogs, StrictValidation(false))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c).ToNot(BeNil())
-			Expect(len(c.Bundles)).To(Equal(1))
-			Expect(c.Bundles[0].Targets[0]).To(Equal("package:utils/edgevpn"))
+			Expect(len(c.Bundles())).To(Equal(1))
+			Expect(c.Bundles()[0].Targets[0]).To(Equal("package:utils/edgevpn"))
 			Expect(c.String()).ToNot(Equal(cc))
 		})
 
@@ -196,11 +190,11 @@ config_url: "https://gist.githubusercontent.com/mudler/7e3d0426fce8bfaaeb2644f83
 			err := os.WriteFile(filepath.Join(d, "test.yaml"), []byte(cc), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
-			c, err := Scan(Directories(d), NoLogs, StrictValidation(false))
+			c, err := KScan(Directories(d), NoLogs, StrictValidation(false))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c).ToNot(BeNil())
-			Expect(len(c.Bundles)).To(Equal(1))
-			Expect(c.Bundles[0].Targets[0]).To(Equal("package:utils/edgevpn"))
+			Expect(len(c.Bundles())).To(Equal(1))
+			Expect(c.Bundles()[0].Targets[0]).To(Equal("package:utils/edgevpn"))
 			Expect(c.String()).ToNot(Equal(cc))
 
 			headerCheck(c)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -176,8 +176,8 @@ config_url: "https://gist.githubusercontent.com/mudler/ab26e8dd65c69c32ab2926857
 			c, err := KScan(Directories(d), NoLogs, StrictValidation(false))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c).ToNot(BeNil())
-			Expect(len(c.Bundles())).To(Equal(1))
-			Expect(c.Bundles()[0].Targets[0]).To(Equal("package:utils/edgevpn"))
+			Expect(len(c.KBundles())).To(Equal(1))
+			Expect(c.KBundles()[0].Targets[0]).To(Equal("package:utils/edgevpn"))
 			Expect(c.String()).ToNot(Equal(cc))
 		})
 
@@ -193,8 +193,8 @@ config_url: "https://gist.githubusercontent.com/mudler/7e3d0426fce8bfaaeb2644f83
 			c, err := KScan(Directories(d), NoLogs, StrictValidation(false))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c).ToNot(BeNil())
-			Expect(len(c.Bundles())).To(Equal(1))
-			Expect(c.Bundles()[0].Targets[0]).To(Equal("package:utils/edgevpn"))
+			Expect(len(c.KBundles())).To(Equal(1))
+			Expect(c.KBundles()[0].Targets[0]).To(Equal("package:utils/edgevpn"))
 			Expect(c.String()).ToNot(Equal(cc))
 
 			headerCheck(c)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -176,8 +176,9 @@ config_url: "https://gist.githubusercontent.com/mudler/ab26e8dd65c69c32ab2926857
 			c, err := KScan(Directories(d), NoLogs, StrictValidation(false))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c).ToNot(BeNil())
-			Expect(len(c.KBundles())).To(Equal(1))
-			Expect(c.KBundles()[0].Targets[0]).To(Equal("package:utils/edgevpn"))
+			bundles, _ := c.KBundles()
+			Expect(len(bundles)).To(Equal(1))
+			Expect(bundles[0].Targets[0]).To(Equal("package:utils/edgevpn"))
 			Expect(c.String()).ToNot(Equal(cc))
 		})
 
@@ -193,8 +194,9 @@ config_url: "https://gist.githubusercontent.com/mudler/7e3d0426fce8bfaaeb2644f83
 			c, err := KScan(Directories(d), NoLogs, StrictValidation(false))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c).ToNot(BeNil())
-			Expect(len(c.KBundles())).To(Equal(1))
-			Expect(c.KBundles()[0].Targets[0]).To(Equal("package:utils/edgevpn"))
+			bundles, _ := c.KBundles()
+			Expect(len(bundles)).To(Equal(1))
+			Expect(bundles[0].Targets[0]).To(Equal("package:utils/edgevpn"))
 			Expect(c.String()).ToNot(Equal(cc))
 
 			headerCheck(c)

--- a/pkg/config/schemas/install_schema.go
+++ b/pkg/config/schemas/install_schema.go
@@ -80,9 +80,16 @@ func (PowerManagement) Foo() PowerAny {
 	return PowerAny{}
 }
 
-func (is InstallSchema) GrubOptions() map[string]string {
-	var myMap map[string]string
-	data, _ := json.Marshal(is.GrubOptionsSchema)
-	json.Unmarshal(data, &myMap)
-	return myMap
+func (is InstallSchema) GrubOptions() (map[string]string, error) {
+	var grubOptions map[string]string
+	data, err := json.Marshal(is.GrubOptionsSchema)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, &grubOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return grubOptions, nil
 }

--- a/pkg/config/schemas/install_schema.go
+++ b/pkg/config/schemas/install_schema.go
@@ -76,7 +76,8 @@ type PowerAny struct {
 	Poweroff bool
 }
 
-func (PowerManagement) Foo() PowerAny {
+// Power still needs to be manually tested, it was just added to make the access to the Power struct easy, but probably is not doing what's expected.
+func (PowerManagement) Power() PowerAny {
 	return PowerAny{}
 }
 

--- a/pkg/config/schemas/install_schema.go
+++ b/pkg/config/schemas/install_schema.go
@@ -1,32 +1,25 @@
 package config
 
 import (
+	"encoding/json"
+
 	jsonschemago "github.com/swaggest/jsonschema-go"
 )
 
 // InstallSchema represents the install block in the Kairos configuration. It is used to drive automatic installations without user interaction.
 type InstallSchema struct {
-	_                   struct{}       `title:"Kairos Schema: Install block" description:"The install block is to drive automatic installations without user interaction."`
-	Auto                bool           `json:"auto,omitempty" description:"Set to true when installing without Pairing"`
-	BindMounts          []string       `json:"bind_mounts,omitempty"`
-	Bundles             []BundleSchema `json:"bundles,omitempty" description:"Add bundles in runtime"`
-	Device              string         `json:"device,omitempty" pattern:"^(auto|/|(/[a-zA-Z0-9_-]+)+)$" description:"Device for automated installs" examples:"[\"auto\",\"/dev/sda\"]"`
-	EphemeralMounts     []string       `json:"ephemeral_mounts,omitempty"`
-	EncryptedPartitions []string       `json:"encrypted_partitions,omitempty"`
-	Env                 []interface{}  `json:"env,omitempty"`
+	_                   struct{}      `title:"Kairos Schema: Install block" description:"The install block is to drive automatic installations without user interaction."`
+	Auto                bool          `json:"auto,omitempty" description:"Set to true when installing without Pairing"`
+	BindMounts          []string      `json:"bind_mounts,omitempty"`
+	Bundles             BBundles      `json:"bundles,omitempty" description:"Add bundles in runtime"`
+	Device              string        `json:"device,omitempty" pattern:"^(auto|/|(/[a-zA-Z0-9_-]+)+)$" description:"Device for automated installs" examples:"[\"auto\",\"/dev/sda\"]"`
+	EphemeralMounts     []string      `json:"ephemeral_mounts,omitempty"`
+	EncryptedPartitions []string      `json:"encrypted_partitions,omitempty"`
+	Env                 []interface{} `json:"env,omitempty"`
 	GrubOptionsSchema   `json:"grub_options,omitempty"`
 	Image               string `json:"image,omitempty" description:"Use a different container image for the installation"`
 	PowerManagement
 	SkipEncryptCopyPlugins bool `json:"skip_copy_kcrypt_plugin,omitempty"`
-}
-
-// BundleSchema represents the bundle block which can be used in different places of the Kairos configuration. It is used to reference a bundle and its confguration.
-type BundleSchema struct {
-	DB         string   `json:"db_path,omitempty"`
-	LocalFile  bool     `json:"local_file,omitempty"`
-	Repository string   `json:"repository,omitempty"`
-	Rootfs     string   `json:"rootfs_path,omitempty"`
-	Targets    []string `json:"targets,omitempty"`
 }
 
 // GrubOptionsSchema represents the grub options block which can be used in different places of the Kairos configuration. It is used to configure grub.
@@ -76,4 +69,20 @@ func (PowerManagement) JSONSchemaOneOf() []interface{} {
 	return []interface{}{
 		NoPowerManagement{}, RebootOnly{}, PowerOffOnly{},
 	}
+}
+
+type PowerAny struct {
+	Reboot   bool
+	Poweroff bool
+}
+
+func (PowerManagement) Foo() PowerAny {
+	return PowerAny{}
+}
+
+func (is InstallSchema) GrubOptions() map[string]string {
+	var myMap map[string]string
+	data, _ := json.Marshal(is.GrubOptionsSchema)
+	json.Unmarshal(data, &myMap)
+	return myMap
 }

--- a/pkg/config/schemas/install_schema.go
+++ b/pkg/config/schemas/install_schema.go
@@ -9,29 +9,29 @@ import (
 // InstallSchema represents the install block in the Kairos configuration. It is used to drive automatic installations without user interaction.
 type InstallSchema struct {
 	_                   struct{}      `title:"Kairos Schema: Install block" description:"The install block is to drive automatic installations without user interaction."`
-	Auto                bool          `json:"auto,omitempty" description:"Set to true when installing without Pairing"`
-	BindMounts          []string      `json:"bind_mounts,omitempty"`
-	Bundles             BBundles      `json:"bundles,omitempty" description:"Add bundles in runtime"`
-	Device              string        `json:"device,omitempty" pattern:"^(auto|/|(/[a-zA-Z0-9_-]+)+)$" description:"Device for automated installs" examples:"[\"auto\",\"/dev/sda\"]"`
-	EphemeralMounts     []string      `json:"ephemeral_mounts,omitempty"`
-	EncryptedPartitions []string      `json:"encrypted_partitions,omitempty"`
-	Env                 []interface{} `json:"env,omitempty"`
-	GrubOptionsSchema   `json:"grub_options,omitempty"`
-	Image               string `json:"image,omitempty" description:"Use a different container image for the installation"`
+	Auto                bool          `json:"auto,omitempty" description:"Set to true when installing without Pairing" yaml:"auto,omitempty"`
+	BindMounts          []string      `json:"bind_mounts,omitempty" yaml:"bind_mounts,omitempty"`
+	Bundles             BBundles      `json:"bundles,omitempty" description:"Add bundles in runtime" yaml:"bundles,omitempty"`
+	Device              string        `json:"device,omitempty" pattern:"^(auto|/|(/[a-zA-Z0-9_-]+)+)$" description:"Device for automated installs" examples:"[\"auto\",\"/dev/sda\"]" yaml:"device,omitempty"`
+	EphemeralMounts     []string      `json:"ephemeral_mounts,omitempty" yaml:"ephemeral_mounts,omitempty"`
+	EncryptedPartitions []string      `json:"encrypted_partitions,omitempty" yaml:"encrypted_partitions,omitempty"`
+	Env                 []interface{} `json:"env,omitempty" yaml:"env,omitempty"`
+	GrubOptionsSchema   `json:"grub_options,omitempty" yaml:"grub_options,omitempty"`
+	Image               string `json:"image,omitempty" description:"Use a different container image for the installation" yaml:"image,omitempty"`
 	PowerManagement
-	SkipEncryptCopyPlugins bool `json:"skip_copy_kcrypt_plugin,omitempty"`
+	SkipEncryptCopyPlugins bool `json:"skip_copy_kcrypt_plugin,omitempty" yaml:"skip_copy_kcrypt_plugin,omitempty"`
 }
 
 // GrubOptionsSchema represents the grub options block which can be used in different places of the Kairos configuration. It is used to configure grub.
 type GrubOptionsSchema struct {
-	DefaultFallback      string `json:"default_fallback,omitempty" description:"Sets default fallback logic"`
-	DefaultMenuEntry     string `json:"default_menu_entry,omitempty" description:"Change GRUB menu entry"`
-	ExtraActiveCmdline   string `json:"extra_active_cmdline,omitempty" description:"Additional Kernel option cmdline to apply just for active"`
-	ExtraCmdline         string `json:"extra_cmdline,omitempty" description:"Additional Kernel option cmdline to apply"`
-	ExtraPassiveCmdline  string `json:"extra_passive_cmdline,omitempty" description:"Additional Kernel option cmdline to apply just for passive"`
-	ExtraRecoveryCmdline string `json:"extra_recovery_cmdline,omitempty" description:"Set additional boot commands when booting into recovery"`
-	NextEntry            string `json:"next_entry,omitempty" description:"Set the next reboot entry."`
-	SavedEntry           string `json:"saved_entry,omitempty" description:"Set the default boot entry."`
+	DefaultFallback      string `json:"default_fallback,omitempty" description:"Sets default fallback logic" yaml:"default_fallback,omitempty"`
+	DefaultMenuEntry     string `json:"default_menu_entry,omitempty" description:"Change GRUB menu entry" yaml:"default_menu_entry,omitempty"`
+	ExtraActiveCmdline   string `json:"extra_active_cmdline,omitempty" description:"Additional Kernel option cmdline to apply just for active" yaml:"extra_active_cmdline,omitempty"`
+	ExtraCmdline         string `json:"extra_cmdline,omitempty" description:"Additional Kernel option cmdline to apply" yaml:"extra_cmdline,omitempty"`
+	ExtraPassiveCmdline  string `json:"extra_passive_cmdline,omitempty" description:"Additional Kernel option cmdline to apply just for passive" yaml:"extra_passive_cmdline,omitempty"`
+	ExtraRecoveryCmdline string `json:"extra_recovery_cmdline,omitempty" description:"Set additional boot commands when booting into recovery" yaml:"extra_recovery_cmdline,omitempty"`
+	NextEntry            string `json:"next_entry,omitempty" description:"Set the next reboot entry." yaml:"next_entry,omitempty"`
+	SavedEntry           string `json:"saved_entry,omitempty" description:"Set the default boot entry." yaml:"saved_entry,omitempty"`
 }
 
 // PowerManagement is a meta structure to hold the different rules for managing power, which are not compatible between each other.
@@ -40,20 +40,20 @@ type PowerManagement struct {
 
 // NoPowerManagement is a meta structure used when the user does not define any power management options or when the user does not want to reboot or poweroff the machine.
 type NoPowerManagement struct {
-	Reboot   bool `json:"reboot,omitempty" const:"false" default:"false" description:"Reboot after installation"`
-	Poweroff bool `json:"poweroff,omitempty" const:"false" default:"false" description:"Power off after installation"`
+	Reboot   bool `json:"reboot,omitempty" const:"false" default:"false" description:"Reboot after installation" yaml:"reboot,omitempty"`
+	Poweroff bool `json:"poweroff,omitempty" const:"false" default:"false" description:"Power off after installation" yaml:"poweroff,omitempty"`
 }
 
 // RebootOnly is a meta structure used to enforce that when the reboot option is set, the poweroff option is not set.
 type RebootOnly struct {
-	Reboot   bool `json:"reboot,omitempty" const:"true" default:"false" required:"true" description:"Reboot after installation"`
-	Poweroff bool `json:"poweroff,omitempty" const:"false" default:"false" description:"Power off after installation"`
+	Reboot   bool `json:"reboot,omitempty" const:"true" default:"false" required:"true" description:"Reboot after installation" yaml:"reboot,omitempty"`
+	Poweroff bool `json:"poweroff,omitempty" const:"false" default:"false" description:"Power off after installation" yaml:"poweroff,omitempty"`
 }
 
 // PowerOffOnly is a meta structure used to enforce that when the poweroff option is set, the reboot option is not set.
 type PowerOffOnly struct {
-	Reboot   bool `json:"reboot,omitempty" const:"false" default:"false" description:"Reboot after installation"`
-	Poweroff bool `json:"poweroff,omitempty" const:"true" default:"false" required:"true" description:"Power off after installation"`
+	Reboot   bool `json:"reboot,omitempty" const:"false" default:"false" description:"Reboot after installation" yaml:"reboot,omitempty"`
+	Poweroff bool `json:"poweroff,omitempty" const:"true" default:"false" required:"true" description:"Power off after installation" yaml:"poweroff,omitempty"`
 }
 
 var _ jsonschemago.OneOfExposer = PowerManagement{}
@@ -72,8 +72,8 @@ func (PowerManagement) JSONSchemaOneOf() []interface{} {
 }
 
 type PowerAny struct {
-	Reboot   bool
-	Poweroff bool
+	Reboot   bool `json:"reboot,omitempty" yaml:"reboot,omitempty"`
+	Poweroff bool `json:"poweroff,omitempty" yaml:"poweroff,omitempty"`
 }
 
 // Power still needs to be manually tested, it was just added to make the access to the Power struct easy, but probably is not doing what's expected.

--- a/pkg/config/schemas/p2p_schema.go
+++ b/pkg/config/schemas/p2p_schema.go
@@ -7,21 +7,21 @@ import (
 // P2PSchema represents the P2P block in the Kairos configuration. It is used to enables and configure the p2p full-mesh functionalities.
 type P2PSchema struct {
 	_          struct{} `title:"Kairos Schema: P2P block" description:"The p2p block enables the p2p full-mesh functionalities."`
-	Role       string   `json:"role,omitempty" default:"none" enum:"[\"master\",\"worker\",\"none\"]"`
-	NetworkID  string   `json:"network_id,omitempty" description:"User defined network-id. Can be used to have multiple clusters in the same network"`
-	DNS        bool     `json:"dns,omitempty" description:"Enable embedded DNS See also: https://mudler.github.io/edgevpn/docs/concepts/overview/dns/"`
-	DisableDHT bool     `json:"disable_dht,omitempty" default:"true" description:"Disabling DHT makes co-ordination to discover nodes only in the local network"`
+	Role       string   `json:"role,omitempty" default:"none" enum:"[\"master\",\"worker\",\"none\"]" yaml:"role,omitempty"`
+	NetworkID  string   `json:"network_id,omitempty" description:"User defined network-id. Can be used to have multiple clusters in the same network" yaml:"network_id,omitempty"`
+	DNS        bool     `json:"dns,omitempty" description:"Enable embedded DNS See also: https://mudler.github.io/edgevpn/docs/concepts/overview/dns/" yaml:"dns,omitempty"`
+	DisableDHT bool     `json:"disable_dht,omitempty" default:"true" description:"Disabling DHT makes co-ordination to discover nodes only in the local network" yaml:"disable_dht,omitempty"`
 	P2PNetworkExtended
-	VPN `json:"vpn,omitempty"`
+	VPN `json:"vpn,omitempty" yaml:"vpn,omitempty"`
 }
 
 // KubeVIPSchema represents the kubevip block in the Kairos configuration. It sets the Elastic IP used in KubeVIP. Only valid with p2p.
 type KubeVIPSchema struct {
 	_           struct{} `title:"Kairos Schema: KubeVIP block" description:"Sets the Elastic IP used in KubeVIP. Only valid with p2p"`
-	EIP         string   `json:"eip,omitempty" example:"192.168.1.110"`
-	ManifestURL string   `json:"manifest_url,omitempty" description:"Specify a manifest URL for KubeVIP." default:""`
-	Enable      bool     `json:"enable,omitempty" description:"Enables KubeVIP"`
-	Interface   bool     `json:"interface,omitempty" description:"Specifies a KubeVIP Interface" example:"ens18"`
+	EIP         string   `json:"eip,omitempty" example:"192.168.1.110" yaml:"eip,omitempty"`
+	ManifestURL string   `json:"manifest_url,omitempty" description:"Specify a manifest URL for KubeVIP." default:"" yaml:"manifest_url,omitempty"`
+	Enable      bool     `json:"enable,omitempty" description:"Enables KubeVIP" yaml:"enable,omitempty"`
+	Interface   bool     `json:"interface,omitempty" description:"Specifies a KubeVIP Interface" example:"ens18" yaml:"interface,omitempty"`
 }
 
 // P2PNetworkExtended is a meta structure to hold the different rules for managing the P2P network, which are not compatible between each other.
@@ -30,25 +30,25 @@ type P2PNetworkExtended struct {
 
 // P2PAutoDisabled is used to validate that when p2p.auto is disabled, then neither p2p.auto.ha not p2p.network_token can be set.
 type P2PAutoDisabled struct {
-	NetworkToken string `json:"network_token,omitempty" const:"" required:"true"`
+	NetworkToken string `json:"network_token,omitempty" const:"" required:"true" yaml:"network_token,omitempty"`
 	Auto         struct {
-		Enable bool `json:"enable" const:"false" required:"true"`
+		Enable bool `json:"enable" const:"false" required:"true" yaml:"enable"`
 		Ha     struct {
-			Enable bool `json:"enable" const:"false"`
-		} `json:"ha"`
-	} `json:"auto"`
+			Enable bool `json:"enable" const:"false" yaml:"enable"`
+		} `json:"ha" yaml:"ha"`
+	} `json:"auto" yaml:"auto"`
 }
 
 // P2PAutoEnabled is used to validate that when p2p.auto is set, p2p.network_token has to be set.
 type P2PAutoEnabled struct {
-	NetworkToken string `json:"network_token" required:"true" minLength:"1" description:"network_token is the shared secret used by the nodes to co-ordinate with p2p"`
+	NetworkToken string `json:"network_token" required:"true" minLength:"1" description:"network_token is the shared secret used by the nodes to co-ordinate with p2p" yaml:"network_token"`
 	Auto         struct {
-		Enable bool `json:"enable,omitempty" const:"true"`
+		Enable bool `json:"enable,omitempty" const:"true" yaml:"enable,omitempty"`
 		Ha     struct {
-			Enable      bool `json:"enable" const:"true"`
-			MasterNodes int  `json:"master_nodes,omitempty" minimum:"1" description:"Number of HA additional master nodes. A master node is always required for creating the cluster and is implied."`
-		} `json:"ha"`
-	} `json:"auto,omitempty"`
+			Enable      bool `json:"enable" const:"true" yaml:"enable"`
+			MasterNodes int  `json:"master_nodes,omitempty" minimum:"1" description:"Number of HA additional master nodes. A master node is always required for creating the cluster and is implied." yaml:"master_nodes,omitempty"`
+		} `json:"ha" yaml:"ha"`
+	} `json:"auto,omitempty" yaml:"auto,omitempty"`
 }
 
 var _ jsonschemago.OneOfExposer = P2PNetworkExtended{}
@@ -62,7 +62,7 @@ func (P2PNetworkExtended) JSONSchemaOneOf() []interface{} {
 
 // VPN represents the vpn block in the Kairos configuration.
 type VPN struct {
-	Create bool          `json:"vpn,omitempty" default:"true"`
-	Use    bool          `json:"use,omitempty" default:"true"`
-	Envs   []interface{} `json:"env,omitempty"`
+	Create bool          `json:"vpn,omitempty" default:"true" yaml:"vpn,omitempty"`
+	Use    bool          `json:"use,omitempty" default:"true" yaml:"use,omitempty"`
+	Envs   []interface{} `json:"env,omitempty" yaml:"env,omitempty"`
 }

--- a/pkg/config/schemas/root_schema.go
+++ b/pkg/config/schemas/root_schema.go
@@ -27,14 +27,17 @@ type RootSchema struct {
 	P2P                P2PSchema     `json:"p2p,omitempty" yaml:"p2p,omitempty"`
 }
 
+// HasEncryptedPartitions is a temporary function introduced to bridge the gap between Config and KConfg. It will be removed as soon as the transition is finished.
 func (kc KConfig) HasEncryptedPartitions() bool {
 	return len(kc.RootSchema.Install.EncryptedPartitions) > 0
 }
 
+// EncryptedPartitions is a temporary function introduced to bridge the gap between Config and KConfg. It will be removed as soon as the transition is finished.
 func (kc KConfig) EncryptedPartitions() []string {
 	return kc.RootSchema.Install.EncryptedPartitions
 }
 
+// FOBE is a temporary function introduced to bridge the gap between Config and KConfg. It will be removed as soon as the transition is finished.
 func (kc KConfig) FOBE() bool {
 	return kc.FailOnBundleErrors
 }
@@ -50,6 +53,7 @@ type BundleSchema struct {
 	Targets    []string `json:"targets,omitempty"`
 }
 
+// GrubOptions returns a map with all the grub options from the root schema
 func (rs RootSchema) GrubOptions() (map[string]string, error) {
 	var grubOptions map[string]string
 	data, _ := json.Marshal(rs.GrubOptionsSchema)
@@ -71,6 +75,7 @@ type KConfig struct {
 	RootSchema
 }
 
+// Header returns the parsed header of a config file or the default header if none.
 func (kc KConfig) Header() string {
 	if !kc.HasHeader() {
 		return KDefaultHeader
@@ -82,6 +87,7 @@ func (kc KConfig) Header() string {
 	return strings.TrimRightFunc(header, unicode.IsSpace)
 }
 
+// KBundles is a temporary function while transitioning from Config to KConfig. It will be removed or at least renamed when the transition is finished.
 func (kc KConfig) KBundles() (BBundles, error) {
 	jsonString, _ := json.Marshal(kc.Data()["bundles"])
 	bundles := []BundleSchema{}
@@ -93,12 +99,14 @@ func (kc KConfig) KBundles() (BBundles, error) {
 	return bundles, nil
 }
 
+// Options returns the options parsed from a KConfig
 func (kc KConfig) Options(key string) interface{} {
 	options := kc.Data()["options"]
 
 	return options.(map[string]interface{})[key]
 }
 
+// String returns the parsed config file in its original format.
 func (kc KConfig) String() string {
 	if len(kc.parsed.(map[string]interface{})) == 0 {
 		dat, err := yaml.Marshal(kc)
@@ -111,14 +119,17 @@ func (kc KConfig) String() string {
 	return fmt.Sprintf("%s\n%s", kc.Header(), string(dat))
 }
 
+// Unmarshal returns the unmarshaled version of the cloud config source.
 func (kc KConfig) Unmarshal(o interface{}) error {
 	return yaml.Unmarshal([]byte(kc.String()), o)
 }
 
+// Data returns a map from the parsed data.
 func (kc KConfig) Data() map[string]interface{} {
 	return kc.parsed.(map[string]interface{})
 }
 
+// Query finds a key in teh configuration.
 func (kc KConfig) Query(s string) (res string, err error) {
 	s = fmt.Sprintf(".%s", s)
 	jsondata := map[string]interface{}{}
@@ -235,6 +246,7 @@ func NewConfigFromYAML(s string, st interface{}) (*KConfig, error) {
 	return kc, nil
 }
 
+// Options loops through the defined bundles and returns their options.
 func (b BBundles) Options() (res [][]bundles.BundleOption) {
 	for _, bundle := range b {
 		for _, t := range bundle.Targets {

--- a/pkg/config/schemas/root_schema.go
+++ b/pkg/config/schemas/root_schema.go
@@ -250,12 +250,6 @@ func NewConfigFromYAML(s string, st interface{}) (*KConfig, error) {
 func (b BBundles) Options() (res [][]bundles.BundleOption) {
 	for _, bundle := range b {
 		for _, t := range bundle.Targets {
-			fmt.Println("Options()")
-			fmt.Println("db: ", bundle.DB)
-			fmt.Println("targets: ", bundle.Targets)
-			fmt.Println("local_file: ", bundle.LocalFile)
-			fmt.Println("repository: ", bundle.Repository)
-			fmt.Println("rootfs: ", bundle.Rootfs)
 			opts := []bundles.BundleOption{bundles.WithRepository(bundle.Repository), bundles.WithTarget(t)}
 			if bundle.Rootfs != "" {
 				opts = append(opts, bundles.WithRootFS(bundle.Rootfs))

--- a/pkg/config/schemas/root_schema.go
+++ b/pkg/config/schemas/root_schema.go
@@ -164,7 +164,6 @@ func (kc *KConfig) validate() {
 		kc.ValidationError = err
 		return
 	}
-	// fmt.Println(generatedSchemaJSON)
 
 	sch, err := jsonschema.CompileString("schema.json", string(generatedSchemaJSON))
 	if err != nil {

--- a/pkg/config/schemas/root_schema.go
+++ b/pkg/config/schemas/root_schema.go
@@ -16,15 +16,15 @@ import (
 // RootSchema groups all the different schemas of the Kairos configuration together.
 type RootSchema struct {
 	_                  struct{} `title:"Kairos Schema" description:"Defines all valid Kairos configuration attributes."`
-	Bundles            BBundles `json:"bundles,omitempty" description:"Add bundles in runtime" yaml:"bundles,omitempty"`
-	ConfigURL          string   `json:"config_url,omitempty" description:"URL download configuration from." yaml:"config_url,omitempty"`
-	Env                []string `json:"env,omitempty" yaml:"env,omitempty"`
-	FailOnBundleErrors bool     `json:"fail_on_bundles_errors,omitempty" yaml:"fail_on_bundles_errors,omitempty"`
-	GrubOptionsSchema  `json:"grub_options,omitempty" yaml:"grub_options,omitempty"`
-	Install            InstallSchema `json:"install,omitempty" yaml:"install,omitempty"`
-	Options            []interface{} `json:"options,omitempty" description:"Various options." yaml:"options,omitempty"`
-	Users              []UserSchema  `json:"users,omitempty" minItems:"1" required:"true"`
-	P2P                P2PSchema     `json:"p2p,omitempty" yaml:"p2p,omitempty"`
+	Bundles            BBundles `json:"bundles,omitempty" description:"Add bundles in runtime" yaml:"bundles,omitempty" yaml:"bundles,omitempty"`
+	ConfigURL          string   `json:"config_url,omitempty" description:"URL download configuration from." yaml:"config_url,omitempty" yaml:"config_url,omitempty"`
+	Env                []string `json:"env,omitempty" yaml:"env,omitempty" yaml:"env,omitempty"`
+	FailOnBundleErrors bool     `json:"fail_on_bundles_errors,omitempty" yaml:"fail_on_bundles_errors,omitempty" yaml:"fail_on_bundles_errors,omitempty"`
+	GrubOptionsSchema  `json:"grub_options,omitempty" yaml:"grub_options,omitempty" yaml:"grub_options,omitempty"`
+	Install            InstallSchema `json:"install,omitempty" yaml:"install,omitempty" yaml:"install,omitempty"`
+	Options            []interface{} `json:"options,omitempty" description:"Various options." yaml:"options,omitempty" yaml:"options,omitempty"`
+	Users              []UserSchema  `json:"users,omitempty" minItems:"1" required:"true" yaml:"users,omitempty"`
+	P2P                P2PSchema     `json:"p2p,omitempty" yaml:"p2p,omitempty" yaml:"p2p,omitempty"`
 }
 
 // HasEncryptedPartitions is a temporary function introduced to bridge the gap between Config and KConfg. It will be removed as soon as the transition is finished.
@@ -46,11 +46,11 @@ type BBundles []BundleSchema
 
 // BundleSchema represents the bundle block which can be used in different places of the Kairos configuration. It is used to reference a bundle and its confguration.
 type BundleSchema struct {
-	DB         string   `json:"db_path,omitempty"`
-	LocalFile  bool     `json:"local_file,omitempty"`
-	Repository string   `json:"repository,omitempty"`
-	Rootfs     string   `json:"rootfs_path,omitempty"`
-	Targets    []string `json:"targets,omitempty"`
+	DB         string   `json:"db_path,omitempty" yaml:"db_path,omitempty" yaml:"db_path,omitempty"`
+	LocalFile  bool     `json:"local_file,omitempty" yaml:"local_file,omitempty" yaml:"local_file,omitempty"`
+	Repository string   `json:"repository,omitempty" yaml:"repository,omitempty" yaml:"repository,omitempty"`
+	Rootfs     string   `json:"rootfs_path,omitempty" yaml:"rootfs_path,omitempty" yaml:"rootfs_path,omitempty"`
+	Targets    []string `json:"targets,omitempty" yaml:"targets,omitempty" yaml:"targets,omitempty"`
 }
 
 // GrubOptions returns a map with all the grub options from the root schema

--- a/pkg/config/schemas/root_schema.go
+++ b/pkg/config/schemas/root_schema.go
@@ -16,15 +16,15 @@ import (
 // RootSchema groups all the different schemas of the Kairos configuration together.
 type RootSchema struct {
 	_                  struct{} `title:"Kairos Schema" description:"Defines all valid Kairos configuration attributes."`
-	Bundles            BBundles `json:"bundles,omitempty" description:"Add bundles in runtime" yaml:"bundles,omitempty" yaml:"bundles,omitempty"`
-	ConfigURL          string   `json:"config_url,omitempty" description:"URL download configuration from." yaml:"config_url,omitempty" yaml:"config_url,omitempty"`
-	Env                []string `json:"env,omitempty" yaml:"env,omitempty" yaml:"env,omitempty"`
-	FailOnBundleErrors bool     `json:"fail_on_bundles_errors,omitempty" yaml:"fail_on_bundles_errors,omitempty" yaml:"fail_on_bundles_errors,omitempty"`
-	GrubOptionsSchema  `json:"grub_options,omitempty" yaml:"grub_options,omitempty" yaml:"grub_options,omitempty"`
-	Install            InstallSchema `json:"install,omitempty" yaml:"install,omitempty" yaml:"install,omitempty"`
-	Options            []interface{} `json:"options,omitempty" description:"Various options." yaml:"options,omitempty" yaml:"options,omitempty"`
+	Bundles            BBundles `json:"bundles,omitempty" description:"Add bundles in runtime" yaml:"bundles,omitempty"`
+	ConfigURL          string   `json:"config_url,omitempty" description:"URL download configuration from." yaml:"config_url,omitempty"`
+	Env                []string `json:"env,omitempty" yaml:"env,omitempty"`
+	FailOnBundleErrors bool     `json:"fail_on_bundles_errors,omitempty" yaml:"fail_on_bundles_errors,omitempty"`
+	GrubOptionsSchema  `json:"grub_options,omitempty" yaml:"grub_options,omitempty"`
+	Install            InstallSchema `json:"install,omitempty" yaml:"install,omitempty"`
+	Options            []interface{} `json:"options,omitempty" description:"Various options." yaml:"options,omitempty"`
 	Users              []UserSchema  `json:"users,omitempty" minItems:"1" required:"true" yaml:"users,omitempty"`
-	P2P                P2PSchema     `json:"p2p,omitempty" yaml:"p2p,omitempty" yaml:"p2p,omitempty"`
+	P2P                P2PSchema     `json:"p2p,omitempty" yaml:"p2p,omitempty"`
 }
 
 // HasEncryptedPartitions is a temporary function introduced to bridge the gap between Config and KConfg. It will be removed as soon as the transition is finished.
@@ -46,14 +46,14 @@ type BBundles []BundleSchema
 
 // BundleSchema represents the bundle block which can be used in different places of the Kairos configuration. It is used to reference a bundle and its confguration.
 type BundleSchema struct {
-	DB         string   `json:"db_path,omitempty" yaml:"db_path,omitempty" yaml:"db_path,omitempty"`
-	LocalFile  bool     `json:"local_file,omitempty" yaml:"local_file,omitempty" yaml:"local_file,omitempty"`
-	Repository string   `json:"repository,omitempty" yaml:"repository,omitempty" yaml:"repository,omitempty"`
-	Rootfs     string   `json:"rootfs_path,omitempty" yaml:"rootfs_path,omitempty" yaml:"rootfs_path,omitempty"`
-	Targets    []string `json:"targets,omitempty" yaml:"targets,omitempty" yaml:"targets,omitempty"`
+	DB         string   `json:"db_path,omitempty" yaml:"db_path,omitempty"`
+	LocalFile  bool     `json:"local_file,omitempty" yaml:"local_file,omitempty"`
+	Repository string   `json:"repository,omitempty" yaml:"repository,omitempty"`
+	Rootfs     string   `json:"rootfs_path,omitempty" yaml:"rootfs_path,omitempty"`
+	Targets    []string `json:"targets,omitempty" yaml:"targets,omitempty"`
 }
 
-// GrubOptions returns a map with all the grub options from the root schema
+// GrubOptions returns a map with all the grub options from the root schema.
 func (rs RootSchema) GrubOptions() (map[string]string, error) {
 	var grubOptions map[string]string
 	data, _ := json.Marshal(rs.GrubOptionsSchema)
@@ -99,7 +99,7 @@ func (kc KConfig) KBundles() (BBundles, error) {
 	return bundles, nil
 }
 
-// Options returns the options parsed from a KConfig
+// Options returns the options parsed from a KConfig.
 func (kc KConfig) Options(key string) interface{} {
 	options := kc.Data()["options"]
 
@@ -129,7 +129,7 @@ func (kc KConfig) Data() map[string]interface{} {
 	return kc.parsed.(map[string]interface{})
 }
 
-// Query finds a key in teh configuration.
+// Query finds a key in the configuration.
 func (kc KConfig) Query(s string) (res string, err error) {
 	s = fmt.Sprintf(".%s", s)
 	jsondata := map[string]interface{}{}
@@ -250,6 +250,12 @@ func NewConfigFromYAML(s string, st interface{}) (*KConfig, error) {
 func (b BBundles) Options() (res [][]bundles.BundleOption) {
 	for _, bundle := range b {
 		for _, t := range bundle.Targets {
+			fmt.Println("Options()")
+			fmt.Println("db: ", bundle.DB)
+			fmt.Println("targets: ", bundle.Targets)
+			fmt.Println("local_file: ", bundle.LocalFile)
+			fmt.Println("repository: ", bundle.Repository)
+			fmt.Println("rootfs: ", bundle.Rootfs)
 			opts := []bundles.BundleOption{bundles.WithRepository(bundle.Repository), bundles.WithTarget(t)}
 			if bundle.Rootfs != "" {
 				opts = append(opts, bundles.WithRootFS(bundle.Rootfs))

--- a/pkg/config/schemas/root_schema.go
+++ b/pkg/config/schemas/root_schema.go
@@ -47,6 +47,14 @@ func (kc KConfig) Header() string {
 	return strings.TrimRightFunc(header, unicode.IsSpace)
 }
 
+func (kc KConfig) Bundles() []BundleSchema {
+	jsonString, _ := json.Marshal(kc.Data()["bundles"])
+	bundles := []BundleSchema{}
+	json.Unmarshal(jsonString, &bundles)
+
+	return bundles
+}
+
 func (kc KConfig) Options(key string) interface{} {
 	options := kc.Data()["options"]
 

--- a/pkg/config/schemas/users_schema.go
+++ b/pkg/config/schemas/users_schema.go
@@ -3,9 +3,9 @@ package config
 // UserSchema represents the users block in the Kairos configuration. It allows the creation of users in the system.
 type UserSchema struct {
 	_                 struct{} `title:"Kairos Schema: Users block" description:"The users block allows you to create users in the system."`
-	Name              string   `json:"name,omitempty" pattern:"([a-z_][a-z0-9_]{0,30})" required:"true" example:"kairos"`
-	Passwd            string   `json:"passwd,omitempty" example:"kairos"`
-	LockPasswd        bool     `json:"lockPasswd,omitempty" example:"true"`
-	Groups            string   `json:"groups,omitempty" example:"admin"`
-	SSHAuthorizedKeys []string `json:"ssh_authorized_keys,omitempty" examples:"[\"github:USERNAME\",\"ssh-ed25519 AAAF00BA5\"]"`
+	Name              string   `json:"name,omitempty" pattern:"([a-z_][a-z0-9_]{0,30})" required:"true" example:"kairos" yaml:"name,omitempty"`
+	Passwd            string   `json:"passwd,omitempty" example:"kairos" yaml:"passwd,omitempty"`
+	LockPasswd        bool     `json:"lockPasswd,omitempty" example:"true" yaml:"lockPasswd,omitempty"`
+	Groups            string   `json:"groups,omitempty" example:"admin" yaml:"groups,omitempty"`
+	SSHAuthorizedKeys []string `json:"ssh_authorized_keys,omitempty" examples:"[\"github:USERNAME\",\"ssh-ed25519 AAAF00BA5\"]" yaml:"ssh_authorized_keys,omitempty"`
 }


### PR DESCRIPTION
This PR is the first of N, in order to use a single schema structure to do the parsing and validation of the cloud config files. The change cannot be done in a single PR because there are external dependencies in Kcrypt, for this reason I think I'll need to open all these PRs (I think only this one will be this big and tricky :crossed_fingers: ):

1. this one to introduce KScan, KRun and other temporary functions, and move everything in this repo to consume them
2. change Kcrypt and any other external sources to consume the temporary functions
3. switch the original functions to be pretty much the same as the new temporary functions
4. re-adapt Kcrypt and any other external sources
5. remove everyhing temporary and any other cleaning

Before this can be merged, the multiple scenarios schemas need to be QAed:

- [x] PowerManagement
  - [x] manual-install config specified reboot, poweroff
  - [x] manual-install flag specified reboot, poweroff
  - [x] webui config specified reboot, poweroff
  - [x] webui checkbox specified reboot, poweroff
- [x] P2PNetworkExtended
