### PR TITLE
:bug: Fix persistent machine-id

### DIFF
--- a/overlay/files/system/oem/00_rootfs.yaml
+++ b/overlay/files/system/oem/00_rootfs.yaml
@@ -27,14 +27,14 @@ stages:
         VOLUMES: "LABEL=COS_OEM:/oem"
         OVERLAY: "tmpfs:25%"
   initramfs:
-    - if: '[ ! -f "/run/cos/recovery_mode" ]'
-      name: "Persist /etc/machine-id"
+    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ -s /usr/local/etc/machine-id ]'
+      name: "Restore /etc/machine-id"
+      commands:
+        - cat /usr/local/etc/machine-id > /etc/machine-id
+  fs:
+    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ ! -s /usr/local/etc/machine-id ] '
+      name: "Save /etc/machine-id"
       commands:
       - |
-        # persist machine-id
-        if [ -s /usr/local/etc/machine-id ]; then
-          cat /usr/local/etc/machine-id > /etc/machine-id
-        else
-          mkdir -p /usr/local/etc
-          cp /etc/machine-id /usr/local/etc
-        fi
+        mkdir -p /usr/local/etc
+        cp /etc/machine-id /usr/local/etc


### PR DESCRIPTION


<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Looks like we were doing it on the same stage which made no sense as by that time there may not be a machine-id yet.

Now the machine id is splitted in two. If we have a stored machine ID, during initramfs we copy it over /etc so systemd doesnt recreate one and during fs if we dont have a stored machien id, we save the one generated.

This results in the machine-id being persistent across reboots and as a side effect things like getting the same dhcp ip on reboot now works out of the box.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1381 
