### PR TITLE
:robot: Setup go cache and go version properly

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -245,7 +245,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: ^1.20
+          go-version-file: tests/go.mod
+          cache-dependency-path: tests/go.sum
       - run: |
           export ISO=$PWD/$(ls *.iso)
           export GOPATH="/Users/runner/go"
@@ -598,7 +599,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: ^1.20
+          go-version-file: tests/go.mod
+          cache-dependency-path: tests/go.sum
       - name: Deps
         run: |
           sudo apt update && \

--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -18,10 +18,6 @@ jobs:
           fetch-depth: 0
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ^1.20
       - name: Install earthly
         uses: Luet-lab/luet-install-action@v1
         with:


### PR DESCRIPTION
This uses the go action to pick up the go versions from the go.mod and the cache from the go.sum files.

as the only thing running go in the CI is the tests, that way they will be properly synced.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
