### PR TITLE
Fix test that wasn't testing anything

### DIFF
--- a/tests/assets/suc.yaml
+++ b/tests/assets/suc.yaml
@@ -9,13 +9,14 @@ metadata:
 spec:
   concurrency: 1
   #version:  latest
-  version: "opensuse-v1.23.5-44"
+  version: "v2.3.1-k3sv1.25.11-k3s1"
+
   nodeSelector:
     matchExpressions:
       - {key: kubernetes.io/hostname, operator: Exists}
   serviceAccountName: system-upgrade
   cordon: false
   upgrade:
-    image: quay.io/kairos/kairos
+    image: quay.io/kairos/kairos-opensuse-leap
     command:
     - "/usr/sbin/suc-upgrade"

--- a/tests/provider_upgrade_k8s_test.go
+++ b/tests/provider_upgrade_k8s_test.go
@@ -125,7 +125,7 @@ var _ = Describe("k3s upgrade test", Label("provider", "provider-upgrade-k8s"), 
 			fmt.Printf("out = %+v\n", out)
 			return out
 
-		}, 900*time.Second, 10*time.Second).ShouldNot(And(ContainSubstring("Pending"), ContainSubstring("ContainerCreating")))
+		}, 900*time.Second, 10*time.Second).ShouldNot(Or(ContainSubstring("Pending"), ContainSubstring("ContainerCreating")))
 
 		By("applying upgrade plan")
 		err = vm.Scp("assets/suc.yaml", "./suc.yaml", "0770")
@@ -145,6 +145,6 @@ var _ = Describe("k3s upgrade test", Label("provider", "provider-upgrade-k8s"), 
 			out, _ = kubectl(vm, "get pods -A")
 			version, _ := vm.Sudo(getVersionCmd)
 			return version
-		}, 30*time.Minute, 10*time.Second).Should(ContainSubstring("v"), out)
+		}, 30*time.Minute, 10*time.Second).Should(ContainSubstring("v2.3.1-k3sv1.25.11+k3s1"), out)
 	})
 })

--- a/tests/provider_upgrade_k8s_test.go
+++ b/tests/provider_upgrade_k8s_test.go
@@ -3,8 +3,11 @@ package mos_test
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -141,10 +144,26 @@ var _ = Describe("k3s upgrade test", Label("provider", "provider-upgrade-k8s"), 
 			return out
 		}, 900*time.Second, 10*time.Second).Should(ContainSubstring("apply-os-upgrade-on-"), out)
 
+		expectedVersion := getExpectedVersion()
+
 		Eventually(func() string {
 			out, _ = kubectl(vm, "get pods -A")
 			version, _ := vm.Sudo(getVersionCmd)
+			fmt.Printf("version = %+v\n", version)
 			return version
-		}, 30*time.Minute, 10*time.Second).Should(ContainSubstring("v2.3.1-k3sv1.25.11+k3s1"), out)
+		}, 30*time.Minute, 10*time.Second).Should(ContainSubstring(expectedVersion), out)
 	})
 })
+
+func getExpectedVersion() string {
+	b, err := os.ReadFile("assets/suc.yaml")
+	Expect(err).ToNot(HaveOccurred())
+
+	yamlData := make(map[string]interface{})
+	err = yaml.Unmarshal(b, &yamlData)
+
+	Expect(err).ToNot(HaveOccurred())
+	spec := yamlData["spec"].(map[string]interface{})
+
+	return strings.TrimSuffix(spec["version"].(string), "-k3s1")
+}

--- a/tests/provider_upgrade_latest_k8s_test.go
+++ b/tests/provider_upgrade_latest_k8s_test.go
@@ -148,10 +148,9 @@ var _ = Describe("k3s upgrade test from k8s", Label("provider", "provider-upgrad
 		By("wait for all containers to be in running state")
 		Eventually(func() string {
 			out, _ := kubectl(vm, "get pods -A")
-			fmt.Printf("out = %+v\n", out)
 			return out
 
-		}, 900*time.Second, 10*time.Second).ShouldNot(And(ContainSubstring("Pending"), ContainSubstring("ContainerCreating")))
+		}, 900*time.Second, 10*time.Second).ShouldNot(Or(ContainSubstring("Pending"), ContainSubstring("ContainerCreating")))
 
 		By("triggering an upgrade")
 		suc := sucYAML(strings.ReplaceAll(containerImage, ":24h", ""), "24h")


### PR DESCRIPTION
because it was returning success too early since the checks were too loose or even wrong.

E.g. we didn't even wait for the Pods to be ready (wrong test condition) and we only tested that there is a "v" in the version which was true even before the upgrade.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
