### PR TITLE
:robot: Run framework build on self-hosted

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -139,7 +139,7 @@ jobs:
   build-framework:
     needs:
       - get-matrix
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       id-token: write
     strategy:
@@ -168,6 +168,18 @@ jobs:
         env:
           FLAVOR: ${{ matrix.flavor }}
         run: |
+          # Configure earthly to use the docker mirror in CI
+          # https://docs.earthly.dev/ci-integration/pull-through-cache#configuring-earthly-to-use-the-cache
+          mkdir -p ~/.earthly/
+          cat << EOF > ~/.earthly/config.yml
+          global:
+            buildkit_additional_config: |
+              [registry."docker.io"]
+                mirrors = ["registry.docker-mirror.svc.cluster.local:5000"]
+              [registry."registry.docker-mirror.svc.cluster.local:5000"]
+                insecure = true
+                http = true
+          EOF
           earthly --push +build-framework-image --FLAVOR=${FLAVOR} --VERSION=master
       - name: Push to quay
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
@@ -179,11 +191,22 @@ jobs:
           docker push "$IMAGE:$TAG" # Otherwise .RepoDigests will be empty for some reason
           cosign sign $(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
       - name: Build framework image 🔧
-        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/master' }}
         env:
           FLAVOR: ${{ matrix.flavor }}
           IMAGE: quay.io/kairos/core-${{ matrix.flavor }}:master
         run: |
+          # Configure earthly to use the docker mirror in CI
+          # https://docs.earthly.dev/ci-integration/pull-through-cache#configuring-earthly-to-use-the-cache
+          mkdir -p ~/.earthly/ || true
+          cat << EOF > ~/.earthly/config.yml
+          global:
+            buildkit_additional_config: |
+              [registry."docker.io"]
+                mirrors = ["registry.docker-mirror.svc.cluster.local:5000"]
+              [registry."registry.docker-mirror.svc.cluster.local:5000"]
+                insecure = true
+                http = true
+          EOF
           earthly +build-framework-image --FLAVOR=${FLAVOR} --VERSION=master
           docker tag quay.io/kairos/framework:master_${{ matrix.flavor }} ttl.sh/kairos-framework-${{ matrix.flavor }}-${{ github.sha }}:8h
           docker push ttl.sh/kairos-framework-${{ matrix.flavor }}-${{ github.sha }}:8h

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -149,12 +149,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           git fetch --prune --unshallow
-      - name: setup-docker
-        uses: docker-practice/actions-setup-docker@master
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
       - name: Login to Quay Registry


### PR DESCRIPTION
**What this PR does / why we need it**:
Those jobs are small (typically runs for 4/5mins) and might be useful to re-use the cache in such case which makes it faster. This is a test - It is also better probably to free some slots, as no other jobs depends on the fw images.