### PR TITLE
:robot: Build and publish ubuntu arm generic

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -171,13 +171,12 @@ jobs:
           if-no-files-found: error
   image_and_iso_arm64_generic:
     runs-on: ubuntu-latest
-    needs:
-      - get-matrix
     strategy:
       fail-fast: false
       matrix:
         flavor:
           - "opensuse-leap"
+          - "ubuntu"
     steps:
       - uses: actions/checkout@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -170,13 +170,12 @@ jobs:
           category: ${{ matrix.flavor }}
   image_and_iso_arm64_generic:
     runs-on: ubuntu-latest
-    needs:
-      - get-matrix
     strategy:
       fail-fast: false
       matrix:
         flavor:
           - "opensuse-leap"
+          - "ubuntu"
     steps:
       - uses: actions/checkout@v3
       - name: Install earthly


### PR DESCRIPTION
Currently, we only release the opensuse-leap, but we can already build ubuntu and maybe others too? Not sure if we want to provide all flavors also as generic, I know this adds to the build time, but my fear would be that if we never test them, they might be in a broken state and we will not notice. So let me know what you think