### PR TITLE
:robot: Fixup test targets

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -509,7 +509,7 @@ jobs:
           sudo rm -rfv build || true
           df -h
       - run: |
-          ./earthly.sh +run-qemu-test --PREBUILT_ISO=$(ls *.iso) \
+          ./earthly.sh +run-qemu-test --PREBUILT_ISO=$(ls kairos-${{matrix.flavor}}-*.iso) \
             --FLAVOR=${{ matrix.flavor }} \
             --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h \
             --TEST_SUITE=upgrade-latest-with-cli

--- a/Earthfile
+++ b/Earthfile
@@ -638,7 +638,6 @@ run-qemu-test:
         COPY +iso/kairos.iso kairos.iso
         ENV ISO=/build/kairos.iso
     END
-    RUN pwd && ls -l && ls -l build
     RUN PATH=$PATH:$GOPATH/bin ginkgo -v --label-filter "$TEST_SUITE" --fail-fast -r ./tests/
 
 ###


### PR DESCRIPTION
We were listing on a dir that now doesn't exist necessarly anymore, and when picking up the iso from latest release, we are selectively picking one flavor for the upgrade test.

