### PR TITLE
:sparkles: Allow serial login in openrc systems

### DIFF
--- a/overlay/files/system/oem/10_accounting.yaml
+++ b/overlay/files/system/oem/10_accounting.yaml
@@ -1,4 +1,4 @@
-name: "Default user and permissions"
+name: "Default user, permissions and serial login"
 stages:
   initramfs:
     - name: "Setup groups"
@@ -48,3 +48,8 @@ stages:
       commands:
         - chown -R root:admin /usr/local/cloud-config
         - chmod 770 /usr/local/cloud-config
+    - name: "Enable serial login for alpine" # https://wiki.alpinelinux.org/wiki/Enable_Serial_Console_on_Boot
+      if: '[ -e /sbin/rc-service ]'
+      commands:
+        - sed -i -e 's/ttyS0.*//g' /etc/inittab
+        - echo "ttyS0::respawn:/sbin/getty -L ttyS0 115200 vt100" >> /etc/inittab


### PR DESCRIPTION


<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Currently is only possible to get the boot process via the serial output wiht no login available.

This patch enables login via the serial console under openrc systems

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
