### PR TITLE
:bug: Fix rpi initrd not being linked

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -350,7 +350,7 @@ base-image:
     END
 
 
-    IF [[ "$FLAVOR" =~ ^alpine.* ]] || [[ "$FLAVOR" =~ .*-arm-rpi$ ]]
+    IF [[ "$FLAVOR" =~ ^alpine.* ]]
         # no dracut on those flavors, do nothing
     ELSE
         # Regenerate initrd if necessary


### PR DESCRIPTION
Looks like I added the skip to the rpi images but those have dracut and we should use that to generate the initrd and link it

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1300 
