### PR TITLE
:seedling: :bug: Run kcrypt in rootfs stage

### DIFF
--- a/overlay/files/system/oem/21_kcrypt.yaml
+++ b/overlay/files/system/oem/21_kcrypt.yaml
@@ -1,5 +1,10 @@
-name: "Update discovery plugins"
+name: "Kcrypt"
 stages:
+  rootfs:
+    - name: "Unlock encrypted volumes"
+      if: '[ ! -f "/run/cos/live_mode" ]'
+      commands:
+        - kcrypt unlock-all
   after-upgrade:
     - name: "Update plugins"
       if: "[ $(kairos-agent state get oem.found) == 'true' ]"


### PR DESCRIPTION
Instead of having it as a serviec we can run it under the rootfs stage. This gives us the assurance that /oem is mounted by that time and that we run it on all boot modes except live mode

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
