### PR TITLE
Bump kairos-agent to v2.1.3

### DIFF
--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -97,9 +97,9 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20230607102148-repository.yaml
+    reference: 20230608114448-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20230512115044-repository.yaml
+    reference: 20230703122722-repository.yaml


### PR DESCRIPTION
Fixes the default grub entry

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
