### PR TITLE
Bring back the bootargs.cfg files to the base image

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -313,7 +313,7 @@ base-image:
         # defined using MODEL and TARGETARCH.
         ARG SIMPLE_FLAVOR=$(echo $FLAVOR | sed 's/-arm-.*//')
 
-        FROM DOCKERFILE --build-arg MODEL=$MODEL --build-arg FLAVOR=$SIMPLE_FLAVOR -f images/Dockerfile.$DISTRO .
+        FROM DOCKERFILE --build-arg MODEL=$MODEL --build-arg FLAVOR=$SIMPLE_FLAVOR -f images/Dockerfile.$DISTRO images/
     ELSE
         FROM $BASE_IMAGE
     END

--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -174,9 +174,9 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20230822094954-repository.yaml
+    reference: 20230822122456-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20230822100213-repository.yaml
+    reference: 20230822123242-repository.yaml

--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -174,9 +174,9 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20230818143315-repository.yaml
+    reference: 20230822094954-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20230818143650-repository.yaml
+    reference: 20230822100213-repository.yaml

--- a/images/Dockerfile.almalinux
+++ b/images/Dockerfile.almalinux
@@ -45,6 +45,8 @@ RUN dnf install -y \
     which \
     https://zfsonlinux.org/epel/zfs-release-2-2.el9.noarch.rpm && dnf clean all
 
+COPY redhat/bootargs.cfg /etc/cos/bootargs.cfg
+
 RUN mkdir -p /run/lock
 RUN touch /usr/libexec/.keep
 RUN systemctl enable getty@tty1.service

--- a/images/Dockerfile.alpine
+++ b/images/Dockerfile.alpine
@@ -93,9 +93,14 @@ RUN apk --no-cache add  \
       bridge \
       grub-bios \
       rbd-nbd
+RUN alpine/bootargs.cfg /etc/cos/bootargs.cfg
 
-FROM common AS rpi3
-FROM common AS rpi4
+FROM common as rpicommon
+RUN rpi/bootargs.cfg /etc/cos/bootargs.cfg
+
+FROM rpicommon AS rpi3
+FROM rpicommon AS rpi4
+
 
 ###############################################################
 ####               Post-Process Common to All              ####

--- a/images/Dockerfile.alpine
+++ b/images/Dockerfile.alpine
@@ -93,10 +93,10 @@ RUN apk --no-cache add  \
       bridge \
       grub-bios \
       rbd-nbd
-RUN alpine/bootargs.cfg /etc/cos/bootargs.cfg
+COPY alpine/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM common as rpicommon
-RUN rpi/bootargs.cfg /etc/cos/bootargs.cfg
+COPY rpi/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM rpicommon AS rpi3
 FROM rpicommon AS rpi4

--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -114,6 +114,7 @@ RUN apt-get update \
     qemu-guest-agent \
     zfsutils-linux \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY debian/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM common AS rpicommon
 RUN sed -i 's/^Components: main.*$/& non-free-firmware/' /etc/apt/sources.list.d/debian.sources
@@ -124,6 +125,7 @@ RUN apt-get update \
     linux-image-arm64 \
     raspi-firmware \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY rpi/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM rpicommon AS rpi3
 FROM rpicommon AS rpi4

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -46,6 +46,8 @@ RUN dnf install -y \
     which \
     zfs && dnf clean all
 
+COPY redhat/bootargs.cfg /etc/cos/bootargs.cfg
+
 RUN mkdir -p /run/lock && \
   touch /usr/libexec/.keep && \
   systemctl enable getty@tty1.service && \

--- a/images/Dockerfile.opensuse-leap
+++ b/images/Dockerfile.opensuse-leap
@@ -70,7 +70,7 @@ RUN zypper in --force-resolution -y \
 ###############################################################
 ####                          Model                        ####
 ###############################################################
-FROM common AS  generic
+FROM common AS generic
 RUN zypper in --force-resolution -y \
     cryptsetup \
     grub2-i386-pc \
@@ -79,6 +79,7 @@ RUN zypper in --force-resolution -y \
     lldpd \
     qemu-guest-agent \
     && zypper cc
+COPY opensuse/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM common AS rpicommon
 RUN zypper in --force-resolution -y \
@@ -105,6 +106,7 @@ RUN zypper in --force-resolution -y \
     wireless-tools \
     wpa_supplicant \
     && zypper cc
+COPY rpi/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM rpicommon as rpi3
 FROM rpicommon as rpi4

--- a/images/Dockerfile.opensuse-tumbleweed
+++ b/images/Dockerfile.opensuse-tumbleweed
@@ -114,6 +114,7 @@ FROM ${TARGETARCH} AS generic
 RUN zypper in --force-resolution -y \
     qemu-guest-agent \
     && zypper cc
+COPY opensuse/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM ${TARGETARCH} AS rpicommon
 RUN zypper in --force-resolution -y \
@@ -126,6 +127,7 @@ RUN zypper in --force-resolution -y \
     wireless-tools \
     wpa_supplicant \
     && zypper cc
+COPY rpi/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM rpicommon AS rpi3
 FROM rpicommon AS rpi4

--- a/images/Dockerfile.rockylinux
+++ b/images/Dockerfile.rockylinux
@@ -46,6 +46,8 @@ RUN dnf install -y \
     https://zfsonlinux.org/epel/zfs-release-2-2.el9.noarch.rpm \
     && dnf clean all
 
+COPY redhat/bootargs.cfg /etc/cos/bootargs.cfg
+
 RUN mkdir -p /run/lock
 RUN touch /usr/libexec/.keep
 RUN systemctl enable getty@tty1.service

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -147,11 +147,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-base \
     qemu-guest-agent \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY debian/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM ${TARGETARCH}-${FLAVOR} AS rpicommon
 RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-raspi \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY rpi/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM rpicommon AS ubuntu-20-lts-rpi
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
+++ b/images/Dockerfile.ubuntu-20-lts-arm-nvidia-jetson-agx-orin
@@ -218,6 +218,8 @@ RUN apt-get install -y libopencv-dev && \
 # Drop the repository file installed by apt (we have installed the repository manually above)
 RUN rm -rf /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
 
+COPY nvidia/bootargs.cfg /etc/cos/bootargs.cfg
+
 # Symlinks to make installer work
 RUN ln -s /usr/sbin/grub-install /usr/sbin/grub2-install && \
     ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv

--- a/images/alpine/bootargs.cfg
+++ b/images/alpine/bootargs.cfg
@@ -1,0 +1,10 @@
+set kernel=/boot/vmlinuz
+if [ -n "$recoverylabel" ]; then
+    # Boot arguments when the image is used as recovery
+    set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.cos.oemlabel=COS_OEM"
+else
+    # Boot arguments when the image is used as active/passive
+    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img rd.emergency=reboot rd.shell=0 panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1 fsck.mode=force fsck.repair=yes systemd.crash_reboot=yes"
+fi
+
+set initramfs=/boot/initrd

--- a/images/debian/bootargs.cfg
+++ b/images/debian/bootargs.cfg
@@ -1,0 +1,8 @@
+set kernel=/boot/vmlinuz
+if [ -n "$recoverylabel" ]; then
+    set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.cos.oemlabel=COS_OEM"
+else
+    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label cos-img/filename=$img panic=5 security=selinux selinux=1 rd.cos.oemlabel=COS_OEM rd.neednet=0 vga=795"
+fi
+
+set initramfs=/boot/initrd

--- a/images/nvidia/bootargs.cfg
+++ b/images/nvidia/bootargs.cfg
@@ -1,0 +1,9 @@
+set kernel=/boot/vmlinuz
+
+if [ -n "$recoverylabel" ]; then
+    set kernelcmd="console=tty1 console=ttyTCU0,115200 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.cos.oemtimeout=10"
+else
+    set kernelcmd="console=tty1 console=ttyTCU0,115200 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux selinux=1 rd.cos.oemtimeout=10 rd.cos.oemlabel=COS_OEM"
+fi
+
+set initramfs=/boot/initrd

--- a/images/opensuse/bootargs.cfg
+++ b/images/opensuse/bootargs.cfg
@@ -1,0 +1,10 @@
+set kernel=/boot/vmlinuz
+if [ -n "$recoverylabel" ]; then
+    # Boot arguments when the image is used as recovery
+    set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.cos.oemlabel=COS_OEM"
+else
+    # Boot arguments when the image is used as active/passive
+    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img rd.emergency=reboot rd.shell=0 panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1 fsck.mode=force fsck.repair=yes systemd.crash_reboot=yes"
+fi
+
+set initramfs=/boot/initrd

--- a/images/redhat/bootargs.cfg
+++ b/images/redhat/bootargs.cfg
@@ -1,0 +1,11 @@
+set kernel=/boot/vmlinuz
+# temporarly disabling SELinux until we have a profile (https://github.com/kairos-io/kairos/issues/114)
+if [ -n "$recoverylabel" ]; then
+    # Boot arguments when the image is used as recovery
+    set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5 selinux=0 rd.cos.oemlabel=COS_OEM"
+else
+    # Boot arguments when the image is used as active/passive
+    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 rd.cos.oemlabel=COS_OEM selinux=0"
+fi
+
+set initramfs=/boot/initrd

--- a/images/rpi/bootargs.cfg
+++ b/images/rpi/bootargs.cfg
@@ -1,0 +1,18 @@
+set kernel=/boot/vmlinuz
+
+# Note on RPI bootargs
+# We additionally set modprobe.blacklist=vc4 as certain Displays are not supported by vc4.
+# As kairos main target is cloud and not graphics usage, we blacklist it to avoid 
+# that the HDMI output goes off due to drivers kicking during boot. vc4 is required where graphics
+# or video playback is needed, which is not the case in this example here.
+# A similar workaround could be applied at config.txt level, by diabling the vc4 overlay.
+# See also: https://en.opensuse.org/HCL:Raspberry_Pi3#I_see_HDMI_output_in_U-Boot.2C_but_not_in_Linux ,
+# https://en.opensuse.org/HCL:Raspberry_Pi3#DSI_output_not_supported_by_VC4_driver,
+# https://bugzilla.opensuse.org/show_bug.cgi?id=1181683 and https://github.com/raspberrypi/linux/issues/4020
+if [ -n "$recoverylabel" ]; then
+    set kernelcmd="console=tty1 console=ttyS0,115200 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 modprobe.blacklist=vc4 rd.cos.oemtimeout=10"
+else
+    set kernelcmd="console=tty1 console=ttyS0,115200 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux selinux=1 modprobe.blacklist=vc4 rd.cos.oemtimeout=10 rd.cos.oemlabel=COS_OEM"
+fi
+
+set initramfs=/boot/initrd


### PR DESCRIPTION
because we need them before any stages are run (grub needs them)

Related PR that removes them from the luet package: https://github.com/kairos-io/packages/pull/391


