### PR TITLE
:sparkles: Cache testing image and simplify scripts

### DIFF
--- a/.github/workflows/reusable-qemu-acceptance-test.yaml
+++ b/.github/workflows/reusable-qemu-acceptance-test.yaml
@@ -62,5 +62,4 @@ jobs:
         repository: quay.io/kairos/packages
         packages: utils/earthly
     - run: |
-            earthly +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
             earthly +run-qemu-datasource-tests --PREBUILT_ISO=$(ls kairos-core-*${{ inputs.flavor }}*.iso) --FLAVOR=${{ inputs.flavor }} --SSH_PORT=${{ inputs.port }}

--- a/.github/workflows/reusable-qemu-reset-test.yaml
+++ b/.github/workflows/reusable-qemu-reset-test.yaml
@@ -41,5 +41,4 @@ jobs:
                   insecure = true
                   http = true
             EOF
-            earthly -P +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
             earthly -P +run-qemu-datasource-tests --PREBUILT_ISO=$(ls kairos-core-*${{ inputs.flavor }}*.iso) --TEST_SUITE=reset-test --FLAVOR=${{ inputs.flavor }}


### PR DESCRIPTION
- adds a golang-testing image which is cached for the golang version. No need to re-build on every test saving some time
- Reduce external call to generate datasource-iso, since the test call already does it internally and the artifact is not being used anywhere else 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
relates to #1708 
