### PR TITLE
:bug: Orin fixups

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -635,8 +635,14 @@ prepare-arm-image:
   ARG IMAGE_NAME=${FLAVOR}.img
   WORKDIR /build
   # These sizes are in MB
+  
   ENV SIZE="15200"
-  IF [[ "$FLAVOR" =~ ^ubuntu* ]]
+
+  IF [[ "$FLAVOR" = "ubuntu-20-lts-arm-nvidia-jetson-agx-orin" ]]
+    ENV STATE_SIZE="14000"
+    ENV RECOVERY_SIZE="10000"
+    ENV DEFAULT_ACTIVE_SIZE="4500"
+  ELSE IF [[ "$FLAVOR" =~ ^ubuntu* ]]
     ENV STATE_SIZE="6900"
     ENV RECOVERY_SIZE="4600"
     ENV DEFAULT_ACTIVE_SIZE="2500"

--- a/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
+++ b/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
@@ -85,6 +85,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     sudo \
     systemd \
     systemd-timesyncd \
+    vim \
     xdg-user-dirs \
     xxd \
     xz-utils

--- a/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
+++ b/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
@@ -54,6 +54,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     file \
     fuse \
     gawk \
+    git \
     grub2-common \
     grub-efi-arm64-bin \
     haveged \
@@ -67,6 +68,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     lvm2 \
     mdadm \
     nbd-client \
+    libssl-dev \
     ncurses-term \
     networkd-dispatcher \
     nfs-common \
@@ -149,6 +151,8 @@ RUN apt-get remove -y unattended-upgrades
 # openvpn/focal-updates,focal-security,now 2.4.7-1ubuntu2.20.04.4 arm64 [installed,automatic]
 
 RUN apt-get install -y -o Dpkg::Options::="--force-overwrite" \
+    cuda-cudart-11-4 \
+    cuda-cudart-dev-11-4 \
     cuda-nvcc-11-4 \
     cuda-nvdisasm-11-4 \
     cuda-nvml-dev-11-4 \
@@ -156,6 +160,8 @@ RUN apt-get install -y -o Dpkg::Options::="--force-overwrite" \
     cuda-nvrtc-11-4 \
     cuda-nvrtc-dev-11-4 \
     cuda-nvtx-11-4 \
+    libcublas-11-4 \
+    libcublas-dev-11-4 \
     nvidia-l4t-3d-core \
     nvidia-l4t-apt-source \
     nvidia-l4t-bootloader \
@@ -196,18 +202,12 @@ RUN apt-get install -y -o Dpkg::Options::="--force-overwrite" \
     nvidia-l4t-x11 \
     nvidia-l4t-xusb-firmware \
     jetson-gpio-common \
-    python3-jetson-gpio \
-    cuda-nvcc-11-4  git  libssl-dev libcublas-11-4 libcublas-dev-11-4 cuda-cudart-11-4 cuda-cudart-dev-11-4
+    python3-jetson-gpio
 
+# OpenCV setup
 RUN apt-get install -y libopencv-dev && \
     ln -s /usr/include/opencv4/opencv2 /usr/include/opencv2
 
 # Symlinks to make installer work
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install && \
     ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
-
-# RUN rm -rf /opt/nvidia/l4t-packages
-# RUN rm -rf /var/lib/apt/lists/*
-# RUN useradd -ms /bin/bash jetson
-# RUN echo 'jetson:jetson' | chpasswd
-# RUN usermod -a -G sudo jetson

--- a/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
+++ b/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
@@ -195,7 +195,11 @@ RUN apt-get install -y -o Dpkg::Options::="--force-overwrite" \
     nvidia-l4t-x11 \
     nvidia-l4t-xusb-firmware \
     jetson-gpio-common \
-    python3-jetson-gpio
+    python3-jetson-gpio \
+    cuda-nvcc-11-4  git  libssl-dev libcublas-11-4 libcublas-dev-11-4 cuda-cudart-11-4 cuda-cudart-dev-11-4
+
+RUN apt-get install -y libopencv-dev && \
+    ln -s /usr/include/opencv4/opencv2 /usr/include/opencv2
 
 # Symlinks to make installer work
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install && \

--- a/overlay/files-nvidia/etc/elemental/config.yaml
+++ b/overlay/files-nvidia/etc/elemental/config.yaml
@@ -1,0 +1,21 @@
+cosign: false
+verify: false
+install:
+  grub-entry-name: "Kairos"
+  system:
+    size: 4500
+  recovery-system:
+    size: 4500
+upgrade:
+  grub-entry-name: "Kairos"
+  recovery-system:
+    size: 4500
+  system:
+    size: 4500
+reset:
+  grub-entry-name: "Kairos"
+  system:
+    size: 4500
+cloud-init-paths:
+- /run/initramfs/cos-state
+# - /run/initramfs/live

--- a/overlay/files-nvidia/system/oem/mount.yaml
+++ b/overlay/files-nvidia/system/oem/mount.yaml
@@ -1,0 +1,11 @@
+## TODO: this is a workaround
+## The orin packages are writing to /usr/local, which is mounted to COS_PERSISTENT.
+## We probably should run this in immucore, overlaying the /usr/local of the image to COS_PERSISTENT.
+## For the time being, doing it in the cloud configs.
+#
+### Note: This have the consequences of everything stored inside /usr/local to go inside the "local" directory inside the partition.
+###       Usually this is not the case as there is no need of subtrees, but due to how overlayfs work the workdir and uppermount needs to be in the same filesystem.
+stages:
+  initramfs:
+  - commands:
+    - umount /usr/local && mkdir -p /run/mount/persistent && mount /dev/disk/by-label/COS_PERSISTENT /run/mount/persistent && mkdir -p /run/mount/persistent/work /run/mount/persistent/local && mount -t overlay -o lowerdir=/usr/local,upperdir=/run/mount/persistent/local,workdir=/run/mount/persistent/work /usr/local

--- a/overlay/files-nvidia/system/oem/mount.yaml
+++ b/overlay/files-nvidia/system/oem/mount.yaml
@@ -6,6 +6,6 @@
 ### Note: This have the consequences of everything stored inside /usr/local to go inside the "local" directory inside the partition.
 ###       Usually this is not the case as there is no need of subtrees, but due to how overlayfs work the workdir and uppermount needs to be in the same filesystem.
 stages:
-  initramfs:
+  initramfs.before:
   - commands:
     - umount /usr/local && mkdir -p /run/mount/persistent && mount /dev/disk/by-label/COS_PERSISTENT /run/mount/persistent && mkdir -p /run/mount/persistent/work /run/mount/persistent/local && mount -t overlay -o lowerdir=/usr/local,upperdir=/run/mount/persistent/local,workdir=/run/mount/persistent/work /usr/local

--- a/overlay/files-nvidia/system/oem/mount.yaml
+++ b/overlay/files-nvidia/system/oem/mount.yaml
@@ -8,4 +8,11 @@
 stages:
   initramfs.before:
   - commands:
-    - umount /usr/local && mkdir -p /run/mount/persistent && mount /dev/disk/by-label/COS_PERSISTENT /run/mount/persistent && mkdir -p /run/mount/persistent/work /run/mount/persistent/local && mount -t overlay -o lowerdir=/usr/local,upperdir=/run/mount/persistent/local,workdir=/run/mount/persistent/work /usr/local
+    - umount /usr/local
+    - |
+       mkdir -p /run/mount/persistent && \
+       mount /dev/disk/by-label/COS_PERSISTENT /run/mount/persistent && \
+       mkdir -p /run/mount/persistent/work /run/mount/persistent/local && \
+       mount -t overlay \
+                  -o lowerdir=/usr/local,upperdir=/run/mount/persistent/local,workdir=/run/mount/persistent/work \
+                  /usr/local


### PR DESCRIPTION
Note: ~~requires docs updates as the partition XML file changed too~~ docs pr: https://github.com/kairos-io/kairos-docs/pull/43

This PR does the following:
- Add cublas and opencv (so can test the GPU from the image)
- Bump the default image size to allow more space for packages
- Adds a workaround for `/usr/local`. The Orin images currently are installing files into `/usr/local`, and as such are not visible on boot (`/usr/local` is mounted to `COS_PERSISTENT`). Introduce here a cloud-config that attempts to overlay the content of the image to `/usr/local` during boot. The consequence is that there will be a folder inside the partition `local` and one `work` due to how the nature of overlayfs works.
