### PR TITLE
:robot: Increase test images livespan to 24h

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -145,8 +145,8 @@ jobs:
           cosign attest --type spdx --predicate $spdx $image_ref
       - name: Push to testing
         run: |
-          docker tag quay.io/kairos/core-${{ matrix.flavor }}:latest ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h
-          docker push ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h
+          docker tag quay.io/kairos/core-${{ matrix.flavor }}:latest ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:24h
+          docker push ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:24h
   build-framework:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     needs:
@@ -466,7 +466,7 @@ jobs:
       - run: |
           earthly +run-qemu-test --PREBUILT_ISO=$(ls *.iso) \
             --FLAVOR=${{ matrix.flavor }} \
-            --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h \
+            --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:24h \
             --TEST_SUITE=upgrade-with-cli
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -538,7 +538,7 @@ jobs:
       - run: |
           earthly +run-qemu-test --PREBUILT_ISO=$(ls kairos-${{matrix.flavor}}-*.iso) \
             --FLAVOR=${{ matrix.flavor }} \
-            --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:8h \
+            --CONTAINER_IMAGE=ttl.sh/kairos-${{ matrix.flavor }}-${{ github.sha }}:24h \
             --TEST_SUITE=upgrade-latest-with-cli
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/Earthfile
+++ b/Earthfile
@@ -867,13 +867,13 @@ pull-build-artifacts:
     COPY +uuidgen/UUIDGEN ./
     COPY +version/VERSION ./
     ARG UUIDGEN=$(cat UUIDGEN)
-    ARG BUNDLE_IMAGE=ttl.sh/$UUIDGEN:8h
+    ARG BUNDLE_IMAGE=ttl.sh/$UUIDGEN:24h
 
     COPY +luet/luet /usr/bin/luet
     RUN luet util unpack $BUNDLE_IMAGE build
     SAVE ARTIFACT build AS LOCAL build
 
-## Push build artifacts as BUNDLE_IMAGE (expected arg, common is to use ttl.sh/$(uuidgen):8h)
+## Push build artifacts as BUNDLE_IMAGE (expected arg, common is to use ttl.sh/$(uuidgen):24h)
 push-build-artifacts:
     ARG OSBUILDER_IMAGE
     FROM $OSBUILDER_IMAGE
@@ -881,7 +881,7 @@ push-build-artifacts:
     COPY +uuidgen/UUIDGEN ./
     COPY +version/VERSION ./
     ARG UUIDGEN=$(cat UUIDGEN)
-    ARG BUNDLE_IMAGE=ttl.sh/$UUIDGEN:8h
+    ARG BUNDLE_IMAGE=ttl.sh/$UUIDGEN:24h
 
     COPY . .
     COPY +luet/luet /usr/bin/luet
@@ -902,7 +902,7 @@ prepare-bundles-tests:
     COPY +uuidgen/UUIDGEN ./
     COPY +version/VERSION ./
     ARG UUIDGEN=$(cat UUIDGEN)
-    ARG BUNDLE_IMAGE=ttl.sh/$UUIDGEN:8h
+    ARG BUNDLE_IMAGE=ttl.sh/$UUIDGEN:24h
    # BUILD +examples-bundle --BUNDLE_IMAGE=$BUNDLE_IMAGE
     ARG VERSION=$(cat VERSION)
     RUN echo "version ${VERSION}"


### PR DESCRIPTION
Master is currently broken not because the test is failing but because the test image was done 12 hours ago. I think it's common that we merge something at night so it would be nice to have those images at least 24 hrs instead of just 8
