### PR TITLE
:robot: Download only the x86 iso for testing

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -269,21 +269,8 @@ jobs:
           # The default value is 'false'
           latest: true
           repository: kairos-io/kairos
-          fileName: '*opensuse-leap*.iso'
+          fileName: '*opensuse-leap-v*.iso'
           out-file-path: last-release
-      - uses: actions/upload-artifact@v3
-        with:
-          name: latest-release.zip
-          path: last-release
-          if-no-files-found: error
-      - uses: robinraju/release-downloader@v1.7
-        with:
-          # A flag to set the download target as latest release
-          # The default value is 'false'
-          latest: true
-          repository: "kairos-io/kairos"
-          fileName: "*opensuse-leap*.iso"
-          out-file-path: "last-release"
       - uses: actions/upload-artifact@v3
         with:
           name: latest-release.zip


### PR DESCRIPTION
As we now have also arm generic images, the download-latest job is now downsloading both isos as they match in name.

Adds a tighter regex to download the proper images

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
