### PR TITLE
:robot: Run jobs on ubuntu-latest instead of self-hosted

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -159,7 +159,7 @@ jobs:
   build-framework:
     needs:
       - get-matrix
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     strategy:
@@ -337,7 +337,7 @@ jobs:
   qemu-bundles-tests:
     needs:
       - build
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -377,7 +377,7 @@ jobs:
   qemu-reset-tests:
     needs:
       - build
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           echo "::set-output name=matrix::{\"include\": $content }"
 
   build-framework:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs:
     - get-matrix
     permissions:


### PR DESCRIPTION
Currently no self-hosted machines available

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
