### PR TITLE
Fix rpi4 serial

### DIFF
--- a/images/Dockerfile.alpine
+++ b/images/Dockerfile.alpine
@@ -97,6 +97,7 @@ COPY alpine/bootargs.cfg /etc/cos/bootargs.cfg
 
 FROM common as rpicommon
 COPY rpi/bootargs.cfg /etc/cos/bootargs.cfg
+COPY rpi/config.txt /boot/config.txt
 
 FROM rpicommon AS rpi3
 FROM rpicommon AS rpi4

--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -126,6 +126,7 @@ RUN apt-get update \
     raspi-firmware \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY rpi/bootargs.cfg /etc/cos/bootargs.cfg
+COPY rpi/config.txt /boot/config.txt
 
 FROM rpicommon AS rpi3
 FROM rpicommon AS rpi4

--- a/images/Dockerfile.opensuse-leap
+++ b/images/Dockerfile.opensuse-leap
@@ -107,6 +107,7 @@ RUN zypper in --force-resolution -y \
     wpa_supplicant \
     && zypper cc
 COPY rpi/bootargs.cfg /etc/cos/bootargs.cfg
+COPY rpi/config.txt /boot/config.txt
 
 FROM rpicommon as rpi3
 FROM rpicommon as rpi4

--- a/images/Dockerfile.opensuse-tumbleweed
+++ b/images/Dockerfile.opensuse-tumbleweed
@@ -128,6 +128,7 @@ RUN zypper in --force-resolution -y \
     wpa_supplicant \
     && zypper cc
 COPY rpi/bootargs.cfg /etc/cos/bootargs.cfg
+COPY rpi/config.txt /boot/config.txt
 
 FROM rpicommon AS rpi3
 FROM rpicommon AS rpi4

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -154,6 +154,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-raspi \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY rpi/bootargs.cfg /etc/cos/bootargs.cfg
+COPY rpi/config.txt /boot/config.txt
 
 FROM rpicommon AS ubuntu-20-lts-rpi
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/images/rpi/bootargs.cfg
+++ b/images/rpi/bootargs.cfg
@@ -9,10 +9,13 @@ set kernel=/boot/vmlinuz
 # See also: https://en.opensuse.org/HCL:Raspberry_Pi3#I_see_HDMI_output_in_U-Boot.2C_but_not_in_Linux ,
 # https://en.opensuse.org/HCL:Raspberry_Pi3#DSI_output_not_supported_by_VC4_driver,
 # https://bugzilla.opensuse.org/show_bug.cgi?id=1181683 and https://github.com/raspberrypi/linux/issues/4020
+# Regarding 8250.nr_uarts : https://forums.raspberrypi.com/viewtopic.php?t=246215#p1659905
+# If not set, ttyS0 produces this error in journalctl (and serial doesn't work):
+#   bcm2835-aux-uart: probe of fe215040.serial failed with error -28
 if [ -n "$recoverylabel" ]; then
-    set kernelcmd="console=tty1 console=ttyS0,115200 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 modprobe.blacklist=vc4 rd.cos.oemtimeout=10"
+    set kernelcmd="console=tty1 console=ttyS0,115200 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 modprobe.blacklist=vc4 rd.cos.oemtimeout=10 8250.nr_uarts=1"
 else
-    set kernelcmd="console=tty1 console=ttyS0,115200 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux selinux=1 modprobe.blacklist=vc4 rd.cos.oemtimeout=10 rd.cos.oemlabel=COS_OEM"
+    set kernelcmd="console=tty1 console=ttyS0,115200 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux selinux=1 modprobe.blacklist=vc4 rd.cos.oemtimeout=10 rd.cos.oemlabel=COS_OEM 8250.nr_uarts=1"
 fi
 
 set initramfs=/boot/initrd

--- a/images/rpi/config.txt
+++ b/images/rpi/config.txt
@@ -1,7 +1,6 @@
 # https://emteria.com/kb/connect-uart-rpi 
 # https://www.raspberrypi.com/documentation/computers/config_txt.html
 enable_uart=1
-console=serial0
 uart_2ndstage=1
 
 # Disabling bluetooth might change the serial device:

--- a/images/rpi/config.txt
+++ b/images/rpi/config.txt
@@ -1,0 +1,10 @@
+# https://emteria.com/kb/connect-uart-rpi 
+# https://www.raspberrypi.com/documentation/computers/config_txt.html
+enable_uart=1
+console=serial0
+uart_2ndstage=1
+
+# Disabling bluetooth might change the serial device:
+# https://raspberrypi.stackexchange.com/a/69721
+# On rpi4, if bluetooth is not disabled (like here), the device is /dev/ttyS0
+#dtoverlay=disable-bt


### PR DESCRIPTION
Fixes the serial output on rpi4. We also need to check if this works on rpi3 otherwise we have to apply this only on rpi4.

Also this fix is an explicit fix  for the `mini-uart's driver (8250)`. I'm not sure if there are other versions of that driver out there that need a similar option in the cmdline