### PR TITLE
✨ Introduce new naming convention for artifacts

### DIFF
--- a/.github/workflows/image-arm-pr.yaml
+++ b/.github/workflows/image-arm-pr.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   docker:
-    uses: kairos-io/kairos/.github/workflows/reusable-docker-arm-build.yaml@master
+    uses: .github/workflows/reusable-docker-arm-build.yaml
     with:
       flavor: opensuse-leap-arm-rpi
       model: rpi64

--- a/.github/workflows/image-arm-pr.yaml
+++ b/.github/workflows/image-arm-pr.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   docker:
-    uses: .github/workflows/reusable-docker-arm-build.yaml
+    uses: ./.github/workflows/reusable-docker-arm-build.yaml
     with:
       flavor: opensuse-leap-arm-rpi
       model: rpi64

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -31,7 +31,7 @@ jobs:
           echo "::set-output name=matrix::{\"include\": $content }"
 
   docker:
-    uses: .github/workflows/reusable-docker-arm-build.yaml
+    uses: ./.github/workflows/reusable-docker-arm-build.yaml
     secrets: inherit
     with:
       flavor: ${{ matrix.flavor }}
@@ -44,7 +44,7 @@ jobs:
       matrix: ${{fromJson(needs.get-matrix.outputs.matrix)}}
 
   image_and_iso_arm64_generic:
-    uses: .github/workflows/reusable-image-and-iso-arm-generic.yaml
+    uses: ./.github/workflows/reusable-image-and-iso-arm-generic.yaml
     secrets: inherit
     with:
       flavor: ${{ matrix.flavor }}

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -31,7 +31,7 @@ jobs:
           echo "::set-output name=matrix::{\"include\": $content }"
 
   docker:
-    uses: kairos-io/kairos/.github/workflows/reusable-docker-arm-build.yaml@master
+    uses: .github/workflows/reusable-docker-arm-build.yaml
     secrets: inherit
     with:
       flavor: ${{ matrix.flavor }}
@@ -44,7 +44,7 @@ jobs:
       matrix: ${{fromJson(needs.get-matrix.outputs.matrix)}}
 
   image_and_iso_arm64_generic:
-    uses: kairos-io/kairos/.github/workflows/reusable-image-and-iso-arm-generic.yaml@master
+    uses: .github/workflows/reusable-image-and-iso-arm-generic.yaml
     secrets: inherit
     with:
       flavor: ${{ matrix.flavor }}

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -11,68 +11,68 @@ env:
   FORCE_COLOR: 1
 jobs:
   core:
-    uses: kairos-io/kairos/.github/workflows/reusable-build-flavor.yaml@master
+    uses: .github/workflows/reusable-build-flavor.yaml
     with:
       flavor: ubuntu
 
   install:
-    uses: kairos-io/kairos/.github/workflows/reusable-install-test.yaml@master
+    uses: .github/workflows/reusable-install-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   zfs:
-    uses: kairos-io/kairos/.github/workflows/reusable-zfs-test.yaml@master
+    uses: .github/workflows/reusable-zfs-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   acceptance:
-    uses: kairos-io/kairos/.github/workflows/reusable-qemu-acceptance-test.yaml@master
+    uses: .github/workflows/reusable-qemu-acceptance-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   bundles:
-    uses: kairos-io/kairos/.github/workflows/reusable-qemu-bundles-test.yaml@master
+    uses: .github/workflows/reusable-qemu-bundles-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   reset:
-    uses: kairos-io/kairos/.github/workflows/reusable-qemu-reset-test.yaml@master
+    uses: .github/workflows/reusable-qemu-reset-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   netboot:
-    uses: kairos-io/kairos/.github/workflows/reusable-qemu-netboot-test.yaml@master
+    uses: .github/workflows/reusable-qemu-netboot-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   upgrade:
-    uses: kairos-io/kairos/.github/workflows/reusable-upgrade-with-cli-test.yaml@master
+    uses: .github/workflows/reusable-upgrade-with-cli-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   upgrade-latest:
-    uses: kairos-io/kairos/.github/workflows/reusable-upgrade-latest-test.yaml@master
+    uses: .github/workflows/reusable-upgrade-latest-test.yaml
     with:
       flavor: ubuntu
     needs:
     - core
 
   encryption:
-    uses: kairos-io/kairos/.github/workflows/reusable-encryption-test.yaml@master
+    uses: .github/workflows/reusable-encryption-test.yaml
     with:
       flavor: ubuntu
       label: ${{ matrix.label }}

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -11,68 +11,68 @@ env:
   FORCE_COLOR: 1
 jobs:
   core:
-    uses: .github/workflows/reusable-build-flavor.yaml
+    uses: ./.github/workflows/reusable-build-flavor.yaml
     with:
       flavor: ubuntu
 
   install:
-    uses: .github/workflows/reusable-install-test.yaml
+    uses: ./.github/workflows/reusable-install-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   zfs:
-    uses: .github/workflows/reusable-zfs-test.yaml
+    uses: ./.github/workflows/reusable-zfs-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   acceptance:
-    uses: .github/workflows/reusable-qemu-acceptance-test.yaml
+    uses: ./.github/workflows/reusable-qemu-acceptance-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   bundles:
-    uses: .github/workflows/reusable-qemu-bundles-test.yaml
+    uses: ./.github/workflows/reusable-qemu-bundles-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   reset:
-    uses: .github/workflows/reusable-qemu-reset-test.yaml
+    uses: ./.github/workflows/reusable-qemu-reset-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   netboot:
-    uses: .github/workflows/reusable-qemu-netboot-test.yaml
+    uses: ./.github/workflows/reusable-qemu-netboot-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   upgrade:
-    uses: .github/workflows/reusable-upgrade-with-cli-test.yaml
+    uses: ./.github/workflows/reusable-upgrade-with-cli-test.yaml
     with:
       flavor: ubuntu
     needs:
       - core
 
   upgrade-latest:
-    uses: .github/workflows/reusable-upgrade-latest-test.yaml
+    uses: ./.github/workflows/reusable-upgrade-latest-test.yaml
     with:
       flavor: ubuntu
     needs:
     - core
 
   encryption:
-    uses: .github/workflows/reusable-encryption-test.yaml
+    uses: ./.github/workflows/reusable-encryption-test.yaml
     with:
       flavor: ubuntu
       label: ${{ matrix.label }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "::set-output name=matrix::{\"include\": $content }"
 
   core:
-    uses: .github/workflows/reusable-build-flavor.yaml
+    uses: ./.github/workflows/reusable-build-flavor.yaml
     secrets: inherit
     with:
       flavor: ${{ matrix.flavor }}
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.get-matrix.outputs.matrix)}}
   framework:
-    uses: .github/workflows/reusable-build-framework-flavor.yaml
+    uses: ./.github/workflows/reusable-build-framework-flavor.yaml
     secrets: inherit
     with:
       flavor: ${{ matrix.flavor }}
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.get-framework-matrix.outputs.matrix)}}
   install:
-    uses: .github/workflows/reusable-install-test.yaml
+    uses: ./.github/workflows/reusable-install-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -85,7 +85,7 @@ jobs:
         include:
           - flavor: opensuse-leap
   zfs:
-    uses: .github/workflows/reusable-zfs-test.yaml
+    uses: ./.github/workflows/reusable-zfs-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -96,7 +96,7 @@ jobs:
         include:
           - flavor: "ubuntu"
   acceptance:
-    uses: .github/workflows/reusable-qemu-acceptance-test.yaml
+    uses: ./.github/workflows/reusable-qemu-acceptance-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -113,7 +113,7 @@ jobs:
           - flavor: "ubuntu-20-lts"
           - flavor: "ubuntu-22-lts"
   bundles:
-    uses: .github/workflows/reusable-qemu-bundles-test.yaml
+    uses: ./.github/workflows/reusable-qemu-bundles-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -124,7 +124,7 @@ jobs:
         include:
           - flavor: opensuse-tumbleweed # Kubo test needs systemd version 252+ which atm is not available in Leap
   reset:
-    uses: .github/workflows/reusable-qemu-reset-test.yaml
+    uses: ./.github/workflows/reusable-qemu-reset-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -136,7 +136,7 @@ jobs:
           - flavor: alpine-opensuse-leap
           - flavor: opensuse-leap
   netboot:
-    uses: .github/workflows/reusable-qemu-netboot-test.yaml
+    uses: ./.github/workflows/reusable-qemu-netboot-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -149,7 +149,7 @@ jobs:
           - flavor: opensuse-leap
           - flavor: ubuntu
   upgrade:
-    uses: .github/workflows/reusable-upgrade-with-cli-test.yaml
+    uses: ./.github/workflows/reusable-upgrade-with-cli-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -161,7 +161,7 @@ jobs:
           - flavor: alpine-opensuse-leap
           - flavor: opensuse-leap
   upgrade-latest:
-    uses: .github/workflows/reusable-upgrade-latest-test.yaml
+    uses: ./.github/workflows/reusable-upgrade-latest-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -176,7 +176,7 @@ jobs:
           # - flavor: "ubuntu"
           # - flavor: "ubuntu"
   encryption:
-    uses: .github/workflows/reusable-encryption-test.yaml
+    uses: ./.github/workflows/reusable-encryption-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
       label: ${{ matrix.label }}
@@ -194,7 +194,7 @@ jobs:
         flavor:
           - "opensuse-leap"
   standard:
-    uses: .github/workflows/reusable-build-provider.yaml
+    uses: ./.github/workflows/reusable-build-provider.yaml
     with:
       flavor: ${{ matrix.flavor }}
     strategy:
@@ -204,7 +204,7 @@ jobs:
           - "opensuse-leap"
           - "alpine-opensuse-leap"
   various:
-    uses: .github/workflows/reusable-provider-tests.yaml
+    uses: ./.github/workflows/reusable-provider-tests.yaml
     with:
       flavor: ${{ matrix.flavor }}
       label: ${{ matrix.label }}
@@ -228,7 +228,7 @@ jobs:
           - label: "provider-upgrade"
             flavor: "alpine-opensuse-leap"
   standard-upgrade-latest:
-    uses: .github/workflows/reusable-provider-upgrade-latest-test.yaml
+    uses: ./.github/workflows/reusable-provider-upgrade-latest-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "::set-output name=matrix::{\"include\": $content }"
 
   core:
-    uses: kairos-io/kairos/.github/workflows/reusable-build-flavor.yaml@master
+    uses: .github/workflows/reusable-build-flavor.yaml
     secrets: inherit
     with:
       flavor: ${{ matrix.flavor }}
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.get-matrix.outputs.matrix)}}
   framework:
-    uses: kairos-io/kairos/.github/workflows/reusable-build-framework-flavor.yaml@master
+    uses: .github/workflows/reusable-build-framework-flavor.yaml
     secrets: inherit
     with:
       flavor: ${{ matrix.flavor }}
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.get-framework-matrix.outputs.matrix)}}
   install:
-    uses: kairos-io/kairos/.github/workflows/reusable-install-test.yaml@master
+    uses: .github/workflows/reusable-install-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -85,7 +85,7 @@ jobs:
         include:
           - flavor: opensuse-leap
   zfs:
-    uses: kairos-io/kairos/.github/workflows/reusable-zfs-test.yaml@master
+    uses: .github/workflows/reusable-zfs-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -96,7 +96,7 @@ jobs:
         include:
           - flavor: "ubuntu"
   acceptance:
-    uses: kairos-io/kairos/.github/workflows/reusable-qemu-acceptance-test.yaml@master
+    uses: .github/workflows/reusable-qemu-acceptance-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -113,7 +113,7 @@ jobs:
           - flavor: "ubuntu-20-lts"
           - flavor: "ubuntu-22-lts"
   bundles:
-    uses: kairos-io/kairos/.github/workflows/reusable-qemu-bundles-test.yaml@master
+    uses: .github/workflows/reusable-qemu-bundles-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -124,7 +124,7 @@ jobs:
         include:
           - flavor: opensuse-tumbleweed # Kubo test needs systemd version 252+ which atm is not available in Leap
   reset:
-    uses: kairos-io/kairos/.github/workflows/reusable-qemu-reset-test.yaml@master
+    uses: .github/workflows/reusable-qemu-reset-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -136,7 +136,7 @@ jobs:
           - flavor: alpine-opensuse-leap
           - flavor: opensuse-leap
   netboot:
-    uses: kairos-io/kairos/.github/workflows/reusable-qemu-netboot-test.yaml@master
+    uses: .github/workflows/reusable-qemu-netboot-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -149,7 +149,7 @@ jobs:
           - flavor: opensuse-leap
           - flavor: ubuntu
   upgrade:
-    uses: kairos-io/kairos/.github/workflows/reusable-upgrade-with-cli-test.yaml@master
+    uses: .github/workflows/reusable-upgrade-with-cli-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -161,7 +161,7 @@ jobs:
           - flavor: alpine-opensuse-leap
           - flavor: opensuse-leap
   upgrade-latest:
-    uses: kairos-io/kairos/.github/workflows/reusable-upgrade-latest-test.yaml@master
+    uses: .github/workflows/reusable-upgrade-latest-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:
@@ -176,7 +176,7 @@ jobs:
           # - flavor: "ubuntu"
           # - flavor: "ubuntu"
   encryption:
-    uses: kairos-io/kairos/.github/workflows/reusable-encryption-test.yaml@master
+    uses: .github/workflows/reusable-encryption-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
       label: ${{ matrix.label }}
@@ -194,7 +194,7 @@ jobs:
         flavor:
           - "opensuse-leap"
   standard:
-    uses: kairos-io/kairos/.github/workflows/reusable-build-provider.yaml@master
+    uses: .github/workflows/reusable-build-provider.yaml
     with:
       flavor: ${{ matrix.flavor }}
     strategy:
@@ -204,7 +204,7 @@ jobs:
           - "opensuse-leap"
           - "alpine-opensuse-leap"
   various:
-    uses: kairos-io/kairos/.github/workflows/reusable-provider-tests.yaml@master
+    uses: .github/workflows/reusable-provider-tests.yaml
     with:
       flavor: ${{ matrix.flavor }}
       label: ${{ matrix.label }}
@@ -228,7 +228,7 @@ jobs:
           - label: "provider-upgrade"
             flavor: "alpine-opensuse-leap"
   standard-upgrade-latest:
-    uses: kairos-io/kairos/.github/workflows/reusable-provider-upgrade-latest-test.yaml@master
+    uses: .github/workflows/reusable-provider-upgrade-latest-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
     needs:

--- a/.github/workflows/reusable-encryption-test.yaml
+++ b/.github/workflows/reusable-encryption-test.yaml
@@ -80,5 +80,5 @@ jobs:
           EMULATE_TPM: true
           USE_QEMU: true
         run: |
-          export ISO=$(ls $PWD/kairos-core-*${{ inputs.flavor }}*).iso
+          export ISO=$(ls $PWD/kairos-core-*${{ inputs.flavor }}*.iso)
           .github/encryption-tests.sh

--- a/.github/workflows/reusable-encryption-test.yaml
+++ b/.github/workflows/reusable-encryption-test.yaml
@@ -80,5 +80,5 @@ jobs:
           EMULATE_TPM: true
           USE_QEMU: true
         run: |
-          export ISO=$PWD/kairos-core-${{ inputs.flavor }}.iso
+          export ISO=$(ls $PWD/kairos-core-*${{ inputs.flavor }}*).iso
           .github/encryption-tests.sh

--- a/.github/workflows/reusable-install-test.yaml
+++ b/.github/workflows/reusable-install-test.yaml
@@ -31,7 +31,7 @@ jobs:
           cache-dependency-path: tests/go.sum
       - name: Ginkgo
         run: |
-          export ISO=$PWD/kairos-core-${{ inputs.flavor }}.iso
+          export ISO=$(ls $PWD/kairos-core-*${{ inputs.flavor }}*).iso
           export GOPATH="/Users/runner/go"
           export PATH=$PATH:$GOPATH/bin
           export CREATE_VM=true

--- a/.github/workflows/reusable-install-test.yaml
+++ b/.github/workflows/reusable-install-test.yaml
@@ -31,7 +31,7 @@ jobs:
           cache-dependency-path: tests/go.sum
       - name: Ginkgo
         run: |
-          export ISO=$(ls $PWD/kairos-core-*${{ inputs.flavor }}*).iso
+          export ISO=$(ls $PWD/kairos-core-*${{ inputs.flavor }}*.iso)
           export GOPATH="/Users/runner/go"
           export PATH=$PATH:$GOPATH/bin
           export CREATE_VM=true

--- a/.github/workflows/reusable-qemu-acceptance-test.yaml
+++ b/.github/workflows/reusable-qemu-acceptance-test.yaml
@@ -63,4 +63,4 @@ jobs:
         packages: utils/earthly
     - run: |
             earthly +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
-            earthly +run-qemu-datasource-tests --PREBUILT_ISO=kairos-core-${{ inputs.flavor }}.iso --FLAVOR=${{ inputs.flavor }} --SSH_PORT=${{ inputs.port }}
+            earthly +run-qemu-datasource-tests --PREBUILT_ISO=$(ls kairos-core-*${{ inputs.flavor }}*.iso) --FLAVOR=${{ inputs.flavor }} --SSH_PORT=${{ inputs.port }}

--- a/.github/workflows/reusable-qemu-bundles-test.yaml
+++ b/.github/workflows/reusable-qemu-bundles-test.yaml
@@ -43,4 +43,4 @@ jobs:
           EOF
 
           earthly -P +prepare-bundles-tests
-          earthly -P +run-qemu-bundles-tests --PREBUILT_ISO=kairos-core-${{ inputs.flavor }}.iso --FLAVOR=${{ inputs.flavor }}
+          earthly -P +run-qemu-bundles-tests --PREBUILT_ISO=$(ls kairos-core-*${{ inputs.flavor }}*.iso) --FLAVOR=${{ inputs.flavor }}

--- a/.github/workflows/reusable-qemu-reset-test.yaml
+++ b/.github/workflows/reusable-qemu-reset-test.yaml
@@ -42,4 +42,4 @@ jobs:
                   http = true
             EOF
             earthly -P +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
-            earthly -P +run-qemu-datasource-tests --PREBUILT_ISO=kairos-core-${{ inputs.flavor }}.iso --TEST_SUITE=reset-test --FLAVOR=${{ inputs.flavor }}
+            earthly -P +run-qemu-datasource-tests --PREBUILT_ISO=$(ls kairos-core-*${{ inputs.flavor }}*.iso) --TEST_SUITE=reset-test --FLAVOR=${{ inputs.flavor }}

--- a/.github/workflows/reusable-upgrade-with-cli-test.yaml
+++ b/.github/workflows/reusable-upgrade-with-cli-test.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -las .
       - run: |
-          earthly +run-qemu-test --PREBUILT_ISO=kairos-core-${{ inputs.flavor }}.iso \
+          earthly +run-qemu-test --PREBUILT_ISO=$(ls kairos-core-*${{ inputs.flavor }}*.iso) \
             --FLAVOR=${{ inputs.flavor }} \
             --CONTAINER_IMAGE=ttl.sh/kairos-${{ inputs.flavor }}-${{ github.sha }}:24h \
             --TEST_SUITE=upgrade-with-cli

--- a/.github/workflows/reusable-zfs-test.yaml
+++ b/.github/workflows/reusable-zfs-test.yaml
@@ -26,5 +26,5 @@ jobs:
           repository: quay.io/kairos/packages
           packages: utils/earthly
       - run: |
-          export ISO=$PWD/kairos-${{ inputs.flavor }}.iso
+          export ISO=$(ls $PWD/kairos-*${{ inputs.flavor }}*).iso
           earthly +run-qemu-test --TEST_SUITE=zfs --FLAVOR=${{ inputs.flavor }}

--- a/Earthfile
+++ b/Earthfile
@@ -594,7 +594,6 @@ netboot:
     ARG ISO_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${ARCH}-${MODEL}-${VERSION}
     ARG OSBUILDER_IMAGE
     FROM $OSBUILDER_IMAGE
-    COPY +version/VERSION ./
     ARG FROM_ARTIFACT
     WORKDIR /build
     ARG RELEASE_URL
@@ -620,7 +619,10 @@ arm-image:
   ARG IMG_COMPRESSION=xz
   FROM $OSBUILDER_IMAGE
   ARG MODEL=rpi64
-  ARG IMAGE_NAME=${FLAVOR}.img
+  COPY +version/VERSION ./
+  RUN echo "version ${VERSION}"
+  ARG VERSION=$(cat VERSION)
+  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${ARCH}-${MODEL}-${VERSION}.img
   WORKDIR /build
   # These sizes are in MB
   ENV SIZE="15200"

--- a/Earthfile
+++ b/Earthfile
@@ -75,7 +75,7 @@ all-arm:
   END
   
   IF [[ "$FLAVOR" = "ubuntu-20-lts-arm-nvidia-jetson-agx-orin" ]]
-    BUILD +prepare-arm-image --MODEL=rpi64 --FLAVOR=${FLAVOR}
+    BUILD +prepare-arm-image --MODEL=nvidia-orin --FLAVOR=${FLAVOR}
 
   ELSE
     BUILD +arm-image --MODEL=rpi64
@@ -615,6 +615,7 @@ netboot:
     SAVE ARTIFACT /build/$ISO_NAME.ipxe ipxe AS LOCAL build/$ISO_NAME.ipxe
 
 arm-image:
+  ARG ARCH=arm64
   ARG OSBUILDER_IMAGE
   ARG COMPRESS_IMG=true
   ARG IMG_COMPRESSION=xz
@@ -623,7 +624,7 @@ arm-image:
   COPY +version/VERSION ./
   RUN echo "version ${VERSION}"
   ARG VERSION=$(cat VERSION)
-  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-arm-${MODEL}-${VERSION}.img
+  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${ARCH}-${MODEL}-${VERSION}.img
   WORKDIR /build
   # These sizes are in MB
   ENV SIZE="15200"

--- a/Earthfile
+++ b/Earthfile
@@ -77,7 +77,7 @@ all-arm:
   IF [[ "$FLAVOR" = "ubuntu-20-lts-arm-nvidia-jetson-agx-orin" ]]
     BUILD +prepare-arm-image --MODEL=rpi64 --FLAVOR=${FLAVOR}
   ELSE
-    BUILD +arm-image --MODEL=rpi64
+    BUILD +arm-image --MODEL=rpi64 --ARCH=arm64
   END
 
 arm-container-image:

--- a/Earthfile
+++ b/Earthfile
@@ -186,7 +186,8 @@ image-sbom:
     ARG VERSION=$(cat VERSION)
 
     IF [ "$ARCH" = "arm64" ]
-        ARG ISO_NAME=${OS_ID}-${VARIANT}-$(echo $FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
+        ARG DISTRO=$(echo $FLAVOR | sed 's/-arm-rpi*//')
+        ARG ISO_NAME=${OS_ID}-${VARIANT}-${DISTRO}-${ARCH}-${MODEL}-${VERSION}
     ELSE
         ARG ISO_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${ARCH}-${MODEL}-${VERSION}
     END
@@ -629,7 +630,9 @@ arm-image:
   COPY +version/VERSION ./
   RUN echo "version ${VERSION}"
   ARG VERSION=$(cat VERSION)
-  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-$(echo $FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
+  ARG DISTRO=$(echo $FLAVOR | sed 's/-arm-rpi*//')
+  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-${DISTRO}-${ARCH}-${MODEL}-${VERSION}.img
+  RUN echo $IMAGE_NAME
   WORKDIR /build
   # These sizes are in MB
   ENV SIZE="15200"
@@ -763,7 +766,8 @@ trivy-scan:
     ARG FLAVOR
     ARG VARIANT
     IF [ "$ARCH" = "arm64" ]
-        ARG ISO_NAME=${OS_ID}-${VARIANT}-$(echo $FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
+        ARG DISTRO=$(echo $FLAVOR | sed 's/-arm-rpi*//')
+        ARG ISO_NAME=${OS_ID}-${VARIANT}-${DISTRO}-${ARCH}-${MODEL}-${VERSION}
     ELSE
         ARG ISO_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${ARCH}-${MODEL}-${VERSION}
     END
@@ -789,7 +793,8 @@ grype-scan:
     ARG FLAVOR
     ARG VARIANT
     IF [ "$ARCH" = "arm64" ]
-        ARG ISO_NAME=${OS_ID}-${VARIANT}-$(echo $FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
+        ARG DISTRO=$(echo $FLAVOR | sed 's/-arm-rpi*//')
+        ARG ISO_NAME=${OS_ID}-${VARIANT}-${DISTRO}-${ARCH}-${MODEL}-${VERSION}
     ELSE
         ARG ISO_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${ARCH}-${MODEL}-${VERSION}
     END

--- a/Earthfile
+++ b/Earthfile
@@ -69,9 +69,9 @@ all-arm:
   ARG SECURITY_SCANS=true
   BUILD --platform=linux/arm64 +base-image --MODEL=rpi64
   IF [ "$SECURITY_SCANS" = "true" ]
-      BUILD --platform=linux/arm64 +image-sbom --MODEL=rpi64
-      BUILD --platform=linux/arm64 +trivy-scan --MODEL=rpi64
-      BUILD --platform=linux/arm64 +grype-scan --MODEL=rpi64
+      BUILD --platform=linux/arm64 +image-sbom --MODEL=rpi64 --ARCH=arm64
+      BUILD --platform=linux/arm64 +trivy-scan --MODEL=rpi64 --ARCH=arm64
+      BUILD --platform=linux/arm64 +grype-scan --MODEL=rpi64 --ARCH=arm64
   END
   
   IF [[ "$FLAVOR" = "ubuntu-20-lts-arm-nvidia-jetson-agx-orin" ]]
@@ -177,6 +177,7 @@ syft:
     SAVE ARTIFACT /syft syft
 
 image-sbom:
+    ARG ARCH
     # Use base-image so it can read original os-release file
     FROM +base-image
     WORKDIR /build
@@ -622,7 +623,7 @@ arm-image:
   COPY +version/VERSION ./
   RUN echo "version ${VERSION}"
   ARG VERSION=$(cat VERSION)
-  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${ARCH}-${MODEL}-${VERSION}.img
+  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-arm-${MODEL}-${VERSION}.img
   WORKDIR /build
   # These sizes are in MB
   ENV SIZE="15200"
@@ -746,6 +747,7 @@ trivy:
     SAVE ARTIFACT /usr/local/bin/trivy /trivy
 
 trivy-scan:
+    ARG ARCH
     # Use base-image so it can read original os-release file
     FROM +base-image
     COPY +trivy/trivy /trivy
@@ -768,6 +770,7 @@ grype:
     SAVE ARTIFACT /grype /grype
 
 grype-scan:
+    ARG ARCH
     # Use base-image so it can read original os-release file
     FROM +base-image
     COPY +grype/grype /grype

--- a/Earthfile
+++ b/Earthfile
@@ -186,7 +186,7 @@ image-sbom:
     ARG VERSION=$(cat VERSION)
 
     IF [ "$ARCH" = "arm64" ]
-        ARG ISO_NAME=${OS_ID}-${VARIANT}-$(FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
+        ARG ISO_NAME=${OS_ID}-${VARIANT}-$(echo $FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
     ELSE
         ARG ISO_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${ARCH}-${MODEL}-${VERSION}
     END
@@ -629,7 +629,7 @@ arm-image:
   COPY +version/VERSION ./
   RUN echo "version ${VERSION}"
   ARG VERSION=$(cat VERSION)
-  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-$(FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
+  ARG IMAGE_NAME=${OS_ID}-${VARIANT}-$(echo $FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
   WORKDIR /build
   # These sizes are in MB
   ENV SIZE="15200"
@@ -763,7 +763,7 @@ trivy-scan:
     ARG FLAVOR
     ARG VARIANT
     IF [ "$ARCH" = "arm64" ]
-        ARG ISO_NAME=${OS_ID}-${VARIANT}-$(FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
+        ARG ISO_NAME=${OS_ID}-${VARIANT}-$(echo $FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
     ELSE
         ARG ISO_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${ARCH}-${MODEL}-${VERSION}
     END
@@ -789,7 +789,7 @@ grype-scan:
     ARG FLAVOR
     ARG VARIANT
     IF [ "$ARCH" = "arm64" ]
-        ARG ISO_NAME=${OS_ID}-${VARIANT}-$(FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
+        ARG ISO_NAME=${OS_ID}-${VARIANT}-$(echo $FLAVOR | sed 's/-arm-rpi*//')-${ARCH}-${MODEL}-${VERSION}.img
     ELSE
         ARG ISO_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${ARCH}-${MODEL}-${VERSION}
     END


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates to #1109

## Results

Running `earthly +all` produces the following artifacts:

```
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-grype.json
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-grype.sarif
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-initrd
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty.ipxe
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-ipxe.iso.ipxe
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-ipxe-usb.img.ipxe
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty.iso
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty.iso.sha256
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-kernel
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-sbom.spdx.json
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-sbom.syft.json
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty.squashfs
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-trivy.html
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-trivy.json
kairos-core-opensuse-leap-amd64-generic-v2.3.0-11-gc84e074-dirty-trivy.sarif
```

`earthly -P +all-arm --FLAVOR=ubuntu-arm-rpi --COMPRESS_IMG=false`

```
kairos-core-ubuntu-arm64-rpi64-v2.3.0-21-gc683a90-dirty-grype.json
kairos-core-ubuntu-arm64-rpi64-v2.3.0-21-gc683a90-dirty-grype.sarif
kairos-core-ubuntu-arm64-rpi64-v2.3.0-21-gc683a90-dirty.img
kairos-core-ubuntu-arm64-rpi64-v2.3.0-21-gc683a90-dirty.img.sha256
kairos-core-ubuntu-arm64-rpi64-v2.3.0-21-gc683a90-dirty-sbom.spdx.json
kairos-core-ubuntu-arm64-rpi64-v2.3.0-21-gc683a90-dirty-sbom.syft.json
kairos-core-ubuntu-arm64-rpi64-v2.3.0-21-gc683a90-dirty-trivy.html
kairos-core-ubuntu-arm64-rpi64-v2.3.0-21-gc683a90-dirty-trivy.json
kairos-core-ubuntu-arm64-rpi64-v2.3.0-21-gc683a90-dirty-trivy.sarif
```
