### PR TITLE
:bug: Add missing lvm packages in fedora+rockylinux

### DIFF
--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -87,9 +87,9 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20230416074937-repository.yaml
+    reference: 20230420084320-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20230416080502-repository.yaml
+    reference: 20230420090242-repository.yaml

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -34,6 +34,7 @@ RUN dnf install -y \
     kernel-modules \
     kernel-modules-extra \
     livecd-tools \
+    lvm2 \
     nano \
     NetworkManager \
     openssh-server \

--- a/images/Dockerfile.rockylinux
+++ b/images/Dockerfile.rockylinux
@@ -33,6 +33,7 @@ RUN dnf install -y \
     kernel-modules \
     kernel-modules-extra \
     livecd-tools \
+    lvm2 \
     nano \
     NetworkManager \
     openssh-server \


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
immucore v0.17.0 now needs the lvm module in the initramfs, so all distros need it installed so it can inject it

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1330
