### PR TITLE
Bundle luet versions in the framework

### DIFF
--- a/.github/workflows/bump_repos.yml
+++ b/.github/workflows/bump_repos.yml
@@ -13,8 +13,36 @@ jobs:
         with:
           repository: quay.io/kairos/packages
           packages: utils/earthly
+      - name: Old packages
+        run: |
+          earthly +base-image --VARIANT=standard --FLAVOR=opensuse-leap --K3S_VERSION=latest
+          mv build/versions.yaml build/versions.old.yaml
       - name: Bump cos 🔧
         run: earthly +bump-repositories
+      - name: New packages
+        run: |
+          earthly +base-image --VARIANT=standard --FLAVOR=opensuse-leap --K3S_VERSION=latest
+          mv build/versions.yaml build/versions.new.yaml
+      - name: Diff versions
+        run: |
+          yq -i -P '.|=sort_by(.name)|.[]|[{"name": .name, "category": .category, "version": .version}]' build/versions.old.yaml
+          yq -i -P '.|=sort_by(.name)|.[]|[{"name": .name, "category": .category, "version": .version}]' build/versions.new.yaml
+          echo "Bump of Kairos repositories" > pr-message
+          echo "--------------------------" >> pr-message
+          DIFF=$(diff -u build/versions.old.yaml build/versions.new.yaml)
+          if [[ $? == 1 ]]; then
+            echo "> [\!WARNING]" >> pr-message
+            echo "> There were changes to installed packages" >> pr-message
+            echo "\`\`\`diff" >> pr-message
+            echo "${DIFF}" >> pr-message
+            echo "\`\`\`" >> pr-message
+            echo "\n" >> pr-message
+          fi
+          echo "> [\!IMPORTANT]" >> pr-message
+          echo "> Full package list from new repo" >> pr-message
+          echo "\`\`\`yaml" >> pr-message
+          echo "$(cat build/versions.new.yaml)" >> pr-message
+          echo "\`\`\`" >> pr-message
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
@@ -22,5 +50,5 @@ jobs:
           push-to-fork: ci-robbot/c3os
           commit-message: ':arrow_up: Update repositories'
           title: ':arrow_up: Update repositories'
-          body: Bump of Kairos repositories
+          body-path: pr-message
           signoff: true

--- a/.github/workflows/reusable-build-flavor.yaml
+++ b/.github/workflows/reusable-build-flavor.yaml
@@ -99,6 +99,7 @@ jobs:
           path: |
             *.iso
             *.sha256
+            versions.yaml
           if-no-files-found: error
       - uses: actions/upload-artifact@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/reusable-build-provider.yaml
+++ b/.github/workflows/reusable-build-provider.yaml
@@ -69,6 +69,7 @@ jobs:
           path: |
             *.iso
             *.sha256
+            versions.yaml
           if-no-files-found: error
       - name: Push to testing
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 coverage.out
 .DS_Store
 internal/webui/public/cypress/videos/
+pr-message
 
 node_modules/
 


### PR DESCRIPTION
Use the new luet 0.35 which provides a way of storing the installed artifacts in the system to bundle the versions file with the framework files so we always have a reference for what was installed in the framework and what versions.

Also reworks the CI pipeline for the bump repos to provide a diff of changes to **installed** packages, not to the full repo unfortunately, as part of the PR creation so its easily visible what changed that directly affects kairos

Also during iso building, extract and upload the versions to the artifacts so its easier to check what packages were installed in a given iso during CI.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
