### PR TITLE
:wrench: Use master as ref in generate schema workflow

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -1,6 +1,6 @@
 name: Cloud Config Schema
 on:
-  # To test with push events, it's easy to use a test branch e.g. schematest
+  # To test with push events, it's easy to use a test branch e.g. schematest, you will also need to update the checkout ref and the create PR base
   # push:
   #   branches:
   #     - schematest
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: schematest
+          ref: master  # change to schematest (or your branch name) if you're testing against a branch
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Install Go
@@ -31,7 +31,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.PAT_TOKEN }}
-          base: master
+          base: master  # change to schematest (or your branch name) if you're testing against a branch
           commit-message: ":book: Update Schema"
           title: ":book: Update Schema"
           body: "Update latest cloud config schema release"


### PR DESCRIPTION
Forgot to change the ref when I was testing this workflow
