### PR TITLE
Revert ":sparkles: Directly blacklist the vc4 module everywhere"

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -223,6 +223,11 @@ framework:
     # TODO: Make this also a package?
     COPY overlay/files /framework
 
+    # Copy common overlay files for Raspberry Pi
+    IF [ "$MODEL" = "rpi64" ]
+        COPY overlay/files-rpi/ /framework
+    END
+
     # Copy flavor-specific overlay files
     IF [[ "$FLAVOR" =~ ^alpine* ]]
         COPY overlay/files-alpine/ /framework

--- a/overlay/files-rpi/etc/cos/bootargs.cfg
+++ b/overlay/files-rpi/etc/cos/bootargs.cfg
@@ -1,0 +1,18 @@
+set kernel=/boot/vmlinuz
+
+# Note on RPI bootargs
+# We additionally set modprobe.blacklist=vc4 as certain Displays are not supported by vc4.
+# As kairos main target is cloud and not graphics usage, we blacklist it to avoid 
+# that the HDMI output goes off due to drivers kicking during boot. vc4 is required where graphics
+# or video playback is needed, which is not the case in this example here.
+# A similar workaround could be applied at config.txt level, by diabling the vc4 overlay.
+# See also: https://en.opensuse.org/HCL:Raspberry_Pi3#I_see_HDMI_output_in_U-Boot.2C_but_not_in_Linux ,
+# https://en.opensuse.org/HCL:Raspberry_Pi3#DSI_output_not_supported_by_VC4_driver,
+# https://bugzilla.opensuse.org/show_bug.cgi?id=1181683 and https://github.com/raspberrypi/linux/issues/4020
+if [ -n "$recoverylabel" ]; then
+    set kernelcmd="console=tty1 console=ttyS0,115200 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 modprobe.blacklist=vc4 rd.cos.oemtimeout=10"
+else
+    set kernelcmd="console=tty1 console=ttyS0,115200 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux selinux=1 modprobe.blacklist=vc4 rd.cos.oemtimeout=10 rd.cos.oemlabel=COS_OEM"
+fi
+
+set initramfs=/boot/initrd

--- a/overlay/files/etc/modprobe.d/vc4-blacklist.conf
+++ b/overlay/files/etc/modprobe.d/vc4-blacklist.conf
@@ -1,9 +1,0 @@
-# We additionally blacklist=vc4 as certain Displays are not supported by vc4.
-# As kairos main target is cloud and not graphics usage, we blacklist it to avoid
-# that the HDMI output goes off due to drivers kicking during boot. vc4 is required where graphics
-# or video playback is needed, which is not the case in this example here.
-# A similar workaround could be applied at config.txt level, by diabling the vc4 overlay.
-# See also: https://en.opensuse.org/HCL:Raspberry_Pi3#I_see_HDMI_output_in_U-Boot.2C_but_not_in_Linux ,
-# https://en.opensuse.org/HCL:Raspberry_Pi3#DSI_output_not_supported_by_VC4_driver,
-# https://bugzilla.opensuse.org/show_bug.cgi?id=1181683 and https://github.com/raspberrypi/linux/issues/4020
-blacklist vc4


### PR DESCRIPTION
Reverts kairos-io/kairos#1443