### PR TITLE
:robot: Add raw image target to earthly

### DIFF
--- a/.earthlyignore
+++ b/.earthlyignore
@@ -1,3 +1,4 @@
 build/*iso
 # this is created by the strat_vm_qemu.sh script
 disk.img
+*.raw

--- a/Earthfile
+++ b/Earthfile
@@ -740,6 +740,10 @@ ipxe-iso:
     SAVE ARTIFACT /build/ipxe/src/bin/ipxe.iso iso AS LOCAL build/${ISO_NAME}-ipxe.iso
     SAVE ARTIFACT /build/ipxe/src/bin/ipxe.usb usb AS LOCAL build/${ISO_NAME}-ipxe-usb.img
 
+# Uses the same config as in the docs: https://kairos.io/docs/advanced/build/#build-a-cloud-image
+# This is the default for cloud images which only come with the recovery partition and the workflow
+# is to boot from them and do a reset to get the latest system installed
+# This allows us to build a raw disk image locally to test the cloud workflow easily
 raw-image:
     ARG TARGETARCH
     COPY +version/VERSION ./

--- a/Earthfile
+++ b/Earthfile
@@ -740,6 +740,21 @@ ipxe-iso:
     SAVE ARTIFACT /build/ipxe/src/bin/ipxe.iso iso AS LOCAL build/${ISO_NAME}-ipxe.iso
     SAVE ARTIFACT /build/ipxe/src/bin/ipxe.usb usb AS LOCAL build/${ISO_NAME}-ipxe-usb.img
 
+raw-image:
+    ARG TARGETARCH
+    COPY +version/VERSION ./
+    RUN echo "version ${VERSION}"
+    ARG VERSION=$(cat VERSION)
+    ARG IMG_NAME=${OS_ID}-${VARIANT}-${FLAVOR}-${TARGETARCH}-${MODEL}-${VERSION}.raw
+    ARG OSBUILDER_IMAGE
+    FROM $OSBUILDER_IMAGE
+    WORKDIR /build
+    COPY tests/assets/raw_image.yaml /raw_image.yaml
+    COPY --keep-own +image-rootfs/rootfs /rootfs
+    RUN /raw-images.sh /rootfs /$IMG_NAME /raw_image.yaml
+    RUN truncate -s "+$((32000*1024*1024))" /$IMG_NAME
+    SAVE ARTIFACT /$IMG_NAME $IMG_NAME AS LOCAL build/$IMG_NAME
+
 # Generic targets
 # usage e.g. ./earthly.sh +datasource-iso --CLOUD_CONFIG=tests/assets/qrcode.yaml
 datasource-iso:

--- a/tests/assets/raw_image.yaml
+++ b/tests/assets/raw_image.yaml
@@ -1,0 +1,30 @@
+#cloud-config
+
+users:
+  - name: "kairos"
+    passwd: "kairos"
+name: "Default deployment"
+stages:
+  boot:
+    - name: "Repart image"
+      layout:
+        device:
+          label: COS_RECOVERY
+        add_partitions:
+          - fsLabel: COS_STATE
+            size: 16240 # At least 16gb
+            pLabel: state
+    - name: "Repart image"
+      layout:
+        device:
+          label: COS_RECOVERY
+        add_partitions:
+          - fsLabel: COS_PERSISTENT
+            pLabel: persistent
+            size: 0 # all space
+    - if: '[ -f "/run/cos/recovery_mode" ] && [ ! -e /usr/local/.deployed ]'
+      name: "Deploy kairos"
+      commands:
+        - kairos-agent --debug reset --unattended
+        - touch /usr/local/.deployed
+        - reboot

--- a/tests/assets/raw_image.yaml
+++ b/tests/assets/raw_image.yaml
@@ -1,4 +1,7 @@
 #cloud-config
+# same config as in the docs: https://kairos.io/docs/advanced/build/#build-a-cloud-image
+# This is the default for cloud images which only come with the recovery partition and the workflow
+# is to boot from them and do a reset to get the latest system installed
 
 users:
   - name: "kairos"


### PR DESCRIPTION
Useful to emulate what osbuilder does to build cloud images for local testing

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
