### PR TITLE
:seedling: remove duplicate installation of `which` package in opensuse-leap Dockerfile

### DIFF
--- a/images/Dockerfile.opensuse-leap
+++ b/images/Dockerfile.opensuse-leap
@@ -64,4 +64,4 @@ RUN zypper in --force-resolution -y \
     tmux \
     vim \
     which \
-    which && zypper cc
+    && zypper cc


### PR DESCRIPTION
**What this PR does / why we need it**:

The `which` package was listed twice in the `zypper install` command. One time should be enough.