### PR TITLE
:robot: Use sudo to move generated sarif files

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -84,7 +84,7 @@ jobs:
           MODEL: ${{ matrix.model }}
         run: |
           mkdir sarif
-          mv build/*.sarif sarif/
+          sudo mv build/*.sarif sarif/
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -108,7 +108,7 @@ jobs:
           MODEL: ${{ matrix.model }}
         run: |
           mkdir sarif
-          mv release/*.sarif sarif/
+          sudo mv release/*.sarif sarif/
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION

Fixes failures affecting master builds: https://github.com/kairos-io/kairos/actions/runs/4321817792/jobs/7543494120

