### PR TITLE
Fix arm pipeline dependency

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     if: failure()
     needs:
-      - docker
+      - build-arm-core
       - image_and_iso_arm64_generic
     steps:
       - name: save commit-message


### PR DESCRIPTION
Master ARM pipeline is currently failing with

```
Invalid workflow file: .github/workflows/image-arm.yaml#L90
The workflow is not valid. .github/workflows/image-arm.yaml (Line: 90, Col: 9): Job 'notify' depends on unknown job 'docker'.
```
see https://github.com/kairos-io/kairos/actions/runs/5819487177

this is because the name was changed during the refactoring