### PR TITLE
:penguin: Use latest for fedora images

### DIFF
--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=fedora:latest
 FROM $BASE_IMAGE
 
 RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
-RUN dnf install -y "https://zfsonlinux.org/fedora/zfs-release-2-2$(rpm --eval "%{dist}").noarch.rpm" && dnf clean all
+RUN dnf install -y "https://zfsonlinux.org/fedora/zfs-release-2-3$(rpm --eval "%{dist}").noarch.rpm" && dnf clean all
 RUN dnf install -y \
     NetworkManager \
     squashfs-tools \

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=fedora:36
+# latest is the last stable release, does not include rawhide
+ARG BASE_IMAGE=fedora:latest
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Bumps fedora from 36 to 38 and uses the latest tag so we don't have to be updating it every time there's a new release

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1431
