### PR TITLE
:bug: duplicate repository definition

### DIFF
--- a/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
+++ b/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
@@ -208,6 +208,9 @@ RUN apt-get install -y -o Dpkg::Options::="--force-overwrite" \
 RUN apt-get install -y libopencv-dev && \
     ln -s /usr/include/opencv4/opencv2 /usr/include/opencv2
 
+# Drop the repository file installed by apt (we have installed the repository manually above)
+RUN rm -rf /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+
 # Symlinks to make installer work
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install && \
     ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv


### PR DESCRIPTION
Seems that apt-get pulls down the apt source repository, but that is wrong as it does not contains the board:

```
cat nvidia-l4t-apt-source.list 
# SPDX-FileCopyrightText: Copyright (c) 2019-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
#
# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
# property and proprietary rights in and to this material, related
# documentation and any modifications thereto. Any use, reproduction,
# disclosure or distribution of this material and related documentation
# without an express license agreement from NVIDIA CORPORATION or
# its affiliates is strictly prohibited.

deb https://repo.download.nvidia.com/jetson/common r35.3 main
deb https://repo.download.nvidia.com/jetson/<SOC> r35.3 main
```

While our definitions are in: `/etc/apt/sources.list`
