### PR TITLE
:bug: Ensure data source is ready during reset

### DIFF
--- a/internal/agent/reset.go
+++ b/internal/agent/reset.go
@@ -64,6 +64,8 @@ func Reset(dir ...string) error {
 	lock.Lock()
 	args := []string{"reset"}
 
+	ensureDataSourceReady()
+
 	bus.Manager.Publish(sdk.EventBeforeReset, sdk.EventPayload{}) //nolint:errcheck
 
 	optsArgs := optsToArgs(options)
@@ -96,7 +98,9 @@ func Reset(dir ...string) error {
 
 	bus.Manager.Publish(sdk.EventAfterReset, sdk.EventPayload{}) //nolint:errcheck
 
-	pterm.Info.Println("Rebooting in 60 seconds, press Enter to abort...")
+	if !agentConfig.Fast {
+		pterm.Info.Println("Rebooting in 60 seconds, press Enter to abort...")
+	}
 
 	// We don't close the lock, as none of the following actions are expected to return
 	lock2 := sync.Mutex{}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1178 
