### PR TITLE
:bug: Improve network stage

### DIFF
--- a/overlay/files/system/oem/05_network.yaml
+++ b/overlay/files/system/oem/05_network.yaml
@@ -1,15 +1,20 @@
 name: "Default network configuration"
 stages:
   initramfs:
-    - name: "Setup network"
+    - name: "Disable NetworkManager and wicked"
+      if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
+      systemctl:
+        disable:
+          - NetworkManager
+          - wicked
+    - name: "Enable systemd-network and systemd-resolved"
       if: '[ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       systemctl:
         enable:
           - systemd-networkd
           - systemd-resolved
-        disable:
-          - NetworkManager
-          - wicked
+    - name: "Link /etc/resolv.conf to systemd resolv.conf"
+      if: '([ -e "/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]) && [ -f /etc/hosts ]'
       commands:
         - rm /etc/resolv.conf
         - ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

 - First disable NetworkManager and wicked
 - Then enable systemd services for network and resolv
 - Then remove and link /etc/resolv.conf

This fixes a case in which systemd-networkd could be enabled before wicked is disabled and because network is linked to wicked it would fail to enable systemd-networkd properly during initramfs.

Also adds a check before removing the resolv.conf, to skip it if it doesnt exist.

Found by immucore running the initramfs as it spits out the errors into the log and we can see them more easily

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
