### PR TITLE
:bug: Backport dracut patch for ubuntu 20 iscsi

### DIFF
--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -52,6 +52,7 @@ RUN apt-get update \
     openssh-server \
     os-prober \
     packagekit-tools \
+    patch \
     parted \
     policykit-1 \
     publicsuffix \
@@ -76,6 +77,11 @@ RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh
+
+# workaround https://github.com/kairos-io/kairos/issues/949
+# TODO: backport patch into packages
+COPY images/dracut-broken-iscsi-ubuntu-20.patch /
+RUN cd /usr/lib/dracut/modules.d/95iscsi && patch < /dracut-broken-iscsi-ubuntu-20.patch && rm -rf /dracut-broken-iscsi-ubuntu-20.patch
 
 # Enable tmp
 RUN cp -v /usr/share/systemd/tmp.mount /etc/systemd/system/ 

--- a/images/dracut-broken-iscsi-ubuntu-20.patch
+++ b/images/dracut-broken-iscsi-ubuntu-20.patch
@@ -1,0 +1,28 @@
+diff --git a/module-setup.sh b/module-setup.sh
+index 59ea5e089..fe40547d1 100755
+--- a/module-setup.sh
++++ b/module-setup.sh
+@@ -265,6 +265,23 @@ install() {
+             echo "After=dracut-cmdline.service"
+             echo "Before=dracut-initqueue.service"
+         ) > "${initdir}/$systemdsystemunitdir/iscsid.service.d/dracut.conf"
++
++        # The iscsi deamon does not need to wait for any storage inside initrd
++        mkdir -p "${initdir}/$systemdsystemunitdir/iscsid.socket.d"
++        (
++            echo "[Unit]"
++            echo "DefaultDependencies=no"
++            echo "Conflicts=shutdown.target"
++            echo "Before=shutdown.target sockets.target"
++        ) > "${initdir}/$systemdsystemunitdir/iscsid.socket.d/dracut.conf"
++        mkdir -p "${initdir}/$systemdsystemunitdir/iscsuio.socket.d"
++        (
++            echo "[Unit]"
++            echo "DefaultDependencies=no"
++            echo "Conflicts=shutdown.target"
++            echo "Before=shutdown.target sockets.target"
++        ) > "${initdir}/$systemdsystemunitdir/iscsuio.socket.d/dracut.conf"
++
+     fi
+     inst_dir /var/lib/iscsi
+     dracut_need_initqueue


### PR DESCRIPTION
**What this PR does / why we need it**:

There was an issue with dracut 48 in which the iscsid.socket required fs targets to be ready. On an iso this could lead to a dependency cycle between the dmsquash module setting up the livecd rootfs and the iscsi socket required the initrd-fs to be ready.

This was fixed on dracut 50 and its what this patch brings, dropping the socket dependency on the fs target so it can break the dependency cycle.

This only affect ubuntu 20 lts, and only affects booting from the iso. Alos the issue is random as systemd will decide to break the dependency in a non predictable way by disabling one of the services that conflict, so sometimes it would be the iscsi serviec, which would make the iso boot but sometimes it could be other more important services liek teh local fs or the dracut pre-mount services.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #949 
