### PR TITLE
:bug: Fix custom binds set as RW_PATHS

### DIFF
--- a/overlay/files/system/oem/11_persistency.yaml
+++ b/overlay/files/system/oem/11_persistency.yaml
@@ -44,7 +44,6 @@ stages:
              source /run/cos/cos-layout.env
              source /run/cos/custom-layout.env
              PERSISTENT_STATE_PATHS="${CUSTOM_EPHEMERAL_MOUNTS} ${PERSISTENT_STATE_PATHS}"
-             RW_PATHS="${CUSTOM_BIND_MOUNTS} ${RW_PATHS}"
              echo CUSTOM_BIND_MOUNTS=\"${CUSTOM_BIND_MOUNTS}\" >> /run/cos/cos-layout.env
              echo CUSTOM_EPHEMERAL_MOUNTS=\"${CUSTOM_EPHEMERAL_MOUNTS}\" >> /run/cos/cos-layout.env
              echo "# rw paths with user bind mounts" >> /run/cos/cos-layout.env


### PR DESCRIPTION
RW_PATHS are meant for overlay dirs which go away after a reboot. Custom binds/binds are mounted under COS_PERSISTENT, so they persist after reboot AND are RW by default.

This patch removes adding the custom binds into the RW_PATHS on the cos-layout file as that can lead to unintended consequences

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
