### PR TITLE
:robot: Fix provider tests

### DIFF
--- a/tests/assets/config_with_rebot.yaml
+++ b/tests/assets/config_with_rebot.yaml
@@ -1,0 +1,15 @@
+#cloud-config
+
+install:
+  reboot: true
+  grub_options:
+    extra_cmdline: "rd.immucore.debug"
+
+stages:
+  initramfs:
+    - name: "Set user and password"
+      users:
+        kairos:
+          passwd: "kairos"
+    - name: "Set hostname"
+      hostname: kairos-{{ trunc 4 .Random }}

--- a/tests/provider_decentralized_test.go
+++ b/tests/provider_decentralized_test.go
@@ -103,10 +103,11 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 
 				Expect(out).Should(ContainSubstring("Kairos remote recovery"))
 
-				grub, err := vm.Sudo("cat /tmp/mnt/STATE/grub_oem_env")
-				Expect(err).ToNot(HaveOccurred(), grub)
-
-				Expect(grub).Should(ContainSubstring("default_menu_entry=Kairos"))
+				// No longer used. This is created to override the default entry but now the default entry is kairos already
+				// TODO: Create a test in acceptance to check for the creation of this file and if it has the correct override entry
+				//grub, err := vm.Sudo("cat /tmp/mnt/STATE/grub_oem_env")
+				//Expect(err).ToNot(HaveOccurred(), grub)
+				//Expect(grub).Should(ContainSubstring("default_menu_entry=Kairos"))
 
 				out, err = vm.Sudo("umount /tmp/mnt/STATE")
 				Expect(err).ToNot(HaveOccurred(), out)

--- a/tests/provider_install_qrcode_test.go
+++ b/tests/provider_install_qrcode_test.go
@@ -72,7 +72,8 @@ var _ = Describe("kairos qr code install", Label("provider", "provider-qrcode-in
 		Expect(err).ToNot(HaveOccurred(), device)
 
 		By("registering with a screenshot")
-		err = register("fatal", fileName, "./assets/config.yaml", strings.TrimSpace(device), true)
+		// pass a config that auto reboots after install as we cannot know when the machine has finished
+		err = register("fatal", fileName, "./assets/config_with_reboot.yaml", strings.TrimSpace(device), true)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("waiting until it reboots to installed system")


### PR DESCRIPTION
One test that is no longer valid and in any case should be moved to acceptance tests and the other that need an extra key in the config to auto reboot

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
