### PR TITLE
:bug: Fix validator on long strings

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -66,7 +66,7 @@ test:
     WORKDIR /build
     COPY +luet/luet /usr/bin/luet
     COPY . .
-    RUN go run github.com/onsi/ginkgo/v2/ginkgo --fail-fast --slow-spec-threshold 30s --covermode=atomic --coverprofile=coverage.out -p -r ./pkg ./internal ./cmd ./sdk
+    RUN go run github.com/onsi/ginkgo/v2/ginkgo --fail-fast --covermode=atomic --coverprofile=coverage.out -p -r ./pkg ./internal ./cmd ./sdk
     SAVE ARTIFACT coverage.out AS LOCAL coverage.out
 
 OSRELEASE:

--- a/internal/agent/validate_test.go
+++ b/internal/agent/validate_test.go
@@ -24,6 +24,21 @@ var _ = Describe("Validate", func() {
 	Context("Validate", func() {
 		var yaml string
 
+		Context("With a really long config string", func() {
+			BeforeEach(func() {
+				yaml = `#cloud-config
+users:
+  - name: kairos
+    passwd: kairos
+vpn:
+  network_token: "dssdnfjkldashfkjhasdkhfkasjdhfkjhasdjkfhaksjdhfkjashjdkfhioreqwhfuihqweruifhuewrbfhuewrfuyequfhuiehuifheqrihfuiqrehfuirqheiufhreqiuhfuiqheiufhqeuihfuiqrehfiuhqreuifrhiuqehfiuhqeirhfiuewhrfhqwehfriuewhfuihewiuhfruewhrifhwiuehrfiuhweiurfhwueihrfuiwehufhweuihrfuiwerhfuihewruifhewuihfiouwehrfiouhwei"
+`
+			})
+			It("validates", func() {
+				Expect(Validate(yaml)).ToNot(HaveOccurred())
+			})
+		})
+
 		Context("with a valid config", func() {
 			BeforeEach(func() {
 				yaml = `#cloud-config
@@ -32,7 +47,7 @@ users:
     passwd: kairos`
 			})
 
-			It("is successful", func() {
+			It("is successful reading it from file", func() {
 				f, err := ioutil.TempDir("", "tests")
 				Expect(err).ToNot(HaveOccurred())
 				defer os.RemoveAll(f)
@@ -42,6 +57,9 @@ users:
 				Expect(err).ToNot(HaveOccurred())
 				err = Validate(path)
 				Expect(err).ToNot(HaveOccurred())
+			})
+			It("is successful reading it from a string", func() {
+				Expect(Validate(yaml)).ToNot(HaveOccurred())
 			})
 		})
 


### PR DESCRIPTION


<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Validator was mistakenly identifying a long yaml as a file and trying to open it, which failed with an error of filename too long.

This was not catched in order to identify that the source is not a file but a yaml, so it was directly returning the error.

This patch adds that error to the list in order ot identify the source to validate as yaml. Also adds a couple of tests for this functionality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #994
