### PR TITLE
:robot: Fix golang image not having qemu packages anymore

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -795,7 +795,7 @@ run-qemu-netboot-test:
     ARG VERSION=$(cat VERSION)
 
     RUN apt update
-    RUN apt install -y qemu qemu-utils qemu-system git swtpm && apt clean
+    RUN apt install -y qemu-utils qemu-system git swtpm && apt clean
 
     # This is the IP at which qemu vm can see the host
     ARG IP="10.0.2.2"


### PR DESCRIPTION
With the change on the golang image to the newest debian release, the metapackage qemu is no longer available.

This patch drops it as we explicitely install the qemu packages and we need no metapackages

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
