### PR TITLE
:penguin: Add systemd-resolved to Debian images

### DIFF
--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -74,6 +74,7 @@ RUN apt-get update \
     squashfs-tools \
     sudo \
     systemd \
+    systemd-resolved \
     systemd-sysv \
     systemd-timesyncd \
     tar \

--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -132,6 +132,12 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 				Expect(out).ToNot(ContainSubstring("videotest"))
 			})
 
+			By("checking that networking is functional", func() {
+				out, err := vm.Sudo(`curl google.it`)
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(out).To(ContainSubstring("Moved"))
+			})
+
 			By("checking corresponding state", func() {
 				out, err := vm.Sudo("kairos-agent state")
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: We were missing `systemd-resolved`, thus the symlink was not available

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1035 
