### PR TITLE
:robot: Add dracut-mkinitrd-deprecated package to Tumblweed

### DIFF
--- a/images/Dockerfile.opensuse-tumbleweed
+++ b/images/Dockerfile.opensuse-tumbleweed
@@ -15,6 +15,7 @@ RUN zypper in --force-resolution -y \
     dhcp-client \
     dosfstools \
     dracut \
+    dracut-mkinitrd-deprecated \
     e2fsprogs \
     fail2ban \
     findutils \

--- a/images/Dockerfile.opensuse-tumbleweed-arm-rpi
+++ b/images/Dockerfile.opensuse-tumbleweed-arm-rpi
@@ -18,6 +18,7 @@ RUN zypper in -y \
     dhcp-client \
     dosfstools \
     dracut \
+    dracut-mkinitrd-deprecated \
     e2fsprogs \
     fail2ban \
     findutils \


### PR DESCRIPTION
Fixes the CI issue, but I think @Itxaka solution is better since it's a "deprecated" package. Still leaving this here in case we want to make CI green before the other PR gets merged, otherwise feel free to close