### PR TITLE
:book: Add byoi fedora/rockylinux-fips example

### DIFF
--- a/.github/flavors.json
+++ b/.github/flavors.json
@@ -12,10 +12,6 @@
         "flavor": "ubuntu-20-lts"
     },
     {
-        "flavor": "ubuntu-20-lts-fips",
-        "frameworkonly": "true"
-    },
-    {
         "flavor": "fips-systemd",
         "frameworkonly": "true"
     },

--- a/examples/byoi/fedora-fips/Dockerfile
+++ b/examples/byoi/fedora-fips/Dockerfile
@@ -1,0 +1,101 @@
+ARG BASE_IMAGE=fedora:36
+FROM $BASE_IMAGE as base
+
+# Generate os-release file
+FROM quay.io/kairos/osbuilder-tools:latest as osbuilder
+RUN zypper install -y gettext && zypper clean
+RUN mkdir /workspace
+COPY --from=base /etc/os-release /workspace/os-release
+# You should change the following values according to your own versioning and other details
+RUN OS_NAME=kairos-core-fedora-fips \
+  OS_VERSION=v9.9.9 \
+  OS_ID="kairos" \
+  OS_NAME=kairos-fedora-fips \
+  BUG_REPORT_URL="https://github.com/YOUR_ORG/YOUR_PROJECT/issues" \
+  HOME_URL="https://github.com/YOUR_ORG/YOUR_PROJECT" \
+  OS_REPO="quay.io/YOUR_ORG/fedora-fips" \
+  OS_LABEL="latest" \
+  GITHUB_REPO="YOUR_ORG/YOUR_PROJECT" \
+  VARIANT="fips" \
+  FLAVOR="fedora" \
+  /update-os-release.sh
+
+FROM base
+
+RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+
+RUN dnf install -y \
+    audit \
+    coreutils \
+    curl \
+    device-mapper \
+    dosfstools \
+    dracut \
+    dracut-live \
+    dracut-network \
+    dracut-squash \
+    e2fsprogs \
+    efibootmgr \
+    gawk \
+    gdisk \
+    grub2 \
+    grub2-efi-x64 \
+    grub2-efi-x64-modules \
+    grub2-pc \
+    haveged \
+    kernel \
+    kernel-modules \
+    kernel-modules-extra \
+    livecd-tools \
+    lvm2 \
+    nano \
+    openssh-server \
+    parted \
+    polkit \
+    qemu-guest-agent \
+    rsync \
+    shim-x64 \
+    squashfs-tools \
+    sudo \
+    systemd \
+    systemd-networkd \
+    systemd-resolved \
+    tar \
+    which \
+    && dnf clean all
+
+RUN mkdir -p /run/lock && \
+  touch /usr/libexec/.keep && \
+  systemctl enable getty@tty1.service && \
+  systemctl enable getty@tty2.service && \
+  systemctl enable getty@tty3.service && \
+  systemctl enable systemd-networkd && \
+  systemctl enable systemd-resolved && \
+  systemctl enable sshd
+
+# Copy the os-release file to identify the OS
+COPY --from=osbuilder /workspace/os-release /etc/os-release
+
+COPY --from=quay.io/kairos/framework:master_fips-systemd / /
+
+# Copy the custom dracut config file
+COPY dracut.conf /etc/dracut.conf.d/kairos-fips.conf
+
+# Activate Kairos services
+RUN systemctl enable cos-setup-reconcile.timer && \
+          systemctl enable cos-setup-fs.service && \
+          systemctl enable cos-setup-boot.service && \
+          systemctl enable cos-setup-network.service
+
+## Generate initrd
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && \
+            ln -sf "${kernel#/boot/}" /boot/vmlinuz
+RUN kernel=$(ls /lib/modules | head -n1) && \
+            dracut -v -N -f "/boot/initrd-${kernel}" "${kernel}" && \
+            ln -sf "initrd-${kernel}" /boot/initrd && depmod -a "${kernel}"
+
+# Symlink kernel HMAC
+RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && ln -sf ."${kernel#/boot/}".hmac /boot/.vmlinuz.hmac
+
+RUN rm -rf /boot/initramfs-*

--- a/examples/byoi/fedora-fips/README.md
+++ b/examples/byoi/fedora-fips/README.md
@@ -1,0 +1,35 @@
+# Kairos Fedora fips
+
+- run `bash build.sh`
+- start the ISO with qemu `bash run.sh`
+
+The system is not enabling FIPS by default in kernel space. 
+
+To Install with `fips` you need a cloud-config file similar to this one adding `fips=1` to the boot options:
+
+```yaml
+#cloud-config
+
+install:
+  # ...
+  # Set grub options
+  grub_options:
+    # additional Kernel option cmdline to apply
+    extra_cmdline: "fips=1 selinux=0"
+```
+
+Notes:
+- Most of the Dockerfile configuration are: packages being installed by fedora, and the framework files coming from Kairos containing FIPS-enabled packages
+- The LiveCD is not running in fips mode
+- You must add `selinux=0`. SELinux is not supported yet and must be explicitly disabled
+
+## Verify FIPS is enabled
+
+After install, you can verify that fips is enabled by running:
+
+```bash
+kairos@localhost:~$ cat /proc/sys/crypto/fips_enabled
+1
+kairos@localhost:~$ uname -a
+Linux localhost 5.4.0-1007-fips #8-Ubuntu SMP Wed Jul 29 21:42:48 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+```

--- a/examples/byoi/fedora-fips/build.sh
+++ b/examples/byoi/fedora-fips/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+# Build the container image
+docker build -t test-byoi-fips .
+
+docker run -v "$PWD"/build:/tmp/auroraboot \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        --rm -ti quay.io/kairos/auroraboot \
+        --set container_image=docker://test-byoi-fips \
+        --set "disable_http_server=true" \
+        --set "disable_netboot=true" \
+        --set "state_dir=/tmp/auroraboot"

--- a/examples/byoi/fedora-fips/dracut.conf
+++ b/examples/byoi/fedora-fips/dracut.conf
@@ -1,0 +1,2 @@
+omit_dracutmodules+=" iscsi iscsiroot "
+add_dracutmodules+=" fips "

--- a/examples/byoi/fedora-fips/run.sh
+++ b/examples/byoi/fedora-fips/run.sh
@@ -1,0 +1,3 @@
+qemu-img create -f qcow2 disk.img 40g
+
+qemu-system-x86_64 -m 8096 -smp cores=2 -nographic -cpu host -enable-kvm -serial mon:stdio -rtc base=utc,clock=rt -chardev socket,path=qga.sock,server,nowait,id=qga0 -device virtio-serial -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0 -drive if=virtio,media=disk,file=disk.img -drive if=ide,media=cdrom,file=build/iso/kairos.iso

--- a/examples/byoi/rockylinux-fips/Dockerfile
+++ b/examples/byoi/rockylinux-fips/Dockerfile
@@ -1,0 +1,103 @@
+ARG BASE_IMAGE=rockylinux:9
+FROM $BASE_IMAGE as base
+
+# Generate os-release file
+FROM quay.io/kairos/osbuilder-tools:latest as osbuilder
+RUN zypper install -y gettext && zypper clean
+RUN mkdir /workspace
+COPY --from=base /etc/os-release /workspace/os-release
+# You should change the following values according to your own versioning and other details
+RUN OS_NAME=kairos-core-rockylinux-fips \
+  OS_VERSION=v9.9.9 \
+  OS_ID="kairos" \
+  OS_NAME=kairos-rockylinux-fips \
+  BUG_REPORT_URL="https://github.com/YOUR_ORG/YOUR_PROJECT/issues" \
+  HOME_URL="https://github.com/YOUR_ORG/YOUR_PROJECT" \
+  OS_REPO="quay.io/YOUR_ORG/rockylinux-fips" \
+  OS_LABEL="latest" \
+  GITHUB_REPO="YOUR_ORG/YOUR_PROJECT" \
+  VARIANT="fips" \
+  FLAVOR="rockylinux" \
+  /update-os-release.sh
+
+FROM base
+RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+
+RUN dnf install -y epel-release && dnf clean all
+RUN dnf update -y
+RUN dnf makecache
+RUN dnf install -y \
+    audit \
+    device-mapper \
+    dosfstools \
+    dracut \
+    dracut-live \
+    dracut-network \
+    dracut-squash \
+    e2fsprogs \
+    efibootmgr \
+    epel-release \
+    gawk \
+    grub2 \
+    grub2-efi-x64 \
+    grub2-efi-x64-modules \
+    grub2-pc \
+    kernel \
+    kernel-modules \
+    kernel-modules-extra \
+    livecd-tools \
+    lvm2 \
+    nano \
+    openssh-server \
+    parted \
+    polkit \
+    qemu-guest-agent \
+    rsync \
+    shim-x64 \
+    squashfs-tools \
+    sudo \
+    systemd \
+    systemd-networkd \
+    systemd-resolved \
+    systemd-timesyncd \
+    tar \
+    which \
+    https://zfsonlinux.org/epel/zfs-release-2-2.el9.noarch.rpm \
+    && dnf clean all
+
+RUN mkdir -p /run/lock
+RUN touch /usr/libexec/.keep
+RUN systemctl enable getty@tty1.service
+RUN systemctl enable getty@tty2.service
+RUN systemctl enable getty@tty3.service
+RUN systemctl enable systemd-networkd
+RUN systemctl enable systemd-resolved
+RUN systemctl disable dnf-makecache.service
+RUN systemctl enable sshd
+
+# Copy the os-release file to identify the OS
+COPY --from=osbuilder /workspace/os-release /etc/os-release
+
+COPY --from=quay.io/kairos/framework:master_fips-systemd / /
+
+# Copy the custom dracut config file
+COPY dracut.conf /etc/dracut.conf.d/kairos-fips.conf
+
+# Activate Kairos services
+RUN systemctl enable cos-setup-reconcile.timer && \
+          systemctl enable cos-setup-fs.service && \
+          systemctl enable cos-setup-boot.service && \
+          systemctl enable cos-setup-network.service
+
+## Generate initrd
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && \
+            ln -sf "${kernel#/boot/}" /boot/vmlinuz
+RUN kernel=$(ls /lib/modules | head -n1) && \
+            dracut -v -N -f "/boot/initrd-${kernel}" "${kernel}" && \
+            ln -sf "initrd-${kernel}" /boot/initrd && depmod -a "${kernel}"
+            
+# Symlink kernel HMAC
+RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && ln -sf ."${kernel#/boot/}".hmac /boot/.vmlinuz.hmac
+
+RUN rm -rf /boot/initramfs-*

--- a/examples/byoi/rockylinux-fips/README.md
+++ b/examples/byoi/rockylinux-fips/README.md
@@ -1,0 +1,35 @@
+# Kairos Rockylinux fips
+
+- run `bash build.sh`
+- start the ISO with qemu `bash run.sh`
+
+The system is not enabling FIPS by default in kernel space. 
+
+To Install with `fips` you need a cloud-config file similar to this one adding `fips=1` to the boot options:
+
+```yaml
+#cloud-config
+
+install:
+  # ...
+  # Set grub options
+  grub_options:
+    # additional Kernel option cmdline to apply
+    extra_cmdline: "fips=1 selinux=0"
+```
+
+Notes:
+- Most of the Dockerfile configuration are: packages being installed by fedora, and the framework files coming from Kairos containing FIPS-enabled packages
+- The LiveCD is not running in fips mode
+- You must add `selinux=0`. SELinux is not supported yet and must be explicitly disabled
+
+## Verify FIPS is enabled
+
+After install, you can verify that fips is enabled by running:
+
+```bash
+[root@localhost ~]# cat /proc/sys/crypto/fips_enabled
+1
+[root@localhost ~]# uname -a
+Linux localhost 5.14.0-284.18.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Jun 22 17:36:46 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
+```

--- a/examples/byoi/rockylinux-fips/build.sh
+++ b/examples/byoi/rockylinux-fips/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+# Build the container image
+docker build -t test-byoi-fips .
+
+docker run -v "$PWD"/build:/tmp/auroraboot \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        --rm -ti quay.io/kairos/auroraboot \
+        --set container_image=docker://test-byoi-fips \
+        --set "disable_http_server=true" \
+        --set "disable_netboot=true" \
+        --set "state_dir=/tmp/auroraboot"

--- a/examples/byoi/rockylinux-fips/dracut.conf
+++ b/examples/byoi/rockylinux-fips/dracut.conf
@@ -1,0 +1,2 @@
+omit_dracutmodules+=" iscsi iscsiroot "
+add_dracutmodules+=" fips "

--- a/examples/byoi/rockylinux-fips/run.sh
+++ b/examples/byoi/rockylinux-fips/run.sh
@@ -1,0 +1,3 @@
+qemu-img create -f qcow2 disk.img 40g
+
+qemu-system-x86_64 -m 8096 -smp cores=2 -nographic -cpu host -enable-kvm -serial mon:stdio -rtc base=utc,clock=rt -chardev socket,path=qga.sock,server,nowait,id=qga0 -device virtio-serial -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0 -drive if=virtio,media=disk,file=disk.img -drive if=ide,media=cdrom,file=build/iso/kairos.iso

--- a/examples/byoi/ubuntu-fips/Dockerfile
+++ b/examples/byoi/ubuntu-fips/Dockerfile
@@ -1,6 +1,6 @@
 
 # Kairos framework packages for ubuntu fips
-FROM quay.io/kairos/framework:master_ubuntu-20-lts-fips as kairos-fips
+FROM quay.io/kairos/framework:master_fips-systemd as kairos-fips
 
 # Base ubuntu image (focal)
 FROM ubuntu:focal as base

--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -47,14 +47,9 @@ flavors:
     - kairos-toolchain
     - systemd-base
     - dracut-network-legacy-compat
-  ubuntu-20-lts-fips:
-    - common-packages
-    - kairos-toolchain-fips
-    - systemd-base
-    - dracut-network-legacy-compat
   fips-systemd:
     - common-packages
-    - kairos-toolchain-fips-static
+    - kairos-toolchain-fips
     - systemd-base
     - dracut-network-legacy-compat
   fedora:


### PR DESCRIPTION
Fixes #362 

Adds fips e2e example for:

- fedora
- rockylinux

~Draft as needs to validate with the latest images~

Renames also the `ubuntu-20-lts-fips` framework image to `fips-systemd` as works as well for rocky and fedora.
