### PR TITLE
Reduce calls to release API

### DIFF
--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -2,7 +2,7 @@ name: Build arm images
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 jobs:
   get-core-matrix:
     runs-on: ubuntu-latest
@@ -138,6 +138,10 @@ jobs:
                 http = true
           EOF
           docker run --privileged -v $HOME/.earthly/config.yml:/etc/.earthly/config.yml -v /var/run/docker.sock:/var/run/docker.sock --rm --env EARTHLY_BUILD_ARGS -t -v "$(pwd)":/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.7.5 --allow-privileged +all-arm -VARIANT=core --MODEL=${{ matrix.model }} --FLAVOR=${{ matrix.flavor }}
+      - name: Convert all json files into a reports.tar.gz file
+        run: |
+          export VERSION=$(cat build/VERSION)
+          sudo tar cvf kairos-core-${matrix.flavor}-arm64-${matrix.model}-${VERSION}-scan-reports.tar.gz build/*.json
       - name: Push  🔧
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -165,7 +169,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            build/*.json
+            build/*scan-reports.tar.gz
       - name: Prepare sarif files  🔧
         run: |
           mkdir sarif
@@ -268,6 +272,10 @@ jobs:
 
           docker run --privileged -v $HOME/.earthly/config.yml:/etc/.earthly/config.yml -v /var/run/docker.sock:/var/run/docker.sock --rm --env EARTHLY_BUILD_ARGS -t -v "$(pwd)":/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.7.5 --allow-privileged +all-arm -VARIANT=standard -K3S_VERSION=${{ matrix.k3s_version }} --MODEL=${{ matrix.model }} --FLAVOR=${{ matrix.flavor }}
 
+      - name: Convert all json files into a reports.tar.gz file
+        run: |
+          export VERSION=$(cat build/VERSION)
+          sudo tar cvf kairos-standard-${matrix.flavor}-arm64-${matrix.model}-${VERSION}-scan-reports.tar.gz build/*.json
       - name: Push  🔧
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -295,7 +303,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            build/*.json
+            build/*scan-reports.tar.gz
       - name: Prepare sarif files  🔧
         run: |
           mkdir sarif
@@ -345,7 +353,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            release/*
+            release/*iso*
 
   build-arm-generic-standard:
     runs-on: ubuntu-latest
@@ -385,4 +393,4 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            release/*
+            release/*iso*


### PR DESCRIPTION
relates to #1766 

From the generic, there are files that don't need to be uploaded, with this change we only upload iso and sha

From the other models, we group all json files into a single scan-reports.tar.gz so we make a few calls less per flavor/version
