### PR TITLE
:sparkles: Allow showing pre-releases on upgrade options

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -68,6 +68,7 @@ var cmds = []*cli.Command{
 			&cli.StringFlag{Name: "auth-type", Usage: "Auth type"},
 			&cli.StringFlag{Name: "auth-registry-token", Usage: "Authentication registry token"},
 			&cli.StringFlag{Name: "auth-identity-token", Usage: "Authentication identity token"},
+			&cli.BoolFlag{Name: "pre", Usage: "Include pre-releases (rc, beta, alpha)"},
 		},
 		Description: `
 Manually upgrade a kairos node.
@@ -90,11 +91,12 @@ See https://kairos.io/docs/upgrade/manual/ for documentation.
 						Name:  "output",
 						Usage: "Output format (json|yaml|terminal)",
 					},
+					&cli.BoolFlag{Name: "pre", Usage: "Include pre-releases (rc, beta, alpha)"},
 				},
 				Name:        "list-releases",
 				Description: `List all available releases versions`,
 				Action: func(c *cli.Context) error {
-					releases := agent.ListReleases()
+					releases := agent.ListReleases(c.Bool("pre"))
 					list := ReleasesToOutput(releases, c.String("output"))
 					for _, i := range list {
 						fmt.Println(i)
@@ -116,6 +118,7 @@ See https://kairos.io/docs/upgrade/manual/ for documentation.
 				c.Bool("strict-validation"), configScanDir,
 				c.String("auth-username"), c.String("auth-password"), c.String("auth-server-address"),
 				c.String("auth-type"), c.String("auth-registry-token"), c.String("auth-identity-token"),
+				c.Bool("pre"),
 			)
 		},
 	},

--- a/pkg/github/releases_test.go
+++ b/pkg/github/releases_test.go
@@ -16,7 +16,16 @@ func TestReleases(t *testing.T) {
 
 var _ = Describe("Releases", func() {
 	It("can find the proper releases in order", func() {
-		releases, err := github.FindReleases(context.Background(), "", "kairos-io/kairos")
+		releases, err := github.FindReleases(context.Background(), "", "kairos-io/kairos", false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(releases)).To(BeNumerically(">", 0))
+		// Expect the one at the bottom to be the first "real" release of kairos
+		Expect(releases[len(releases)-1].Original()).To(Equal("v1.0.0"))
+		// Expect the first one to be greater than the last one
+		Expect(releases[0].GreaterThan(releases[len(releases)-1]))
+	})
+	It("can find the proper releases in order with prereleases", func() {
+		releases, err := github.FindReleases(context.Background(), "", "kairos-io/kairos", true)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(releases)).To(BeNumerically(">", 0))
 		// Expect the one at the bottom to be the first "real" release of kairos


### PR DESCRIPTION
By default get 30 releases and skip any pre-releases found. Allow toggling showing pre-releases both for upgrade and for listing them

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
