### PR TITLE
:book: Add airgap docs

### DIFF
--- a/docs/content/en/docs/Examples/airgap.md
+++ b/docs/content/en/docs/Examples/airgap.md
@@ -1,0 +1,122 @@
+---
+title: "How to Create an Airgap K3s Installation with Kairos"
+linkTitle: "Airgapped ISO with AuroraBoot"
+weight: 4
+description: > 
+    This section describe examples on how to use Auroraboot and Kairos bundles to create ISOs for airgapped installs
+---
+
+If you want to create an [airgap K3s installation](https://docs.k3s.io/installation/airgap), Kairos provides a convenient way to do so using AuroraBoot. In this guide, we will go through the process of creating a custom ISO of Kairos that contains a configuration file and a [bundle](https://kairos.io/docs/advanced/bundles/) that executes preparatory steps after installation. The bundle will overlay new files in the system and prepare the node for having an airgapped K3s installation.
+
+{{% alert title="Note" %}}
+If you already have a Kubernetes cluster, you can use the osbuilder controller to generate container images with your additional files already inside.
+{{% /alert %}}
+
+## Prerequisites
+
+Docker running in the host
+
+## Creating the Bundle
+
+First, we need to create a bundle that contains the K3s images used for the airgap installation. The bundle will place the images in the `/var/lib/rancher/k3s/agent/images` directory. The `/var/lib/rancher` is already configured as persistent by Kairos defaults and every change to that directory persist reboots. You can add additional persistent paths in the system with [the cloud config](https://kairos.io/docs/advanced/customizing/#bind-mounts)
+
+1. Create a new directory named `images-bundle`, and create a new file inside it called `Dockerfile`.
+2. Paste the following code into the `Dockerfile`:
+
+```Dockerfile
+FROM alpine
+WORKDIR /build
+RUN wget https://github.com/k3s-io/k3s/releases/download/v1.23.16%2Bk3s1/k3s-airgap-images-amd64.tar.gz
+
+FROM scratch
+COPY ./run.sh /
+COPY --from=alpine /build/k3s-airgap-images-amd64.tar.gz /assets
+```
+3. Create a new file called `run.sh` inside the `images-bundle` directory, and paste the following code:
+
+```bash
+#!/bin/bash
+
+mkdir -p /usr/local/.state/var-lib-rancher.bind/k3s/agent/images/
+cp -rfv ./k3s-airgap-images-amd64.tar.gz /usr/local/.state/var-lib-rancher.bind/k3s/agent/images/
+```
+4. Make the `run.sh` file executable by running the following command: 
+```bash
+chmod +x run.sh
+```
+5. Build the container image by running the following command inside the images-bundle directory. This will save the image as `data/bundle.tar`:
+```bash
+docker build -t images-bundle .
+```
+6. Save the bundle:
+
+```
+$ ls
+images-bundle
+
+# create a directory
+$ mkdir data
+$ docker save images-bundle -o data/bundle.tar
+```
+
+## Building the Offline ISO for Airgap
+
+Now that we have created the bundle, we can use it to build an offline ISO for the airgap installation.
+
+1. Create a cloud config for the ISO and save it as config.yaml. The config.yaml file should contain your cloud configuration for Kairos and is used to set up the system when it is installed. An example can be:
+```yaml
+#cloud-config
+
+install:
+ auto: true
+ device: "auto"
+ reboot: true
+ bundles:
+  # This bundle needs to run after-install as it consumes assets from the LiveCD
+  # which is not accessible otherwise at the first boot (there is no live-cd with any bundle.tar)
+ - targets:
+   - run:///run/initramfs/live/bundle.tar
+   local_file: true
+
+# Define the user accounts on the node.
+users:
+- name: "kairos"                       # The username for the user.
+  passwd: "kairos"                      # The password for the user.
+  ssh_authorized_keys:                  # A list of SSH keys to add to the user's authorized keys.
+  - github:mudler                       # A key from the user's GitHub account.
+
+k3s:
+  enabled: true
+```
+
+2. Build the ISO with [AuroraBoot](/docs/reference/auroraboot) by running the following command:
+
+
+```bash
+IMAGE=quay.io/kairos/kairos-opensuse-leap:v1.6.1-k3sv1.26.1-k3s1
+
+docker pull $IMAGE
+
+docker run -v $PWD/config.yaml:/config.yaml \
+             -v $PWD/build:/tmp/auroraboot \
+             -v /var/run/docker.sock:/var/run/docker.sock \
+             -v $PWD/data:/tmp/data \
+             --rm -ti quay.io/kairos/auroraboot:v0.2.0 \
+             --set "disable_http_server=true" \
+             --set "disable_netboot=true" \
+             --set "container_image=docker://$IMAGE" \
+             --set "iso.data=/tmp/data" \
+             --cloud-config /config.yaml \
+             --set "state_dir=/tmp/auroraboot"
+```
+
+The resulting ISO should be available at: `build/iso/kairos.iso`
+
+This example is also available in the [Auroraboot repository](https://github.com/kairos-io/AuroraBoot/tree/master/examples/airgap) in the `examples/airgap` directory, where you can run `build_docker.sh` to reproduce the example.
+
+## See also
+
+- [Customize the OS image](/docs/advanced/customizing/)
+- [Live layer bundles](/docs/advanced/livelayering/)
+- [Create ISOs with Kubernetes](/docs/installation/automated/#kubernetes)
+- [Bundles reference](https://kairos.io/docs/advanced/bundles/)

--- a/docs/content/en/docs/Examples/airgap.md
+++ b/docs/content/en/docs/Examples/airgap.md
@@ -6,7 +6,7 @@ description: >
     This section describe examples on how to use AuroraBoot and Kairos bundles to create ISOs for airgapped installs
 ---
 
-If you want to create an [airgap K3s installation](https://docs.k3s.io/installation/airgap), Kairos provides a convenient way to do so using AuroraBoot. In this guide, we will go through the process of creating a custom ISO of Kairos that contains a configuration file and a [bundle](https://kairos.io/docs/advanced/bundles/) that executes preparatory steps after installation. The bundle will overlay new files in the system and prepare the node for having an airgapped K3s installation.
+If you want to create an [airgap K3s installation](https://docs.k3s.io/installation/airgap), Kairos provides a convenient way to do so using AuroraBoot. In this guide, we will go through the process of creating a custom ISO of Kairos that contains a configuration file and a [bundle](/docs/advanced/bundles/) that executes preparatory steps after installation. The bundle will overlay new files in the system and prepare the node for having an airgapped K3s installation.
 
 {{% alert title="Note" %}}
 If you already have a Kubernetes cluster, you can use the osbuilder controller to generate container images with your additional files already inside.
@@ -18,7 +18,7 @@ Docker running in the host
 
 ## Creating the Bundle
 
-First, we need to create a bundle that contains the K3s images used for the airgap installation. The bundle will place the images in the `/var/lib/rancher/k3s/agent/images` directory. The `/var/lib/rancher` is already configured as persistent by Kairos defaults and every change to that directory persist reboots. You can add additional persistent paths in the system with [the cloud config](https://kairos.io/docs/advanced/customizing/#bind-mounts)
+First, we need to create a bundle that contains the K3s images used for the airgap installation. The bundle will place the images in the `/var/lib/rancher/k3s/agent/images` directory. The `/var/lib/rancher` is already configured as persistent by Kairos defaults and every change to that directory persist reboots. You can add additional persistent paths in the system with [the cloud config](/docs/advanced/customizing/#bind-mounts)
 
 1. Create a new directory named `images-bundle`, and create a new file inside it called `Dockerfile`.
 2. Paste the following code into the `Dockerfile`:

--- a/docs/content/en/docs/Examples/airgap.md
+++ b/docs/content/en/docs/Examples/airgap.md
@@ -3,7 +3,7 @@ title: "How to Create an Airgap K3s Installation with Kairos"
 linkTitle: "Airgapped ISO with AuroraBoot"
 weight: 4
 description: > 
-    This section describe examples on how to use Auroraboot and Kairos bundles to create ISOs for airgapped installs
+    This section describe examples on how to use AuroraBoot and Kairos bundles to create ISOs for airgapped installs
 ---
 
 If you want to create an [airgap K3s installation](https://docs.k3s.io/installation/airgap), Kairos provides a convenient way to do so using AuroraBoot. In this guide, we will go through the process of creating a custom ISO of Kairos that contains a configuration file and a [bundle](https://kairos.io/docs/advanced/bundles/) that executes preparatory steps after installation. The bundle will overlay new files in the system and prepare the node for having an airgapped K3s installation.

--- a/docs/content/en/docs/Examples/airgap.md
+++ b/docs/content/en/docs/Examples/airgap.md
@@ -112,7 +112,7 @@ docker run -v $PWD/config.yaml:/config.yaml \
 
 The resulting ISO should be available at: `build/iso/kairos.iso`
 
-This example is also available in the [Auroraboot repository](https://github.com/kairos-io/AuroraBoot/tree/master/examples/airgap) in the `examples/airgap` directory, where you can run `build_docker.sh` to reproduce the example.
+This example is also available in the [AuroraBoot repository](https://github.com/kairos-io/AuroraBoot/tree/master/examples/airgap) in the `examples/airgap` directory, where you can run `build_docker.sh` to reproduce the example.
 
 ## See also
 

--- a/docs/content/en/docs/Installation/automated.md
+++ b/docs/content/en/docs/Installation/automated.md
@@ -110,7 +110,6 @@ total 778M
 34648526 drwxr-xr-x 5 root root 4.0K Feb  8 16:38 ..
 34648529 -rw-r--r-- 1 root root  253 Feb  8 16:38 config.yaml
 34649370 -rw-r--r-- 1 root root 389M Feb  8 16:38 kairos.iso
-34649372 -rw-r--r-- 1 root root 389M Feb  8 16:39 kairos.iso.custom.iso
 34649371 -rw-r--r-- 1 root root   76 Feb  8 16:39 kairos.iso.sha256
 ```
 {{% /tab %}}
@@ -137,6 +136,8 @@ $ docker run -v $PWD:/cOS -v /var/run/docker.sock:/var/run/docker.sock -i --rm q
 This will create a new ISO with your specified cloud configuration embedded in it. You can then use this ISO to boot your machine and automatically install Kairos with your desired settings.
 
 You can as well modify the image in this step and add additional packages before deployment. See [customizing the system image](/docs/advanced/customizing).
+
+Check out the [AuroraBoot documentation](/docs/reference/auroraboot) and the [examples](/docs/examples) for learn more on how to generate customized images for installation.
 
 ### Kubernetes
 

--- a/docs/content/en/docs/Reference/auroraboot.md
+++ b/docs/content/en/docs/Reference/auroraboot.md
@@ -501,6 +501,10 @@ docker run -v $PWD/config.yaml:/config.yaml \
              --set "state_dir=/tmp/auroraboot"
 ```
 
+### Prepare ISO for Airgap installations
+
+See the [Airgap example](/docs/examples/airgap)in the [examples section](/docs/examples).
+
 ### Netboot with core images from Github releases
 
 ```bash

--- a/docs/content/en/docs/Reference/auroraboot.md
+++ b/docs/content/en/docs/Reference/auroraboot.md
@@ -492,7 +492,6 @@ Build the custom ISO with the cloud config:
 ```bash
 docker run -v $PWD/config.yaml:/config.yaml \
              -v $PWD/build:/tmp/auroraboot \
-             -v /var/run/docker.sock:/var/run/docker.sock \
              --rm -ti quay.io/kairos/auroraboot \
              --set container_image=quay.io/kairos/core-rockylinux:v1.5.0 \
              --set "disable_http_server=true" \
@@ -501,9 +500,33 @@ docker run -v $PWD/config.yaml:/config.yaml \
              --set "state_dir=/tmp/auroraboot"
 ```
 
+### Override GRUB config file
+
+It is possible to override the default GRUB config file of the ISO by creating a directory that
+contains the files that we want to add or replace in it.
+
+For example, to override the GRUB config file:
+
+```bash
+mkdir -p data/boot/grub2
+# You can replace this step with your own grub config. This GRUB configuration is the boot menu of the ISO
+wget https://raw.githubusercontent.com/kairos-io/kairos/master/overlay/files-iso/boot/grub2/grub.cfg -O data/boot/grub2/grub.cfg
+
+docker run -v $PWD/config.yaml:/config.yaml \
+             -v $PWD/data:/tmp/data \
+             -v $PWD/build:/tmp/auroraboot \
+             --rm -ti quay.io/kairos/auroraboot \
+             --set container_image=quay.io/kairos/core-rockylinux:v1.5.0 \
+             --set "disable_http_server=true" \
+             --set "disable_netboot=true" \
+             --cloud-config /config.yaml \
+             --set "state_dir=/tmp/auroraboot" \
+             --set "iso.data=/tmp/data"
+```
+
 ### Prepare ISO for Airgap installations
 
-See the [Airgap example](/docs/examples/airgap)in the [examples section](/docs/examples).
+See the [Airgap example](/docs/examples/airgap) in the [examples section](/docs/examples).
 
 ### Netboot with core images from Github releases
 


### PR DESCRIPTION
**What this PR does / why we need it**: It adds documentation about the latest `AuroraBoot` features that allows to build ISOs for airgapped installations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #938

cc: @areitz86 @vfiftyfive 