### PR TITLE
Add missing repository in tumbleweed

### DIFF
--- a/images/Dockerfile.opensuse-tumbleweed-arm-rpi
+++ b/images/Dockerfile.opensuse-tumbleweed-arm-rpi
@@ -3,6 +3,7 @@ ARG BASE_IMAGE=opensuse/tumbleweed
 
 FROM $BASE_IMAGE
 
+RUN zypper ar https://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/ aarch64 && zypper ref
 RUN zypper in -y \
     bash-completion \
     bcm43xx-firmware \


### PR DESCRIPTION
This should fix CI:  https://github.com/kairos-io/kairos/actions/runs/4346604653/jobs/7592922961
