### PR TITLE
:robot: Attach and sign SBOM

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -105,10 +105,9 @@ jobs:
         run: |
           docker push "$IMAGE:$TAG"
           image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
-          cosign sign $image_ref
           spdx=$(ls build/*.spdx.json)
           cosign attach sbom --sbom $spdx $image_ref
-          cosign sign ${image_ref}.sbom
+          cosign sign $image_ref --attachment sbom
           # in-toto attestation
           cosign attest --type spdx --predicate $spdx $image_ref
       - name: Upload results

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -107,8 +107,8 @@ jobs:
           image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
           cosign sign $image_ref
           spdx=$(ls build/*.spdx.json)
-          sbom=$(cosign attach sbom --sbom $spdx $image_ref 2>&1 | grep "Uploading SBOM" | awk '{print $7}' | sed 's/\[//g;s/\]//g')
-          cosign sign $sbom
+          cosign attach sbom --sbom $spdx $image_ref
+          cosign sign ${image_ref}.sbom
           # in-toto attestation
           cosign attest --type spdx --predicate $spdx $image_ref
       - name: Upload results

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -103,8 +103,14 @@ jobs:
           TAG: "latest"
           COSIGN_YES: true
         run: |
-          docker push "$IMAGE:$TAG" # Otherwise .RepoDigests will be empty for some reason
-          cosign sign $(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
+          docker push "$IMAGE:$TAG"
+          image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
+          cosign sign $image_ref
+          spdx=$(ls build/*.spdx.json)
+          sbom=$(cosign attach sbom --sbom $spdx $image_ref 2>&1 | grep "Uploading SBOM" | awk '{print $7}' | sed 's/\[//g;s/\]//g')
+          cosign sign $sbom
+          # in-toto attestation
+          cosign attest --type spdx --predicate $spdx $image_ref
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -149,8 +149,8 @@ jobs:
           image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
           cosign sign $image_ref
           spdx=$(ls *.spdx.json)
-          sbom=$(cosign attach sbom --sbom $spdx $image_ref 2>&1 | grep "Uploading SBOM" | awk '{print $7}' | sed 's/\[//g;s/\]//g')
-          cosign sign $sbom
+          cosign attach sbom --sbom $spdx $image_ref
+          cosign sign ${image_ref}.sbom
           # in-toto attestation
           cosign attest --type spdx --predicate $spdx $image_ref
       - name: Push to testing

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -146,7 +146,13 @@ jobs:
           COSIGN_YES: true
         run: |
           docker push "$IMAGE:$TAG"
-          cosign sign $(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
+          image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
+          cosign sign $image_ref
+          spdx=$(ls *.spdx.json)
+          sbom=$(cosign attach sbom --sbom $spdx $image_ref 2>&1 | grep "Uploading SBOM" | awk '{print $7}' | sed 's/\[//g;s/\]//g')
+          cosign sign $sbom
+          # in-toto attestation
+          cosign attest --type spdx --predicate $spdx $image_ref
       - name: Push to testing
         run: |
           docker tag quay.io/kairos/core-${{ matrix.flavor }}:latest ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -147,10 +147,9 @@ jobs:
         run: |
           docker push "$IMAGE:$TAG"
           image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
-          cosign sign $image_ref
           spdx=$(ls *.spdx.json)
           cosign attach sbom --sbom $spdx $image_ref
-          cosign sign ${image_ref}.sbom
+          cosign sign $image_ref --attachment sbom
           # in-toto attestation
           cosign attest --type spdx --predicate $spdx $image_ref
       - name: Push to testing

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -79,8 +79,8 @@ jobs:
           image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
           cosign sign $image_ref
           spdx=$(ls build/*.spdx.json)
-          sbom=$(cosign attach sbom --sbom $spdx $image_ref 2>&1 | grep "Uploading SBOM" | awk '{print $7}' | sed 's/\[//g;s/\]//g')
-          cosign sign $sbom
+          cosign attach sbom --sbom $spdx $image_ref
+          cosign sign ${image_ref}.sbom
           # in-toto attestation
           cosign attest --type spdx --predicate $spdx $image_ref
       - name: Export version

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -76,7 +76,13 @@ jobs:
         run: |
           export TAG=${GITHUB_REF##*/}
           export IMAGE="quay.io/kairos/core-${{ matrix.flavor }}"
-          cosign sign $(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
+          image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
+          cosign sign $image_ref
+          spdx=$(ls build/*.spdx.json)
+          sbom=$(cosign attach sbom --sbom $spdx $image_ref 2>&1 | grep "Uploading SBOM" | awk '{print $7}' | sed 's/\[//g;s/\]//g')
+          cosign sign $sbom
+          # in-toto attestation
+          cosign attest --type spdx --predicate $spdx $image_ref
       - name: Export version
         run: |
           TAG=${GITHUB_REF##*/}

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -77,10 +77,9 @@ jobs:
           export TAG=${GITHUB_REF##*/}
           export IMAGE="quay.io/kairos/core-${{ matrix.flavor }}"
           image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
-          cosign sign $image_ref
           spdx=$(ls build/*.spdx.json)
           cosign attach sbom --sbom $spdx $image_ref
-          cosign sign ${image_ref}.sbom
+          cosign sign $image_ref --attachment sbom
           # in-toto attestation
           cosign attest --type spdx --predicate $spdx $image_ref
       - name: Export version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,10 +111,9 @@ jobs:
           export IMAGE="quay.io/kairos/core-${{ matrix.flavor }}"
           docker push "$IMAGE:$TAG"
           image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
-          cosign sign $image_ref
           spdx=$(ls release/*.spdx.json)
           cosign attach sbom --sbom $spdx $image_ref
-          cosign sign ${image_ref}.sbom
+          cosign sign $image_ref --attachment sbom
           # in-toto attestation
           cosign attest --type spdx --predicate $spdx $image_ref
       - name: Sign ISO sha files

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,8 +110,13 @@ jobs:
           export TAG=${GITHUB_REF##*/}
           export IMAGE="quay.io/kairos/core-${{ matrix.flavor }}"
           docker push "$IMAGE:$TAG"
-          cosign sign $(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
-
+          image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
+          cosign sign $image_ref
+          spdx=$(ls release/*.spdx.json)
+          sbom=$(cosign attach sbom --sbom $spdx $image_ref 2>&1 | grep "Uploading SBOM" | awk '{print $7}' | sed 's/\[//g;s/\]//g')
+          cosign sign $sbom
+          # in-toto attestation
+          cosign attest --type spdx --predicate $spdx $image_ref
       - name: Sign ISO sha files
         env:
           COSIGN_YES: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,8 +113,8 @@ jobs:
           image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
           cosign sign $image_ref
           spdx=$(ls release/*.spdx.json)
-          sbom=$(cosign attach sbom --sbom $spdx $image_ref 2>&1 | grep "Uploading SBOM" | awk '{print $7}' | sed 's/\[//g;s/\]//g')
-          cosign sign $sbom
+          cosign attach sbom --sbom $spdx $image_ref
+          cosign sign ${image_ref}.sbom
           # in-toto attestation
           cosign attest --type spdx --predicate $spdx $image_ref
       - name: Sign ISO sha files


### PR DESCRIPTION
Attempt to fix: #1228 and #1055

I don't really like this bashism, but there seems to be no better way at the moment. Cosign attach sbom generates a new image - and the only way to get it's digest is parsing cosign output :shrug: 

Open to other solutions, but so far didn't had luck with other approaches, this is the output of `cosign attach sbom`:

```
WARNING: Attaching SBOMs this way does not sign them. If you want to sign them, use 'cosign attest --predicate core-alpine-arm-rpi-v2.0.0-alpha3-sbom.spdx.json --key <key path>' or 'cosign s
ign --key <key path> --attachment sbom <image uri>'.                                                                                                                                          
Uploading SBOM file for [quay.io/mudler/tests:sbom] to [quay.io/mudler/tests:sha256-b6ca290b6b4cdcca5b3db3ffa338ee0285c11744b4a6abaa9627746ee3291d8d.sbom] with mediaType [text/spdx+json].                                                                                                                                                    
```

which is, by the way, printed to STDERR (hence why the redirection).

I refrained to inspect docker, as there is no clear way to distinguish the images generated at this point ( we would have the signatures and the sbom, that are two sep. images)
