### PR TITLE
:robot: Attach trivy scan reports

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -74,6 +74,19 @@ jobs:
           export IMAGE_NAME=kairos-$FLAVOR-$TAG.img
           export IMAGE=quay.io/kairos/core-$FLAVOR:$TAG
           docker push quay.io/kairos/core-$FLAVOR:$TAG
+      - name: Prepare sarif files  🔧
+        env:
+          FLAVOR: ${{ matrix.flavor }}
+          IMAGE: quay.io/kairos/core-$FLAVOR:latest
+          MODEL: ${{ matrix.model }}
+        run: |
+          mkdir sarif
+          mv build/*.sarif sarif/
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'sarif'
+          category: ${{ matrix.flavor }}
       - name: Sign image
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         env:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -77,6 +77,13 @@ jobs:
           ./earthly.sh +all --IMAGE=$IMAGE --FLAVOR=$FLAVOR
           sudo mv build/* .
           sudo rm -rf build
+          mkdir sarif
+          mv *.sarif sarif/
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'sarif'
+          category: ${{ matrix.flavor }}
       - uses: actions/upload-artifact@v3
         with:
           name: kairos-${{ matrix.flavor }}.iso.zip

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -99,3 +99,16 @@ jobs:
         with:
           files: |
             build/*.json
+      - name: Prepare sarif files  🔧
+        env:
+          FLAVOR: ${{ matrix.flavor }}
+          IMAGE: quay.io/kairos/core-$FLAVOR:latest
+          MODEL: ${{ matrix.model }}
+        run: |
+          mkdir sarif
+          mv release/*.sarif sarif/
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'sarif'
+          category: ${{ matrix.flavor }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,6 +121,19 @@ jobs:
         with:
           files: |
             release/*
+      - name: Prepare sarif files  🔧
+        env:
+          FLAVOR: ${{ matrix.flavor }}
+          IMAGE: quay.io/kairos/core-$FLAVOR:latest
+          MODEL: ${{ matrix.model }}
+        run: |
+          mkdir sarif
+          mv release/*.sarif sarif/
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'sarif'
+          category: ${{ matrix.flavor }}
 # build-vm-images:
 #   needs: build
 #   runs-on: macos-12


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR attaches sarif scan reports to Github actions (see: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github) allowing to assess security components in the "Security tab". It also adds the reports to the release and attaches to the build results

Part of: https://github.com/kairos-io/kairos/issues/115
