### PR TITLE
Zfs reuse iso

### DIFF
--- a/.github/workflows/reusable-zfs-test.yaml
+++ b/.github/workflows/reusable-zfs-test.yaml
@@ -12,19 +12,17 @@ jobs:
     runs-on: kvm
     steps:
       - uses: actions/checkout@v4
-      - name: Download artifacts
+      - name: Download ISO
+        id: iso
         uses: actions/download-artifact@v3
         with:
           name: kairos-${{ inputs.flavor }}.iso.zip
-          path: ./build
       - name: Display structure of downloaded files
         run: ls -R
-        working-directory: ./build
       - name: Install earthly
         uses: jimmykarily/luet-install-action@v1.2
         with:
           repository: quay.io/kairos/packages
           packages: utils/earthly
       - run: |
-          export ISO=$(ls $PWD/kairos-*${{ inputs.flavor }}*).iso
-          earthly +run-qemu-test --TEST_SUITE=zfs --FLAVOR=${{ inputs.flavor }}
+          earthly +run-qemu-test --PREBUILT_ISO=$(ls kairos-core-*${{ inputs.flavor }}*.iso) --TEST_SUITE=zfs --FLAVOR=${{ inputs.flavor }}

--- a/Earthfile
+++ b/Earthfile
@@ -957,6 +957,7 @@ run-qemu-netboot-test:
 
 run-qemu-test:
     FROM +go-deps-test
+    WORKDIR /test
     ARG FLAVOR
     ARG TEST_SUITE=upgrade-with-cli
     ARG PREBUILT_ISO
@@ -969,10 +970,10 @@ run-qemu-test:
 
     COPY . .
     IF [ -n "$PREBUILT_ISO" ]
-        ENV ISO=/build/$PREBUILT_ISO
+        ENV ISO=/test/$PREBUILT_ISO
     ELSE
         COPY +iso/kairos.iso kairos.iso
-        ENV ISO=/build/kairos.iso
+        ENV ISO=/test/kairos.iso
     END
     COPY +go-deps-test/go.mod go.mod
     COPY +go-deps-test/go.sum go.sum

--- a/tests/reset_test.go
+++ b/tests/reset_test.go
@@ -31,8 +31,7 @@ var _ = Describe("kairos reset test", Label("reset-test"), func() {
 			expectStartedInstallation(vm)
 			expectRebootedToActive(vm)
 		})
-
-		It("has grubenv file", func() {
+		It("resets", func() {
 			Eventually(func() string {
 				out, _ := vm.Sudo("cat /oem/grubenv")
 				return out
@@ -40,9 +39,6 @@ var _ = Describe("kairos reset test", Label("reset-test"), func() {
 				Or(
 					ContainSubstring("foobarzz"),
 				))
-		})
-
-		It("resets", func() {
 			_, err := vm.Sudo("touch /usr/local/test")
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

Makes the zfs job reuse the download iso to reduce the time it takes for the job.
Merges the 2 reset tests into one as it was creating,installiong and reseting 2 machines in the full test suite but its not needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
