### PR TITLE
Easy option to build non-hwe kernels

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -300,6 +300,7 @@ base-image:
     ARG KAIROS_VERSION
     ARG BUILD_INITRD="true"
     ARG TARGETARCH
+    ARG HWE
 
     IF [ "$BASE_IMAGE" = "" ]
         # DISTRO is used to match the Linux distribution in the Dockerfile e.g. Dockerfile.ubuntu
@@ -320,7 +321,7 @@ base-image:
         # defined using MODEL and TARGETARCH.
         ARG SIMPLE_FLAVOR=$(echo $FLAVOR | sed 's/-arm-.*//')
 
-        FROM DOCKERFILE --build-arg MODEL=$MODEL --build-arg FLAVOR=$SIMPLE_FLAVOR -f images/Dockerfile.$DISTRO images/
+        FROM DOCKERFILE --build-arg MODEL=$MODEL --build-arg FLAVOR=$SIMPLE_FLAVOR --build-arg HWE=$HWE -f images/Dockerfile.$DISTRO images/
     ELSE
         FROM $BASE_IMAGE
     END

--- a/Earthfile
+++ b/Earthfile
@@ -300,6 +300,9 @@ base-image:
     ARG KAIROS_VERSION
     ARG BUILD_INITRD="true"
     ARG TARGETARCH
+    # HWE is used to determine if the HWE kernel should be installed on Ubuntu LTS.
+    # The default value is empty, which means the HWE kernel WILL be installed
+    # if you want to disable the HWE kernel, set HWE to "-non-hwe"
     ARG HWE
 
     IF [ "$BASE_IMAGE" = "" ]

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -1,9 +1,22 @@
 ###############################################################
 ####                           ARGS                        ####
 ###############################################################
+# Currently supported flavors are:
+#   - ubuntu
+#   - ubuntu-20-lts
+#   - ubuntu-22-lts
 ARG FLAVOR
+# Currently supported models are:
+#   - generic
+#   - rpi4
+#   - rpi3
 ARG MODEL=generic
+# HWE is used to determine if the HWE kernel should be installed
+# the default value is empty, which means the HWE kernel WILL be installed
+# if you want to disable the HWE kernel, set HWE to "-non-hwe"
 ARG HWE=""
+# TARGETARCH is used to determine the architecture of the image
+# it is already set by Docker so it doesn't need to be defined here
 
 ###############################################################
 ####                     Upstream Images                   ####

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -3,6 +3,7 @@
 ###############################################################
 ARG FLAVOR
 ARG MODEL=generic
+ARG HWE=""
 
 ###############################################################
 ####                     Upstream Images                   ####
@@ -44,7 +45,9 @@ RUN apt-get update \
     iputils-ping \
     jq \
     kbd \
+    krb5-locales \
     less \
+    lldpd \
     lvm2 \
     nano \
     nbd-client \
@@ -56,11 +59,13 @@ RUN apt-get update \
     parted \
     rsync \
     snapd \
+    snmpd \
     squashfs-tools \
     sudo \
     systemd \
     systemd-timesyncd \
     tar \
+    ubuntu-advantage-tools \
     xz-utils \
     && apt-get remove -y unattended-upgrades && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -106,55 +111,55 @@ RUN apt-get update \
 ###############################################################
 ####            Common to an Arch and Flavor               ####
 ###############################################################
-FROM ${TARGETARCH} AS amd64-ubuntu
+FROM ${TARGETARCH} AS base-20-lts
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    file \
+    fuse \
+    patch \
+    policykit-1 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+FROM ${TARGETARCH} AS base-22-lts
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dracut-live \
-    linux-image-generic-hwe-22.04 \
+    firmware-sof-signed \
+    fuse3 \
+    pigz \
     polkitd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM ${TARGETARCH} AS amd64-ubuntu-20-lts-non-hwe
+FROM base-22-lts AS hwe-22-lts
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    linux-image-generic \
+    linux-image-generic-hwe-22.04 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM ${TARGETARCH} AS amd64-ubuntu-20-lts
+FROM base-20-lts AS hwe-20-lts
 RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-image-generic-hwe-20.04 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM ${TARGETARCH} AS amd64-ubuntu-22-lts
+FROM base-22-lts AS non-hwe-20-lts
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    dracut-live \
-    linux-image-generic-hwe-22.04 \
-    polkitd \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-FROM ${TARGETARCH} AS amd64-ubuntu-22-lts-non-hwe
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    dracut-live \
     linux-image-generic \
-    polkitd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM ${TARGETARCH} AS arm64-ubuntu
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    dracut-live \
-    polkitd \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM non-hwe-20-lts AS non-hwe-22-lts
 
-FROM ${TARGETARCH} AS arm64-ubuntu-20-lts
+FROM hwe-22-lts AS amd64-ubuntu
+FROM hwe-22-lts AS amd64-ubuntu-22-lts
+FROM hwe-20-lts AS amd64-ubuntu-20-lts
 
-FROM ${TARGETARCH} AS arm64-ubuntu-22-lts
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    dracut-live \
-    polkitd \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM non-hwe-22-lts AS amd64-ubuntu-22-lts-non-hwe
+FROM non-hwe-20-lts AS amd64-ubuntu-20-lts-non-hwe
+
+FROM base-22-lts AS arm64-ubuntu
+FROM base-22-lts AS arm64-ubuntu-22-lts
+FROM base-20-lts AS arm64-ubuntu-20-lts
 
 ###############################################################
 ####               Common to a Single Model                ####
 ###############################################################
-FROM ${TARGETARCH}-${FLAVOR} AS generic
+FROM ${TARGETARCH}-${FLAVOR}${HWE} AS generic
 RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-base \
     qemu-guest-agent \
@@ -182,8 +187,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM generic AS amd64-ubuntu-generic
 FROM generic AS amd64-ubuntu-22-lts-generic
 FROM generic AS amd64-ubuntu-20-lts-generic
-FROM generic AS amd64-ubuntu-22-lts-non-hwe-generic
-FROM generic AS amd64-ubuntu-20-lts-non-hwe-generic
 FROM generic AS arm64-ubuntu-generic
 FROM ubuntu-rpi AS arm64-ubuntu-rpi3
 FROM ubuntu-rpi AS arm64-ubuntu-rpi4
@@ -199,39 +202,14 @@ FROM ${TARGETARCH}-${FLAVOR}-${MODEL} AS ubuntu
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     dbus-user-session \
-    firmware-sof-signed \
-    fuse3 \
-    krb5-locales \
-    pigz \
     pkg-config \
     systemd-hwe-hwdb \
     systemd-resolved \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM ${TARGETARCH}-${FLAVOR}-${MODEL} AS ubuntu-20-lts
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    file \
-    fuse \
-    krb5-locales \
-    lldpd \
-    patch \
-    policykit-1 \
-    snmpd \
-    ubuntu-advantage-tools \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-FROM ubuntu-20-lts AS ubuntu-20-lts-non-hwe
-
+FROM ${TARGETARCH}-${FLAVOR}-${MODEL} AS ubuntu-20-lts-non-hwe
 FROM ${TARGETARCH}-${FLAVOR}-${MODEL} AS ubuntu-22-lts-non-hwe
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    firmware-sof-signed \
-    fuse3 \
-    lldpd \
-    pigz \
-    snmpd \
-    ubuntu-advantage-tools \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM ubuntu-22-lts-non-hwe AS ubuntu-22-lts
 RUN apt-get update \
@@ -239,7 +217,7 @@ RUN apt-get update \
     systemd-hwe-hwdb \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM ${FLAVOR} AS all
+FROM ${FLAVOR}${HWE} AS all
 
 ###############################################################
 ####               Post-Process Common to All              ####

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -113,6 +113,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     polkitd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+FROM ${TARGETARCH} AS amd64-ubuntu-20-lts-non-hwe
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    linux-image-generic \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 FROM ${TARGETARCH} AS amd64-ubuntu-20-lts
 RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-image-generic-hwe-20.04 \
@@ -122,6 +127,13 @@ FROM ${TARGETARCH} AS amd64-ubuntu-22-lts
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dracut-live \
     linux-image-generic-hwe-22.04 \
+    polkitd \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+FROM ${TARGETARCH} AS amd64-ubuntu-22-lts-non-hwe
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dracut-live \
+    linux-image-generic \
     polkitd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -170,6 +182,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM generic AS amd64-ubuntu-generic
 FROM generic AS amd64-ubuntu-22-lts-generic
 FROM generic AS amd64-ubuntu-20-lts-generic
+FROM generic AS amd64-ubuntu-22-lts-non-hwe-generic
+FROM generic AS amd64-ubuntu-20-lts-non-hwe-generic
 FROM generic AS arm64-ubuntu-generic
 FROM ubuntu-rpi AS arm64-ubuntu-rpi3
 FROM ubuntu-rpi AS arm64-ubuntu-rpi4
@@ -206,8 +220,9 @@ RUN apt-get update \
     snmpd \
     ubuntu-advantage-tools \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM ubuntu-20-lts AS ubuntu-20-lts-non-hwe
 
-FROM ${TARGETARCH}-${FLAVOR}-${MODEL} AS ubuntu-22-lts
+FROM ${TARGETARCH}-${FLAVOR}-${MODEL} AS ubuntu-22-lts-non-hwe
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     firmware-sof-signed \
@@ -215,8 +230,13 @@ RUN apt-get update \
     lldpd \
     pigz \
     snmpd \
-    systemd-hwe-hwdb \
     ubuntu-advantage-tools \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+FROM ubuntu-22-lts-non-hwe AS ubuntu-22-lts
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    systemd-hwe-hwdb \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM ${FLAVOR} AS all


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

Adds a flag `HWE` to build ubuntu without HWE kernles. It can be used as follows

```
earthly +all --FLAVOR=ubuntu-20-lts --HWE=-non-hwe
```

if you want the HWE kernel you don't need to pass it

It only works for LTS versions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1779
