### PR TITLE
:bug: Add a netlify redirect for /docs/contribution-guidlines/

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,17 +1,6 @@
 # Hugo build configuration for Netlify
 # (https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify)
 
-[build]
-publish = "userguide/public"
-command = "npm run docs-install && npm run build:preview"
-
-[build.environment]
-GO_VERSION = "1.19.2"
-HUGO_THEME = "repo"
-
-[context.production]
-command = "npm run docs-install && npm run build:production"
-
 [[redirects]]
 from = "/docs/contribution-guidelines/"
 to = "https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,21 @@
+# Hugo build configuration for Netlify
+# (https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify)
+
+[build]
+publish = "userguide/public"
+command = "npm run docs-install && npm run build:preview"
+
+[build.environment]
+GO_VERSION = "1.19.2"
+HUGO_THEME = "repo"
+
+[context.production]
+command = "npm run docs-install && npm run build:production"
+
+[[redirects]]
+from = "/docs/contribution-guidelines/"
+to = "https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md"
+status = 200
+force = true # COMMENT: ensure that we always redirect
+headers = {X-From = "Netlify"}
+signed = "API_SIGNATURE_TOKEN"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

Docsy comes with the /docs/community-guidlines/ url as part of the theme. I thought it would be much easier just to add a redirect in netlify than re-define the whole layout

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1301
