### PR TITLE
:penguin: Drop removed packages from opensuse-tumbleweed-arm-rpi

### DIFF
--- a/images/Dockerfile.opensuse-tumbleweed-arm-rpi
+++ b/images/Dockerfile.opensuse-tumbleweed-arm-rpi
@@ -67,7 +67,6 @@ RUN zypper in -y \
     sysconfig-netconfig \
     systemd \
     systemd-network \
-    systemd-sysvinit \
     sysvinit-tools \
     tar \
     timezone \

--- a/images/Dockerfile.opensuse-tumbleweed-arm-rpi
+++ b/images/Dockerfile.opensuse-tumbleweed-arm-rpi
@@ -46,7 +46,6 @@ RUN zypper in -y \
     multipath-tools \
     nano \
     nethogs \
-    nfs-utils \
     open-iscsi \
     open-vm-tools \
     openssh \


### PR DESCRIPTION
Those should not be required, and seem were dropped from the openSUSE repositories too.

CI logs: https://github.com/kairos-io/kairos/actions/runs/4327767275/jobs/7581273754