### PR TITLE
:penguin: Add Jetson agx orin image

### DIFF
--- a/.github/flavors-arm.json
+++ b/.github/flavors-arm.json
@@ -22,5 +22,9 @@
     {
         "flavor": "ubuntu-22-lts-arm-rpi",
         "model": "rpi64"
+    },
+    {
+        "flavor": "ubuntu-20-lts-arm-nvidia-jetson-agx-orin",
+        "model": "none"
     }
 ]

--- a/.github/flavors-arm.json
+++ b/.github/flavors-arm.json
@@ -1,30 +1,37 @@
 [
     {
        "flavor": "opensuse-leap-arm-rpi",
-       "model": "rpi64"
+       "model": "rpi64",
+       "worker": "ubuntu-latest"
     },
     {
         "flavor": "opensuse-tumbleweed-arm-rpi",
-        "model": "rpi64"
+        "model": "rpi64",
+        "worker": "ubuntu-latest"
     },
     {
         "flavor": "alpine-arm-rpi",
-        "model": "rpi64"
+        "model": "rpi64",
+        "worker": "ubuntu-latest"
     },
     {
         "flavor": "ubuntu-arm-rpi",
-        "model": "rpi64"
+        "model": "rpi64",
+        "worker": "ubuntu-latest"
     },
     {
         "flavor": "ubuntu-20-lts-arm-rpi",
-        "model": "rpi64"
+        "model": "rpi64",
+        "worker": "ubuntu-latest"
     },
     {
         "flavor": "ubuntu-22-lts-arm-rpi",
-        "model": "rpi64"
+        "model": "rpi64",
+        "worker": "ubuntu-latest"
     },
     {
         "flavor": "ubuntu-20-lts-arm-nvidia-jetson-agx-orin",
-        "model": "none"
+        "model": "none",
+        "worker": "self-hosted"
     }
 ]

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -86,7 +86,7 @@ jobs:
                 insecure = true
                 http = true
           EOF
-          earthly -P +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR
+          docker run --privileged -v $HOME/.earthly/config.yml:/etc/.earthly/config.yml -v /var/run/docker.sock:/var/run/docker.sock --rm --env EARTHLY_BUILD_ARGS -t -v "$(pwd)":/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.7.5 --allow-privileged +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR
       - name: Push  🔧
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         env:

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -65,12 +65,19 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
+      - name: Install earthly
+        uses: Luet-lab/luet-install-action@v1
+        with:
+          repository: quay.io/kairos/packages
+          packages: utils/earthly
       - name: Build  🔧
         env:
           FLAVOR: ${{ matrix.flavor }}
           MODEL: ${{ matrix.model }}
         run: |
-          ./earthly.sh +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR
+          earthly config "global.conversion_parallelism" "1"
+          earthly config "global.buildkit_max_parallelism" "1"
+          earthly -P +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR
       - name: Push  🔧
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         env:

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -71,6 +71,7 @@ jobs:
           FLAVOR: ${{ matrix.flavor }}
           MODEL: ${{ matrix.model }}
         run: |
+          # Lower Earthly parallelism: earthly seems to fail hardly when transfering over big files
           earthly config "global.conversion_parallelism" "1"
           earthly config "global.buildkit_max_parallelism" "1"
           earthly -P +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -36,7 +36,7 @@ jobs:
   docker:
     needs:
     - get-matrix
-    runs-on: self-hosted
+    runs-on: ${{ matrix.worker }}
     permissions:
       id-token: write  # OIDC support
       contents: write
@@ -66,14 +66,19 @@ jobs:
         with:
           repository: quay.io/kairos/packages
           packages: utils/earthly
-      - name: Build  🔧
+      - name: Standard Build  🔧
+        if: ${{ matrix.worker != 'self-hosted' }}
         env:
           FLAVOR: ${{ matrix.flavor }}
           MODEL: ${{ matrix.model }}
         run: |
-          # Lower Earthly parallelism: earthly seems to fail hardly when transfering over big files
-          earthly config "global.conversion_parallelism" "1"
-          earthly config "global.buildkit_max_parallelism" "1"
+          ./earthly.sh +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR
+      - name: Selfhosted Build  🔧
+        if: ${{ matrix.worker == 'self-hosted' }}
+        env:
+          FLAVOR: ${{ matrix.flavor }}
+          MODEL: ${{ matrix.model }}
+        run: |
           # Configure earthly to use the docker mirror in CI
           # https://docs.earthly.dev/ci-integration/pull-through-cache#configuring-earthly-to-use-the-cache
           mkdir -p ~/.earthly/

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -74,6 +74,18 @@ jobs:
           # Lower Earthly parallelism: earthly seems to fail hardly when transfering over big files
           earthly config "global.conversion_parallelism" "1"
           earthly config "global.buildkit_max_parallelism" "1"
+          # Configure earthly to use the docker mirror in CI
+          # https://docs.earthly.dev/ci-integration/pull-through-cache#configuring-earthly-to-use-the-cache
+          mkdir -p ~/.earthly/
+          cat << EOF > ~/.earthly/config.yml
+          global:
+            buildkit_additional_config: |
+              [registry."docker.io"]
+                mirrors = ["registry.docker-mirror.svc.cluster.local:5000"]
+              [registry."registry.docker-mirror.svc.cluster.local:5000"]
+                insecure = true
+                http = true
+          EOF
           earthly -P +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR
       - name: Push  🔧
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -36,7 +36,7 @@ jobs:
   docker:
     needs:
     - get-matrix
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       id-token: write  # OIDC support
       contents: write
@@ -46,44 +46,6 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.get-matrix.outputs.matrix)}}
     steps:
-
-      - name: Release space from worker
-        run: |
-          echo "Listing top largest packages"
-          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
-          head -n 30 <<< "${pkgs}"
-          echo
-          df -h
-          echo
-          sudo apt-get remove -y '^llvm-.*|^libllvm.*' || true
-          sudo apt-get remove --auto-remove android-sdk-platform-tools || true
-          sudo apt-get purge --auto-remove android-sdk-platform-tools || true
-          sudo rm -rf /usr/local/lib/android
-          sudo apt-get remove -y '^dotnet-.*|^aspnetcore-.*' || true
-          sudo rm -rf /usr/share/dotnet
-          sudo apt-get remove -y '^mono-.*' || true
-          sudo apt-get remove -y '^ghc-.*' || true
-          sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
-          sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
-          sudo apt-get remove -y '^google-.*' || true
-          sudo apt-get remove -y azure-cli || true
-          sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
-          sudo apt-get remove -y '^gfortran-.*' || true
-          sudo apt-get remove -y microsoft-edge-stable humanity-icon-theme buildah skopeo podman vim-runtime firefox gcc-12 cpp-12 powershell gcc-11 gcc-10 g++-9 gcc-9 g++-11 cpp-9 g++-10 r-base-core gh snapd || true
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-          echo
-          echo "Listing top largest packages"
-          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
-          head -n 30 <<< "${pkgs}"
-          echo
-          sudo rm -rfv build || true
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf "/usr/local/share/boost" || true
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-          df -h
       - uses: actions/checkout@v3
       - run: |
           git fetch --prune --unshallow

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -46,6 +46,39 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.get-matrix.outputs.matrix)}}
     steps:
+      - name: Release space from worker
+        if: ${{ matrix.worker != 'self-hosted' }}
+        run: |
+          echo "Listing top largest packages"
+          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
+          head -n 30 <<< "${pkgs}"
+          echo
+          df -h
+          echo
+          sudo apt-get remove -y '^llvm-.*|^libllvm.*' || true
+          sudo apt-get remove --auto-remove android-sdk-platform-tools || true
+          sudo apt-get purge --auto-remove android-sdk-platform-tools || true
+          sudo rm -rf /usr/local/lib/android
+          sudo apt-get remove -y '^dotnet-.*|^aspnetcore-.*' || true
+          sudo rm -rf /usr/share/dotnet
+          sudo apt-get remove -y '^mono-.*' || true
+          sudo apt-get remove -y '^ghc-.*' || true
+          sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
+          sudo apt-get remove -y 'php.*' || true
+          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y '^google-.*' || true
+          sudo apt-get remove -y azure-cli || true
+          sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
+          sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+          echo
+          echo "Listing top largest packages"
+          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
+          head -n 30 <<< "${pkgs}"
+          echo
+          sudo rm -rfv build || true
+          df -h
       - uses: actions/checkout@v3
       - run: |
           git fetch --prune --unshallow

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -46,10 +46,44 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.get-matrix.outputs.matrix)}}
     steps:
+
       - name: Release space from worker
         run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+          echo "Listing top largest packages"
+          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
+          head -n 30 <<< "${pkgs}"
+          echo
+          df -h
+          echo
+          sudo apt-get remove -y '^llvm-.*|^libllvm.*' || true
+          sudo apt-get remove --auto-remove android-sdk-platform-tools || true
+          sudo apt-get purge --auto-remove android-sdk-platform-tools || true
+          sudo rm -rf /usr/local/lib/android
+          sudo apt-get remove -y '^dotnet-.*|^aspnetcore-.*' || true
+          sudo rm -rf /usr/share/dotnet
+          sudo apt-get remove -y '^mono-.*' || true
+          sudo apt-get remove -y '^ghc-.*' || true
+          sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
+          sudo apt-get remove -y 'php.*' || true
+          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y '^google-.*' || true
+          sudo apt-get remove -y azure-cli || true
+          sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
+          sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y microsoft-edge-stable humanity-icon-theme buildah skopeo podman vim-runtime firefox gcc-12 cpp-12 powershell gcc-11 gcc-10 g++-9 gcc-9 g++-11 cpp-9 g++-10 r-base-core gh snapd || true
+          sudo apt-get autoremove -y
+          sudo apt-get clean
+          echo
+          echo "Listing top largest packages"
+          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
+          head -n 30 <<< "${pkgs}"
+          echo
+          sudo rm -rfv build || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf "/usr/local/share/boost" || true
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
+          df -h
       - uses: actions/checkout@v3
       - run: |
           git fetch --prune --unshallow

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -57,12 +57,34 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
       - name: Build  🔧
+        if: ${{ matrix.worker != 'self-hosted' }}
         env:
           FLAVOR: ${{ matrix.flavor }}
           MODEL: ${{ matrix.model }}
         run: |
           export TAG=${GITHUB_REF##*/}
           ./earthly.sh +all-arm --IMAGE_NAME=kairos-$FLAVOR-$TAG.img --IMAGE=quay.io/kairos/core-$FLAVOR:$TAG --MODEL=$MODEL --FLAVOR=$FLAVOR
+      - name: Selfhosted Build  🔧
+        if: ${{ matrix.worker == 'self-hosted' }}
+        env:
+          FLAVOR: ${{ matrix.flavor }}
+          MODEL: ${{ matrix.model }}
+        run: |
+          # Configure earthly to use the docker mirror in CI
+          # https://docs.earthly.dev/ci-integration/pull-through-cache#configuring-earthly-to-use-the-cache
+          mkdir -p ~/.earthly/
+          cat << EOF > ~/.earthly/config.yml
+          global:
+            buildkit_additional_config: |
+              [registry."docker.io"]
+                mirrors = ["registry.docker-mirror.svc.cluster.local:5000"]
+              [registry."registry.docker-mirror.svc.cluster.local:5000"]
+                insecure = true
+                http = true
+          EOF
+          export TAG=${GITHUB_REF##*/}
+          docker run --privileged -v $HOME/.earthly/config.yml:/etc/.earthly/config.yml -v /var/run/docker.sock:/var/run/docker.sock --rm --env EARTHLY_BUILD_ARGS -t -v "$(pwd)":/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.7.5 --allow-privileged +all-arm --IMAGE_NAME=kairos-$FLAVOR-$TAG.img --IMAGE=quay.io/kairos/core-$FLAVOR:$TAG --MODEL=$MODEL --FLAVOR=$FLAVOR
+
       - name: Push  🔧
         env:
           FLAVOR: ${{ matrix.flavor }}

--- a/Earthfile
+++ b/Earthfile
@@ -222,6 +222,9 @@ framework:
         COPY overlay/files-ubuntu-arm-rpi/ /framework
     END
 
+    IF [[ "$FLAVOR" = "ubuntu-20-lts-arm-nvidia-jetson" ]]
+        COPY overlay/files-nvidia/ /framework
+    END
     SAVE ARTIFACT --keep-own /framework/ framework
 
 build-framework-image:

--- a/Earthfile
+++ b/Earthfile
@@ -57,6 +57,10 @@ all-arm:
   END
   BUILD +arm-image --MODEL=rpi64
 
+arm-container-image:
+  ARG MODEL
+  BUILD --platform=linux/arm64 +image --MODEL=$MODEL
+
 all-arm-generic:
   BUILD --platform=linux/arm64 +image --MODEL=generic
   BUILD --platform=linux/arm64 +iso --MODEL=generic

--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -18,6 +18,9 @@ flavors:
   ubuntu-arm-rpi:
     - systemd-base
     - dracut-network-legacy
+  ubuntu-20-lts-arm-nvidia-jetson:
+    - systemd-base
+    - dracut-network-legacy-compat
   ubuntu-20-lts-arm-rpi:
     - systemd-base
     - dracut-network-legacy-compat

--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -18,7 +18,7 @@ flavors:
   ubuntu-arm-rpi:
     - systemd-base
     - dracut-network-legacy
-  ubuntu-20-lts-arm-nvidia-jetson:
+  ubuntu-20-lts-arm-nvidia-jetson-agx-orin:
     - systemd-base
     - dracut-network-legacy-compat
   ubuntu-20-lts-arm-rpi:

--- a/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson
+++ b/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson
@@ -1,0 +1,124 @@
+FROM ubuntu:20.04 as base
+
+RUN apt update
+RUN apt install -y ca-certificates
+
+RUN apt install -y sudo
+RUN apt install -y ssh
+RUN apt install -y netplan.io
+
+# resizerootfs
+RUN apt install -y udev
+RUN apt install -y parted
+
+# ifconfig
+RUN apt install -y net-tools
+
+# needed by knod-static-nodes to create a list of static device nodes
+RUN apt install -y kmod
+
+# Install our resizerootfs service
+#COPY root/etc/systemd/ /etc/systemd
+
+#RUN systemctl enable resizerootfs
+RUN systemctl enable ssh
+RUN systemctl enable systemd-networkd
+
+RUN mkdir -p /opt/nvidia/l4t-packages
+RUN touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
+#jetson origin 
+ARG BOARD_MODEL=t234 
+ARG FRAMEWORK_VERSION=35.3
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
+
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-key https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
+    RUN add-apt-repository "deb https://repo.download.nvidia.com/jetson/common r$FRAMEWORK_VERSION main"
+        RUN add-apt-repository "deb https://repo.download.nvidia.com/jetson/$BOARD_MODEL r$FRAMEWORK_VERSION main"
+
+#RUN echo "deb [signed-by=/usr/share/keyrings/nvidia-l4t-archive-keyring.asc] https://repo.download.nvidia.com/jetson/common r$FRAMEWORK_VERSION main" >> /etc/apt/sources.list.d/nvidia-l4t.list
+#RUN echo "deb [signed-by=/usr/share/keyrings/nvidia-l4t-archive-keyring.asc] https://repo.download.nvidia.com/jetson/$BOARD_MODEL r$FRAMEWORK_VERSION main" >> /etc/apt/sources.list.d/nvidia-l4t.list
+#RUN echo "deb http://ports.ubuntu.com/ubuntu-ports/ bionic main" >> /etc/apt/sources.list.d/bionic.list
+
+
+RUN apt update
+
+# nv-l4t-usb-device-mode
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    bridge-utils \
+    conntrack \
+    console-data \
+    coreutils \
+    cryptsetup \
+    curl \
+    debianutils \
+    dmsetup \
+    dosfstools \
+    dracut \
+    dracut-network \
+    e2fsprogs \
+    efibootmgr \
+    file \
+    fuse \
+    gawk \
+    grub-efi-arm64-bin \
+    grub2-common \
+    haveged \
+    iproute2 \
+    iptables \
+    isc-dhcp-common \
+    jq \
+    kbd \
+    krb5-locales \
+    lldpd \
+    lvm2 \
+    mdadm \
+    nbd-client \
+    ncurses-term \
+    networkd-dispatcher \
+    nfs-common \
+    open-iscsi \
+    open-vm-tools \
+    openssh-server \
+    os-prober \
+    packagekit-tools \
+    parted \
+    policykit-1 \
+    publicsuffix \
+    rsync \
+    shared-mime-info \
+    snmpd \
+    squashfs-tools \
+    sudo \
+    systemd \
+    systemd-timesyncd \
+    xdg-user-dirs \
+    xxd \
+    xz-utils
+
+# https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%20Linux%20Driver%20Package%20Development%20Guide/updating_jetson_and_host.html
+RUN apt install -y -o Dpkg::Options::="--force-overwrite" \
+    nvidia-l4t-core \
+    nvidia-l4t-init \
+    nvidia-l4t-bootloader \
+    nvidia-l4t-camera \
+    nvidia-l4t-initrd \
+    nvidia-l4t-xusb-firmware \
+    nvidia-l4t-kernel \
+    nvidia-l4t-kernel-dtbs \
+    nvidia-l4t-kernel-headers \
+    nvidia-l4t-cuda \
+    jetson-gpio-common \
+    python3-jetson-gpio
+
+RUN rm -rf /opt/nvidia/l4t-packages
+RUN rm -rf /var/lib/apt/lists/*
+#COPY root/ /
+
+RUN useradd -ms /bin/bash jetson
+RUN echo 'jetson:jetson' | chpasswd
+
+RUN usermod -a -G sudo jetson

--- a/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
+++ b/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
@@ -17,16 +17,12 @@ RUN apt install -y net-tools
 # needed by knod-static-nodes to create a list of static device nodes
 RUN apt install -y kmod
 
-# Install our resizerootfs service
-#COPY root/etc/systemd/ /etc/systemd
-
-#RUN systemctl enable resizerootfs
 RUN systemctl enable ssh
 RUN systemctl enable systemd-networkd
 
 RUN mkdir -p /opt/nvidia/l4t-packages
 RUN touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
-#jetson origin 
+#jetson orin 
 ARG BOARD_MODEL=t234 
 ARG FRAMEWORK_VERSION=35.3
 
@@ -35,18 +31,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
 RUN apt-key adv --fetch-key https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
-    RUN add-apt-repository "deb https://repo.download.nvidia.com/jetson/common r$FRAMEWORK_VERSION main"
-        RUN add-apt-repository "deb https://repo.download.nvidia.com/jetson/$BOARD_MODEL r$FRAMEWORK_VERSION main"
-
-#RUN echo "deb [signed-by=/usr/share/keyrings/nvidia-l4t-archive-keyring.asc] https://repo.download.nvidia.com/jetson/common r$FRAMEWORK_VERSION main" >> /etc/apt/sources.list.d/nvidia-l4t.list
-#RUN echo "deb [signed-by=/usr/share/keyrings/nvidia-l4t-archive-keyring.asc] https://repo.download.nvidia.com/jetson/$BOARD_MODEL r$FRAMEWORK_VERSION main" >> /etc/apt/sources.list.d/nvidia-l4t.list
-#RUN echo "deb http://ports.ubuntu.com/ubuntu-ports/ bionic main" >> /etc/apt/sources.list.d/bionic.list
-
+RUN add-apt-repository "deb https://repo.download.nvidia.com/jetson/common r$FRAMEWORK_VERSION main"
+RUN add-apt-repository "deb https://repo.download.nvidia.com/jetson/$BOARD_MODEL r$FRAMEWORK_VERSION main"
 
 RUN apt update
 
 # nv-l4t-usb-device-mode
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     bridge-utils \
     conntrack \
@@ -114,11 +104,8 @@ RUN apt install -y -o Dpkg::Options::="--force-overwrite" \
     jetson-gpio-common \
     python3-jetson-gpio
 
-RUN rm -rf /opt/nvidia/l4t-packages
-RUN rm -rf /var/lib/apt/lists/*
-#COPY root/ /
-
-RUN useradd -ms /bin/bash jetson
-RUN echo 'jetson:jetson' | chpasswd
-
-RUN usermod -a -G sudo jetson
+# RUN rm -rf /opt/nvidia/l4t-packages
+# RUN rm -rf /var/lib/apt/lists/*
+# RUN useradd -ms /bin/bash jetson
+# RUN echo 'jetson:jetson' | chpasswd
+# RUN usermod -a -G sudo jetson

--- a/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
+++ b/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
@@ -1,21 +1,21 @@
 FROM ubuntu:20.04 as base
 
-RUN apt update
-RUN apt install -y ca-certificates
+RUN apt-get update
+RUN apt-get install -y ca-certificates
 
-RUN apt install -y sudo
-RUN apt install -y ssh
-RUN apt install -y netplan.io
+RUN apt-get install -y sudo
+RUN apt-get install -y ssh
+RUN apt-get install -y netplan.io
 
 # resizerootfs
-RUN apt install -y udev
-RUN apt install -y parted
+RUN apt-get install -y udev
+RUN apt-get install -y parted
 
 # ifconfig
-RUN apt install -y net-tools
+RUN apt-get install -y net-tools
 
 # needed by knod-static-nodes to create a list of static device nodes
-RUN apt install -y kmod
+RUN apt-get install -y kmod
 
 RUN systemctl enable ssh
 RUN systemctl enable systemd-networkd
@@ -34,7 +34,7 @@ RUN apt-key adv --fetch-key https://repo.download.nvidia.com/jetson/jetson-ota-p
 RUN add-apt-repository "deb https://repo.download.nvidia.com/jetson/common r$FRAMEWORK_VERSION main"
 RUN add-apt-repository "deb https://repo.download.nvidia.com/jetson/$BOARD_MODEL r$FRAMEWORK_VERSION main"
 
-RUN apt update
+RUN apt-get update
 
 # nv-l4t-usb-device-mode
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -90,7 +90,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     xz-utils
 
 # https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%20Linux%20Driver%20Package%20Development%20Guide/updating_jetson_and_host.html
-RUN apt install -y -o Dpkg::Options::="--force-overwrite" \
+RUN apt-get install -y -o Dpkg::Options::="--force-overwrite" \
     nvidia-l4t-core \
     nvidia-l4t-init \
     nvidia-l4t-bootloader \

--- a/overlay/files-nvidia/etc/cos/bootargs.cfg
+++ b/overlay/files-nvidia/etc/cos/bootargs.cfg
@@ -1,0 +1,9 @@
+set kernel=/boot/vmlinuz
+
+if [ -n "$recoverylabel" ]; then
+    set kernelcmd="console=tty1 console=ttyTCU0,115200 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.cos.oemtimeout=10"
+else
+    set kernelcmd="console=tty1 console=ttyTCU0,115200 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux selinux=1 rd.cos.oemtimeout=10 rd.cos.oemlabel=COS_OEM"
+fi
+
+set initramfs=/boot/initrd

--- a/overlay/files-nvidia/etc/dracut.conf.d/iscsi.conf
+++ b/overlay/files-nvidia/etc/dracut.conf.d/iscsi.conf
@@ -1,0 +1,1 @@
+omit_dracutmodules+=" iscsi "


### PR DESCRIPTION
**What this PR does / why we need it**: Adds initial support for Nvidia AGX Orin. Will follow up and iterate with the image hooked from the CI.

The difference with the other flavors is that instead of a flashable SD image, we prepare the partitions .img files that are ready to be flashed to the eeprom, and we just pack that as part of the releases so others don't have to re-create those images again.

Next:
- Try upgrades
- Create equivalent image in provider-kairos
- Add documentation on how to flash the board with the image files
- See what we can do about resets https://github.com/kairos-io/kairos/issues/622 

Related to #1395 
