### PR TITLE
:penguin: Drop zfs from alpine-arm images

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    paths:
+      - '**'
+      - '!docs/**'
 
 concurrency:
   group: ci-arm-${{ github.head_ref || github.ref }}-${{ github.repository }}

--- a/images/Dockerfile.alpine-arm-rpi
+++ b/images/Dockerfile.alpine-arm-rpi
@@ -82,9 +82,7 @@ RUN apk --no-cache add  \
       open-vm-tools-deploypkg \
       open-vm-tools-guestinfo \
       open-vm-tools-static \
-      open-vm-tools-vmbackup \
-      zfs \
-      zfs-lts
+      open-vm-tools-vmbackup
 
 RUN rc-update add sshd boot && \
     rc-update add connman boot  && \


### PR DESCRIPTION
Dependencies make the image size grow as such it needs changes in the layout - this is not an issue by itself if not that it would cause to exceed our current 16GB size requirements.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1118 
Supersedes #1123 