### PR TITLE
:penguin: do not install unattended upgrades

### DIFF
--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -70,7 +70,6 @@ RUN apt-get update \
     systemd-resolved \
     systemd-timesyncd \
     thermald \
-    unattended-upgrades \
     xdg-user-dirs \
     xxd \
     xz-utils \
@@ -82,11 +81,6 @@ RUN apt-get update \
     zstd \
     linux-image-generic-hwe-22.04 \
     && apt-get remove -y unattended-upgrades && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# not sure if this is really necessary, since the package is already removed
-RUN sed -i 's/APT::Periodic::Update-Package-Lists "1";/APT::Periodic::Update-Package-Lists "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-RUN sed -i 's/APT::Periodic::Unattended-Upgrade "1";/APT::Periodic::Unattended-Upgrade "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv

--- a/images/Dockerfile.ubuntu-20-lts
+++ b/images/Dockerfile.ubuntu-20-lts
@@ -68,7 +68,6 @@ RUN apt-get update \
     systemd-timesyncd \
     thermald \
     ubuntu-advantage-tools \
-    unattended-upgrades \
     xdg-user-dirs \
     xxd \
     xz-utils \
@@ -78,9 +77,6 @@ RUN apt-get update \
     zfsutils-linux \
     && apt-get remove -y unattended-upgrades && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# not sure if this is really necessary, since the package is already removed
-RUN sed -i 's/APT::Periodic::Update-Package-Lists "1";/APT::Periodic::Update-Package-Lists "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-RUN sed -i 's/APT::Periodic::Unattended-Upgrade "1";/APT::Periodic::Unattended-Upgrade "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv

--- a/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
+++ b/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
@@ -91,10 +91,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 
 RUN apt-get remove -y unattended-upgrades
 
-# not sure if this is really necessary, since the package is already removed
-RUN sed -i 's/APT::Periodic::Update-Package-Lists "1";/APT::Periodic::Update-Package-Lists "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-RUN sed -i 's/APT::Periodic::Unattended-Upgrade "1";/APT::Periodic::Unattended-Upgrade "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-
 # https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%20Linux%20Driver%20Package%20Development%20Guide/updating_jetson_and_host.html
 RUN apt-get install -y -o Dpkg::Options::="--force-overwrite" \
     nvidia-l4t-core \

--- a/images/Dockerfile.ubuntu-20-lts-arm-rpi
+++ b/images/Dockerfile.ubuntu-20-lts-arm-rpi
@@ -61,11 +61,6 @@ RUN apt-get update && apt-get install -y \
     tar \
     && apt-get remove -y unattended-upgrades && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# not sure if this is really necessary, since the package is already removed
-RUN sed -i 's/APT::Periodic::Update-Package-Lists "1";/APT::Periodic::Update-Package-Lists "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-RUN sed -i 's/APT::Periodic::Unattended-Upgrade "1";/APT::Periodic::Unattended-Upgrade "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-
-
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
 RUN systemctl enable systemd-networkd

--- a/images/Dockerfile.ubuntu-22-lts
+++ b/images/Dockerfile.ubuntu-22-lts
@@ -69,7 +69,6 @@ RUN apt-get update \
     systemd-timesyncd \
     thermald \
     ubuntu-advantage-tools \
-    unattended-upgrades \
     xdg-user-dirs \
     xxd \
     xz-utils \
@@ -78,10 +77,6 @@ RUN apt-get update \
     console-data \
     zfsutils-linux \
     && apt-get remove -y unattended-upgrades && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# not sure if this is really necessary, since the package is already removed
-RUN sed -i 's/APT::Periodic::Update-Package-Lists "1";/APT::Periodic::Update-Package-Lists "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-RUN sed -i 's/APT::Periodic::Unattended-Upgrade "1";/APT::Periodic::Unattended-Upgrade "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
 
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv

--- a/images/Dockerfile.ubuntu-22-lts-arm-rpi
+++ b/images/Dockerfile.ubuntu-22-lts-arm-rpi
@@ -63,11 +63,6 @@ RUN apt-get update && apt-get install -y \
     tar \
     && apt-get remove -y unattended-upgrades && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# not sure if this is really necessary, since the package is already removed
-RUN sed -i 's/APT::Periodic::Update-Package-Lists "1";/APT::Periodic::Update-Package-Lists "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-RUN sed -i 's/APT::Periodic::Unattended-Upgrade "1";/APT::Periodic::Unattended-Upgrade "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-
-
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
 RUN systemctl enable systemd-networkd

--- a/images/Dockerfile.ubuntu-arm-rpi
+++ b/images/Dockerfile.ubuntu-arm-rpi
@@ -56,11 +56,6 @@ RUN apt-get update && apt-get install -y \
     tar \
     && apt-get remove -y unattended-upgrades && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# not sure if this is really necessary, since the package is already removed
-RUN sed -i 's/APT::Periodic::Update-Package-Lists "1";/APT::Periodic::Update-Package-Lists "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-RUN sed -i 's/APT::Periodic::Unattended-Upgrade "1";/APT::Periodic::Unattended-Upgrade "0";/g' /etc/apt/apt.conf.d/20auto-upgrades
-
-
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install
 RUN ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
 RUN systemctl enable systemd-networkd


### PR DESCRIPTION
We do remove it in case it is present in the base image already, but there is no reason to install it in the first place if isn't there.
