### PR TITLE
:robot: Add guards to UKI test

### DIFF
--- a/tests/uki_test.go
+++ b/tests/uki_test.go
@@ -4,11 +4,21 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/spectrocloud/peg/matcher"
+	"os"
 	"strings"
 )
 
-var _ = Describe("kairos UKI test", Label("uki"), func() {
+var _ = Describe("kairos UKI test", Label("uki"), Ordered, func() {
 	var vm VM
+
+	BeforeAll(func() {
+		if os.Getenv("UKI_DRIVE") == "" {
+			Fail("UKI_DRIVE environment variable set to a UKI disk is needed for UKI test")
+		}
+		if os.Getenv("FIRMWARE") == "" {
+			Fail("FIRMWARE environment variable set to a EFI firmware is needed for UKI test")
+		}
+	})
 
 	BeforeEach(func() {
 		_, vm = startVM()


### PR DESCRIPTION
So we dont start the vm without the required env vars

Brought up by @jimmykarily 

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
To not waste CI cycles

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
