### PR TITLE
:bug: Stop kairos services in proper time

### DIFF
--- a/overlay/files/etc/systemd/system/kairos-webui.service
+++ b/overlay/files/etc/systemd/system/kairos-webui.service
@@ -3,5 +3,6 @@ Description=kairos installer
 After=sysinit.target
 [Service]
 ExecStart=/usr/bin/kairos-agent webui
+TimeoutStopSec=10s
 [Install]
 WantedBy=multi-user.target

--- a/overlay/files/etc/systemd/system/kairos.service
+++ b/overlay/files/etc/systemd/system/kairos.service
@@ -10,5 +10,6 @@ ExecStartPre=-/bin/sh -c "dmesg -D"
 TTYPath=/dev/tty1
 RemainAfterExit=yes
 ExecStart=/usr/bin/kairos-agent install
+TimeoutStopSec=10s
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Marks the services of kairos and webui with a max stop time of 10 seconds to not block when shutting down or restarting as they get the default 1m30s and that slows the whole system.

10s should be more than enough for the services to stop.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
