### PR TITLE
:robot: Add SBOM artifacts to CI pipelines

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -68,6 +68,13 @@ jobs:
           if-no-files-found: error
       - uses: actions/upload-artifact@v3
         with:
+          name: kairos-${{ matrix.flavor }}.sbom.zip
+          path: |
+            *.syft.json
+            *.spdx.json
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v3
+        with:
           name: kairos-${{ matrix.flavor }}.initrd.zip
           path: |
             *-initrd

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -92,3 +92,9 @@ jobs:
           sudo luet util pack quay.io/kairos/core-${{ matrix.flavor }}:$VERSION.img build.tar image.tar
           sudo -E docker load -i image.tar
           sudo -E docker push quay.io/kairos/core-${{ matrix.flavor }}:$VERSION.img
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            build/*.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,22 +118,6 @@ jobs:
         with:
           files: |
             release/*
-      - run: |
-          sudo mv release/*.iso ./
-          sudo mv release/*.sha256 ./
-          sudo mv release/*.sha256.pem ./
-          sudo mv release/*.sha256.sig ./
-      - uses: actions/upload-artifact@v3
-        with:
-          name: kairos-${{ matrix.flavor }}.iso.zip
-          path: |
-            *.iso
-            *.sha256
-            *.sha256.pem
-            *.sha256.sig
-          if-no-files-found: error
-
-
 # build-vm-images:
 #   needs: build
 #   runs-on: macos-12

--- a/Earthfile
+++ b/Earthfile
@@ -196,6 +196,21 @@ lint:
     BUILD +shellcheck-lint
     BUILD +yamllint
 
+syft:
+    FROM anchore/syft:latest
+    SAVE ARTIFACT /syft syft
+
+image-sbom:
+    FROM +docker
+    WORKDIR /build
+    COPY +version/VERSION ./
+    ARG VERSION=$(cat VERSION)
+    ARG FLAVOR
+    COPY +syft/syft /usr/bin/syft
+    RUN syft / -o json=sbom.syft.json -o spdx-json=sbom.spdx.json
+    SAVE ARTIFACT /build/sbom.syft.json sbom.syft.json AS LOCAL core-${FLAVOR}-${VERSION}-sbom.syft.json
+    SAVE ARTIFACT /build/sbom.spdx.json sbom.spdx.json AS LOCAL core-${FLAVOR}-${VERSION}-sbom.spdx.json
+
 luet:
     FROM quay.io/luet/base:$LUET_VERSION
     SAVE ARTIFACT /usr/bin/luet /luet

--- a/Earthfile
+++ b/Earthfile
@@ -36,12 +36,14 @@ ARG IMAGE_REPOSITORY_ORG=quay.io/kairos
 
 all:
   BUILD +docker
+  BUILD +image-sbom
   BUILD +iso
   BUILD +netboot
   BUILD +ipxe-iso
 
 all-arm:
   BUILD --platform=linux/arm64 +docker
+  BUILD +image-sbom
   BUILD +arm-image
 
 go-deps:


### PR DESCRIPTION
**What this PR does / why we need it**: This PR introduces generated images SBOM to our releases

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #51 

This PR introduces https://github.com/anchore/syft generating a SBOM which is attached at the end of the image build process. It also adds the SBOM to the uploaded artifacts (jobs and releases)

Example generated SBOM files: [core-debian-v1.6.0-14-g193c740-dirty-sbom.s.zip](https://github.com/kairos-io/kairos/files/10863881/core-debian-v1.6.0-14-g193c740-dirty-sbom.s.zip)
