### PR TITLE
:bug: Add back gdisk to ubuntu/debian images

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -447,7 +447,6 @@ datasource-iso:
   ARG OSBUILDER_IMAGE
   ARG CLOUD_CONFIG
   FROM $OSBUILDER_IMAGE
-  RUN zypper in -y mkisofs
   WORKDIR /build
   RUN touch meta-data
   COPY ${CLOUD_CONFIG} user-data

--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -26,6 +26,7 @@ RUN apt-get update \
     firmware-linux-free \
     fuse3 \
     gawk \
+    gdisk \
     gnupg \
     gnupg1-l10n \
     grub-efi-amd64-bin \

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -17,6 +17,7 @@ RUN dnf install -y \
     e2fsprogs \
     efibootmgr \
     gawk \
+    gdisk \
     grub2 \
     grub2-efi-x64 \
     grub2-efi-x64-modules \

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -28,6 +28,7 @@ RUN apt-get update \
     firmware-sof-signed \
     fuse3 \
     gawk \
+    gdisk \
     grub-efi-amd64-bin \
     grub-efi-amd64-signed \
     grub-pc-bin \

--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -26,6 +26,7 @@ RUN apt-get update \
     file \
     fuse \
     gawk \
+    gdisk \
     grub-efi-amd64-bin \
     grub-efi-amd64-signed \
     grub-pc-bin \

--- a/images/Dockerfile.ubuntu-22-lts
+++ b/images/Dockerfile.ubuntu-22-lts
@@ -27,6 +27,7 @@ RUN apt-get update \
     firmware-sof-signed \
     fuse3 \
     gawk \
+    gdisk \
     grub-efi-amd64-bin \
     grub-efi-amd64-signed \
     grub-pc-bin \


### PR DESCRIPTION
**What this PR does / why we need it**: Otherwise EFI installs are broken

See also https://github.com/kairos-io/kairos/issues/949 and https://github.com/kairos-io/kairos/pull/874