### PR TITLE
POC: Use prebuilt image for most of the targets

### DIFF
--- a/images/Dockerfile.opensuse-leap
+++ b/images/Dockerfile.opensuse-leap
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG BASE_IMAGE=opensuse/leap:15.4
+ARG BASE_IMAGE=registry.opensuse.org/opensuse/leap:15.4
 
 FROM $BASE_IMAGE
 

--- a/images/Dockerfile.opensuse-leap-arm-rpi
+++ b/images/Dockerfile.opensuse-leap-arm-rpi
@@ -1,5 +1,5 @@
 
-ARG BASE_IMAGE=opensuse/leap:15.4
+ARG BASE_IMAGE=registry.opensuse.org/opensuse/leap:15.4
 
 FROM $BASE_IMAGE
 

--- a/images/Dockerfile.opensuse-tumbleweed
+++ b/images/Dockerfile.opensuse-tumbleweed
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=opensuse/tumbleweed
+ARG BASE_IMAGE=registry.opensuse.org/opensuse/tumbleweed
 
 FROM $BASE_IMAGE
 

--- a/images/Dockerfile.opensuse-tumbleweed-arm-rpi
+++ b/images/Dockerfile.opensuse-tumbleweed-arm-rpi
@@ -1,5 +1,5 @@
 
-ARG BASE_IMAGE=opensuse/tumbleweed
+ARG BASE_IMAGE=registry.opensuse.org/opensuse/tumbleweed
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
This uses a prebuilt image with all the deps already on it.
The image is tracked against the golang:VERSION dokcer image as base image
Renovate is used to autobump it when the upstream image changes
Quay auto builds both master and any tags added



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This solves:

 - reuse of the same image everywhere instead of having 5 different images
 - do not waste time installing deps on each target that needs it
 - for some targets it speeds up running them as the image was already downloaded (like version already gets it so we got the image in cache at that point)
 - easily see if something is broken on the base image (just happened during the lat release, image changed, release was broken in the middle)
 - no more api limits reached, quay has "unlimited" pulls
 - easy to update, at our own cadence, easy to test that it works
 - one single place for the image configuration, also renovate bumps it if we bump it, easy to change to dockerhub/gcr or whatever.
