### PR TITLE
:seedling: Add /var/lib/containerd to bind paths

### DIFF
--- a/overlay/files/system/oem/00_rootfs.yaml
+++ b/overlay/files/system/oem/00_rootfs.yaml
@@ -38,6 +38,7 @@ stages:
           /var/snap
           /usr/libexec
           /var/log
+          /var/lib/containerd
           /var/lib/rancher
           /var/lib/kubelet
           /var/lib/snapd
@@ -80,6 +81,7 @@ stages:
           /var/snap
           /usr/libexec
           /var/log
+          /var/lib/containerd
           /var/lib/rancher
           /var/lib/kubelet
           /var/lib/snapd
@@ -117,6 +119,7 @@ stages:
           /var/snap
           /usr/libexec
           /var/log
+          /var/lib/containerd
           /var/lib/rancher
           /var/lib/kubelet
           /var/lib/snapd


### PR DESCRIPTION
Seems an important dir to have it persistent, plus containerd snapshot will not work on an overlay system

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
