### PR TITLE
:robot: Disable push from Earthly for framework images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
                 http = true
           EOF
           export TAG=${GITHUB_REF##*/}
-          earthly --push +build-framework-image --FLAVOR=${FLAVOR}
+          earthly +build-framework-image --FLAVOR=${FLAVOR}
       - name: Push to quay
         env:
           COSIGN_YES: true


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1240 

Seems we already push with docker in the step right afterwards