### PR TITLE
Use osbuilder tools to update os-release

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -113,7 +113,7 @@ jobs:
           FLAVOR: ${{ matrix.flavor }}
           MODEL: ${{ matrix.model }}
         run: |
-          ./earthly.sh +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR --IMG_COMPRESSION=${{env.IMG_COMPRESSION}}
+          earthly +all-arm --IMAGE_NAME=kairos-$FLAVOR-latest.img --IMAGE=quay.io/kairos/core-$FLAVOR:latest --MODEL=$MODEL --FLAVOR=$FLAVOR --IMG_COMPRESSION=${{env.IMG_COMPRESSION}}
       - name: Selfhosted Build  🔧
         if: ${{ matrix.worker == 'self-hosted' }}
         env:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -94,7 +94,7 @@ jobs:
           FLAVOR: ${{ matrix.flavor }}
           IMAGE: quay.io/kairos/core-${{ matrix.flavor }}:latest
         run: |
-          earthly +ci --SECURITY_SCANS=false --IMAGE=$IMAGE --FLAVOR=$FLAVOR
+          earthly -P +ci --SECURITY_SCANS=false --IMAGE=$IMAGE --FLAVOR=$FLAVOR
           sudo mv build/* .
           sudo rm -rf build
       - name: Build master 🔧
@@ -103,7 +103,7 @@ jobs:
           FLAVOR: ${{ matrix.flavor }}
           IMAGE: quay.io/kairos/core-${{ matrix.flavor }}:latest
         run: |
-          earthly +ci --IMAGE=$IMAGE --FLAVOR=$FLAVOR
+          earthly -P +ci --IMAGE=$IMAGE --FLAVOR=$FLAVOR
           sudo mv build/* .
           sudo rm -rf build
           mkdir sarif

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,7 +131,7 @@ jobs:
           FLAVOR: ${{ matrix.flavor }}
         run: |
           export TAG=${GITHUB_REF##*/}
-          earthly +all --IMAGE=quay.io/kairos/core-$FLAVOR:$TAG --FLAVOR=$FLAVOR --ISO_NAME=kairos-$FLAVOR-$TAG
+          earthly -P +all --IMAGE=quay.io/kairos/core-$FLAVOR:$TAG --FLAVOR=$FLAVOR --ISO_NAME=kairos-$FLAVOR-$TAG
           sudo mv build release
       - name: Push to quay
         env:


### PR DESCRIPTION
Dog fooding what was added on the docs, plus makes our factory process less dependant on Earthly and more into Osbuilder like we want to do for BYOI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
relates to #1548
