### PR TITLE
:bug: Alpine: Mount bpf system once we boot

### DIFF
--- a/overlay/files/system/oem/00_rootfs.yaml
+++ b/overlay/files/system/oem/00_rootfs.yaml
@@ -13,6 +13,10 @@ stages:
         providers: ["aws", "gcp", "openstack", "cdrom"]
         path: "/oem"
   rootfs:
+    - name: "Mount BPF on Alpine systems"
+      if: '[ ! -e "/sbin/systemctl" ] && [ ! -e "/usr/bin/systemctl" ] && [ ! -e "/usr/sbin/systemctl" ] && [ ! -e "/usr/bin/systemctl" ]'
+      commands:
+        - mount bpffs -o rw,nosuid,nodev,noexec,relatime,mode=700 /sys/fs/bpf -t bpf
     - if: '[ ! -f "/run/cos/recovery_mode" ] &&  [ ! -e "/run/cos/uki_mode" ]'
       name: "Layout configuration for active/passive mode"
       environment_file: /run/cos/cos-layout.env
@@ -153,10 +157,6 @@ stages:
           # Size 0 is required to specify all remaining space
           size: 0
   initramfs:
-    - name: "Mount BPF"
-      if: '[ ! -e "/sbin/systemctl" ] && [ ! -e "/usr/bin/systemctl" ] && [ ! -e "/usr/sbin/systemctl" ] && [ ! -e "/usr/bin/systemctl" ]'
-      commands:
-        - mount bpffs -o rw,nosuid,nodev,noexec,relatime,mode=700 /sys/fs/bpf -t bpf
     - name: "Create journalctl /var/log/journal dir"
       if: '[ -e "/sbin/systemctl" ] || [ -e "/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       directories:


### PR DESCRIPTION

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
initramfs stage runs under a chroot.
If we do the mount in initramfs we are troublemaking the chroot mounts that the stage uses to run the config files. Nothing should be mounted in the binded paths during that stage to avoid issues as after the stage is finished, the chroot is removed fully, so those mounts would get lost.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes k3s issues on provider-kairos
Fixes cgroups for alpine
