### PR TITLE
:arrow_up: Bump osbuilder

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -125,6 +125,10 @@ jobs:
                 http = true
           EOF
           docker run --privileged -v $HOME/.earthly/config.yml:/etc/.earthly/config.yml -v /var/run/docker.sock:/var/run/docker.sock --rm --env EARTHLY_BUILD_ARGS -t -v "$(pwd)":/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.7.5 --allow-privileged +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR
+      - name: Show img sizes
+        run: |
+          ls -ltra build
+          ls -ltrh build
       - name: Push  🔧
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         env:

--- a/Earthfile
+++ b/Earthfile
@@ -20,7 +20,7 @@ END
 ARG COSIGN_EXPERIMENTAL=0
 ARG CGO_ENABLED=0
 # renovate: datasource=docker depName=quay.io/kairos/osbuilder-tools versioning=semver-coerced
-ARG OSBUILDER_VERSION=v0.7.4
+ARG OSBUILDER_VERSION=v0.7.5
 ARG OSBUILDER_IMAGE=quay.io/kairos/osbuilder-tools:$OSBUILDER_VERSION
 ARG GOLINT_VERSION=1.52.2
 # renovate: datasource=docker depName=golang


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

Should fix the broken rpi images in which several hundreds Mb are missing due to closing the loop devices too fast and too aggresive

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
