### PR TITLE
Install cryptsetup also on opensuse rpi

### DIFF
--- a/images/Dockerfile.opensuse-leap
+++ b/images/Dockerfile.opensuse-leap
@@ -15,6 +15,7 @@ RUN zypper in --force-resolution -y \
     bash-completion \
     conntrack-tools \
     coreutils \
+    cryptsetup \
     curl \
     device-mapper \
     dhcp-client \
@@ -72,7 +73,6 @@ RUN zypper in --force-resolution -y \
 ###############################################################
 FROM common AS generic
 RUN zypper in --force-resolution -y \
-    cryptsetup \
     grub2-i386-pc \
     grub2-x86_64-efi \
     kernel-firmware-all \


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Move crypsetup to the generic section so it gets installed on all opensuse derivatives since it is required by dracut

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1698 
