### PR TITLE
:bug: (WIP - Do not merge) Ensure systemd-networkd starts properly

### DIFF
--- a/overlay/files/system/oem/05_network.yaml
+++ b/overlay/files/system/oem/05_network.yaml
@@ -13,6 +13,7 @@ stages:
       commands:
         - rm /etc/resolv.conf
         - ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
+# This change ensures any network config files updated during initramfs are read into systemd-networkd and the stack is restarted. This fixes issues with the DHCP IP address getting dropped under certain circumstances in Equinix Metal. Also fixes dynamically defined network bonding not coming up properly until the daemon-reload and restart commands are issued. See also: https://github.com/kairos-io/kairos/pull/1030
   boot.after:
     - name: "Restart network"
       commands:

--- a/overlay/files/system/oem/05_network.yaml
+++ b/overlay/files/system/oem/05_network.yaml
@@ -1,5 +1,10 @@
 name: "Default network configuration"
 stages:
+  boot:
+    - name: "Restart network"
+      commands:
+       	- systemctl daemon-reload
+       	- systemctl restart systemd-networkd
   initramfs:
     - name: "Setup network"
       if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'

--- a/overlay/files/system/oem/05_network.yaml
+++ b/overlay/files/system/oem/05_network.yaml
@@ -14,7 +14,7 @@ stages:
         - rm /etc/resolv.conf
         - ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
 # This change ensures any network config files updated during initramfs are read into systemd-networkd and the stack is restarted. This fixes issues with the DHCP IP address getting dropped under certain circumstances in Equinix Metal. Also fixes dynamically defined network bonding not coming up properly until the daemon-reload and restart commands are issued. See also: https://github.com/kairos-io/kairos/pull/1030
-  boot.after:
+  initramfs.after:
     - name: "Restart network"
       commands:
         - systemctl daemon-reload

--- a/overlay/files/system/oem/05_network.yaml
+++ b/overlay/files/system/oem/05_network.yaml
@@ -15,12 +15,13 @@ stages:
         - ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
 # This change ensures any network config files updated during initramfs are read into systemd-networkd and the stack is restarted. This fixes issues with the DHCP IP address getting dropped under certain circumstances in Equinix Metal. Also fixes dynamically defined network bonding not coming up properly until the daemon-reload and restart commands are issued. See also: https://github.com/kairos-io/kairos/pull/1030
   initramfs.after:
-    - name: "Restart network"
+    - name: "Restart network stack when booting in live mode"
+      if: '[ -f /run/cos/live_mode ]'
       commands:
         - systemctl daemon-reload
         - systemctl restart systemd-networkd
         - |
-          if [ -f /run/cos/live_mode ]; then ip link | awk -F: '$0 !~ "NO-CARRIER|lo|vir|wl|usb|^[^0-9]"{print $2;getline}'| while read line; do /sbin/dhclient -4 $line; done; fi
+          ip link | awk -F: '$0 !~ "NO-CARRIER|lo|vir|wl|usb|^[^0-9]"{print $2;getline}'| while read line; do /sbin/dhclient -4 $line; done
 #     dns:
 #      path: /etc/resolv.conf
 #      nameservers:

--- a/overlay/files/system/oem/05_network.yaml
+++ b/overlay/files/system/oem/05_network.yaml
@@ -20,6 +20,9 @@ stages:
       commands:
         - systemctl daemon-reload
         - systemctl restart systemd-networkd
+  before-install:
+    - name: "Force DHCP refresh before installing to disk"
+      commands:
         - |
           ip link | awk -F: '$0 !~ "NO-CARRIER|lo|vir|wl|usb|^[^0-9]"{print $2;getline}'| while read line; do /sbin/dhclient -4 $line; done
 #     dns:

--- a/overlay/files/system/oem/05_network.yaml
+++ b/overlay/files/system/oem/05_network.yaml
@@ -1,10 +1,5 @@
 name: "Default network configuration"
 stages:
-  boot:
-    - name: "Restart network"
-      commands:
-       	- systemctl daemon-reload
-       	- systemctl restart systemd-networkd
   initramfs:
     - name: "Setup network"
       if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
@@ -18,6 +13,13 @@ stages:
       commands:
         - rm /etc/resolv.conf
         - ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
+  initramfs.after:
+    - name: "Restart network"
+      commands:
+        - systemctl daemon-reload
+        - systemctl restart systemd-networkd
+        - |
+          ip link | awk -F: '$0 !~ "NO-CARRIER|lo|vir|wl|usb|^[^0-9]"{print $2;getline}'| while read line; do /sbin/dhclient -4 $line; done
 #     dns:
 #      path: /etc/resolv.conf
 #      nameservers:

--- a/overlay/files/system/oem/05_network.yaml
+++ b/overlay/files/system/oem/05_network.yaml
@@ -13,13 +13,13 @@ stages:
       commands:
         - rm /etc/resolv.conf
         - ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
-  initramfs.after:
+  boot.after:
     - name: "Restart network"
       commands:
         - systemctl daemon-reload
         - systemctl restart systemd-networkd
         - |
-          ip link | awk -F: '$0 !~ "NO-CARRIER|lo|vir|wl|usb|^[^0-9]"{print $2;getline}'| while read line; do /sbin/dhclient -4 $line; done
+          if [ -f /run/cos/live_mode ]; then ip link | awk -F: '$0 !~ "NO-CARRIER|lo|vir|wl|usb|^[^0-9]"{print $2;getline}'| while read line; do /sbin/dhclient -4 $line; done; fi
 #     dns:
 #      path: /etc/resolv.conf
 #      nameservers:


### PR DESCRIPTION
**What this PR does / why we need it**:
This change ensures any network config files updated during `initramfs` are read into systemd-networkd and the stack is restarted. This fixes issues with the DHCP IP address getting dropped under certain circumstances in Equinix Metal. Also fixes dynamically defined network bonding not coming up properly until the daemon-reload and restart commands are issued.
