### PR TITLE
✨  add support to upgrade bundles with runbundles

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,6 +62,7 @@ type Bundle struct {
 	DB         string   `yaml:"db_path,omitempty"`
 	LocalFile  bool     `yaml:"local_file,omitempty"`
 	Targets    []string `yaml:"targets,omitempty"`
+	Upgrade    bool     `yaml:"upgrade,omitempty"`
 }
 
 const DefaultHeader = "#cloud-config"
@@ -90,6 +91,9 @@ func (b Bundles) Options() (res [][]bundles.BundleOption) {
 			}
 			if bundle.LocalFile {
 				opts = append(opts, bundles.WithLocalFile(true))
+			}
+			if bundle.Upgrade {
+				opts = append(opts, bundles.WithUpgrade(true))
 			}
 			res = append(res, opts)
 		}

--- a/pkg/config/schemas/install_schema.go
+++ b/pkg/config/schemas/install_schema.go
@@ -27,6 +27,7 @@ type BundleSchema struct {
 	Repository string   `json:"repository,omitempty"`
 	Rootfs     string   `json:"rootfs_path,omitempty"`
 	Targets    []string `json:"targets,omitempty"`
+	Upgrade    bool     `json:"upgrade,omitempty"`
 }
 
 // GrubOptionsSchema represents the grub options block which can be used in different places of the Kairos configuration. It is used to configure grub.


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
bundles.RunBundles luet installer as of now only supports luet installs. This PR adds support to perform upgrades.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #974 
