### PR TITLE
:robot: Use builjet arm workers for arm jobs

### DIFF
--- a/.github/flavors-arm.json
+++ b/.github/flavors-arm.json
@@ -2,36 +2,36 @@
     {
        "flavor": "opensuse-leap-arm-rpi",
        "model": "rpi64",
-       "worker": "ubuntu-latest"
+       "worker": "buildjet-4vcpu-ubuntu-2204-arm"
     },
     {
         "flavor": "opensuse-tumbleweed-arm-rpi",
         "model": "rpi64",
-        "worker": "ubuntu-latest"
+        "worker": "buildjet-4vcpu-ubuntu-2204-arm"
     },
     {
         "flavor": "alpine-arm-rpi",
         "model": "rpi64",
-        "worker": "ubuntu-latest"
+        "worker": "buildjet-4vcpu-ubuntu-2204-arm"
     },
     {
         "flavor": "ubuntu-arm-rpi",
         "model": "rpi64",
-        "worker": "ubuntu-latest"
+        "worker": "buildjet-4vcpu-ubuntu-2204-arm"
     },
     {
         "flavor": "ubuntu-20-lts-arm-rpi",
         "model": "rpi64",
-        "worker": "ubuntu-latest"
+        "worker": "buildjet-4vcpu-ubuntu-2204-arm"
     },
     {
         "flavor": "ubuntu-22-lts-arm-rpi",
         "model": "rpi64",
-        "worker": "ubuntu-latest"
+        "worker": "buildjet-4vcpu-ubuntu-2204-arm"
     },
     {
         "flavor": "ubuntu-20-lts-arm-nvidia-jetson-agx-orin",
         "model": "none",
-        "worker": "self-hosted"
+        "worker": "buildjet-4vcpu-ubuntu-2204-arm"
     }
 ]

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -46,46 +46,9 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.get-matrix.outputs.matrix)}}
     steps:
-      - name: Release space from worker
-        if: ${{ matrix.worker != 'self-hosted' }}
-        run: |
-          echo "Listing top largest packages"
-          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
-          head -n 30 <<< "${pkgs}"
-          echo
-          df -h
-          echo
-          sudo apt-get remove -y '^llvm-.*|^libllvm.*' || true
-          sudo apt-get remove --auto-remove android-sdk-platform-tools || true
-          sudo apt-get purge --auto-remove android-sdk-platform-tools || true
-          sudo rm -rf /usr/local/lib/android
-          sudo apt-get remove -y '^dotnet-.*|^aspnetcore-.*' || true
-          sudo rm -rf /usr/share/dotnet
-          sudo apt-get remove -y '^mono-.*' || true
-          sudo apt-get remove -y '^ghc-.*' || true
-          sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
-          sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
-          sudo apt-get remove -y '^google-.*' || true
-          sudo apt-get remove -y azure-cli || true
-          sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
-          sudo apt-get remove -y '^gfortran-.*' || true
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-          echo
-          echo "Listing top largest packages"
-          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
-          head -n 30 <<< "${pkgs}"
-          echo
-          sudo rm -rfv build || true
-          df -h
       - uses: actions/checkout@v3
       - run: |
           git fetch --prune --unshallow
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
       - name: Login to Quay Registry
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
@@ -97,7 +60,7 @@ jobs:
       - name: Install earthly
         uses: Luet-lab/luet-install-action@v1
         with:
-          repository: quay.io/kairos/packages
+          repository: quay.io/kairos/packages-arm64
           packages: utils/earthly
       - name: Standard Build  🔧
         if: ${{ matrix.worker != 'self-hosted' }}
@@ -185,13 +148,8 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: Luet-lab/luet-install-action@v1
         with:
-          repository: quay.io/kairos/packages
+          repository: quay.io/kairos/packages-arm64
           packages: utils/earthly
-      - name: Set up QEMU
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
       - name: Set up Docker Buildx
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         id: buildx

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -62,32 +62,20 @@ jobs:
         with:
           repository: quay.io/kairos/packages-arm64
           packages: utils/earthly
-      - name: Standard Build  🔧
-        if: ${{ matrix.worker != 'self-hosted' }}
+      - name: Build PR 🔧
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           FLAVOR: ${{ matrix.flavor }}
           MODEL: ${{ matrix.model }}
         run: |
-          ./earthly.sh +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR
-      - name: Selfhosted Build  🔧
-        if: ${{ matrix.worker == 'self-hosted' }}
+          earthly -P +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR --IMG_COMPRESSION=qcow2
+      - name: Build master 🔧
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         env:
           FLAVOR: ${{ matrix.flavor }}
           MODEL: ${{ matrix.model }}
         run: |
-          # Configure earthly to use the docker mirror in CI
-          # https://docs.earthly.dev/ci-integration/pull-through-cache#configuring-earthly-to-use-the-cache
-          mkdir -p ~/.earthly/
-          cat << EOF > ~/.earthly/config.yml
-          global:
-            buildkit_additional_config: |
-              [registry."docker.io"]
-                mirrors = ["registry.docker-mirror.svc.cluster.local:5000"]
-              [registry."registry.docker-mirror.svc.cluster.local:5000"]
-                insecure = true
-                http = true
-          EOF
-          docker run --privileged -v $HOME/.earthly/config.yml:/etc/.earthly/config.yml -v /var/run/docker.sock:/var/run/docker.sock --rm --env EARTHLY_BUILD_ARGS -t -v "$(pwd)":/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.7.5 --allow-privileged +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR
+          earthly -P +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR
       - name: Push  🔧
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         env:

--- a/Earthfile
+++ b/Earthfile
@@ -614,8 +614,8 @@ arm-image:
     RUN /build-arm-image.sh --use-lvm --model $MODEL --directory "/build/image" /build/$IMAGE_NAME
   END
   IF [ "$COMPRESS_IMG" = "true" ]
-      RUN xz -v /build/$IMAGE_NAME
-      SAVE ARTIFACT /build/$IMAGE_NAME.xz img AS LOCAL build/$IMAGE_NAME.xz
+      RUN qemu-img convert -f raw -O qcow2 /build/$IMAGE_NAME /build/${FLAVOR}.qcow2
+      SAVE ARTIFACT /build/${FLAVOR}.qcow2 img AS LOCAL build/${FLAVOR}.qcow2
   ELSE
       SAVE ARTIFACT /build/$IMAGE_NAME img AS LOCAL build/$IMAGE_NAME
   END

--- a/Earthfile
+++ b/Earthfile
@@ -593,6 +593,7 @@ netboot:
 arm-image:
   ARG OSBUILDER_IMAGE
   ARG COMPRESS_IMG=true
+  ARG IMG_COMPRESSION=xz
   FROM $OSBUILDER_IMAGE
   ARG MODEL=rpi64
   ARG IMAGE_NAME=${FLAVOR}.img
@@ -614,8 +615,13 @@ arm-image:
     RUN /build-arm-image.sh --use-lvm --model $MODEL --directory "/build/image" /build/$IMAGE_NAME
   END
   IF [ "$COMPRESS_IMG" = "true" ]
-      RUN qemu-img convert -f raw -O qcow2 /build/$IMAGE_NAME /build/${FLAVOR}.qcow2
-      SAVE ARTIFACT /build/${FLAVOR}.qcow2 img AS LOCAL build/${FLAVOR}.qcow2
+      IF [ "$IMG_COMPRESSION" = "qcow2" ]
+        RUN qemu-img convert -f raw -O qcow2 /build/$IMAGE_NAME /build/${FLAVOR}.qcow2
+        SAVE ARTIFACT /build/${FLAVOR}.qcow2 img AS LOCAL build/${FLAVOR}.qcow2
+      ELSE IF [ "$IMG_COMPRESSION" = "xz" ]
+        RUN xz -v /build/$IMAGE_NAME
+        SAVE ARTIFACT /build/$IMAGE_NAME.xz img AS LOCAL build/$IMAGE_NAME.xz
+      END
   ELSE
       SAVE ARTIFACT /build/$IMAGE_NAME img AS LOCAL build/$IMAGE_NAME
   END


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Runs arm workers on buildjet with native arm64 workers.
Instead of compressing img files, we transform them into qcow2 which are compressed by default, speeding up the build up to 30 minutes.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
