### PR TITLE
:art: Bundle bootargs with framework images

### DIFF
--- a/.github/workflows/reusable-upgrade-latest-test.yaml
+++ b/.github/workflows/reusable-upgrade-latest-test.yaml
@@ -51,13 +51,8 @@ jobs:
           # A flag to set the download target as latest release
           # The default value is 'false'
           latest: true
-          fileName: '*${{ inputs.flavor }}-v*.iso'
+          fileName: 'kairos-${{ inputs.flavor }}-v*.iso'
           out-file-path: ""
-      - name: Download ISO
-        id: iso
-        uses: actions/download-artifact@v3
-        with:
-          name: kairos-${{ inputs.flavor }}.iso.zip
       - name: Display structure of downloaded files
         run: ls -las .
       - name: Install earthly

--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -174,9 +174,9 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20230904094341-repository.yaml
+    reference: 20230907140136-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20230904111459-repository.yaml
+    reference: 20230907141836-repository.yaml

--- a/images/alpine/bootargs.cfg
+++ b/images/alpine/bootargs.cfg
@@ -5,3 +5,9 @@ else
     # Boot arguments when the image is used as active/passive
     set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img rd.emergency=reboot rd.shell=0 panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1 fsck.mode=force fsck.repair=yes systemd.crash_reboot=yes"
 fi
+
+# grub.cfg now ships this but during upgrades we do not update the COS_GRUB partition, so no new grub.cfg is copied over there
+# We need to keep it for upgrades to work.
+# TODO: Deprecate in v2.8-v3.0
+set kernel=/boot/vmlinuz
+set initramfs=/boot/initrd

--- a/images/alpine/bootargs.cfg
+++ b/images/alpine/bootargs.cfg
@@ -1,4 +1,3 @@
-set kernel=/boot/vmlinuz
 if [ -n "$recoverylabel" ]; then
     # Boot arguments when the image is used as recovery
     set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.cos.oemlabel=COS_OEM"
@@ -6,5 +5,3 @@ else
     # Boot arguments when the image is used as active/passive
     set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img rd.emergency=reboot rd.shell=0 panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1 fsck.mode=force fsck.repair=yes systemd.crash_reboot=yes"
 fi
-
-set initramfs=/boot/initrd

--- a/images/debian/bootargs.cfg
+++ b/images/debian/bootargs.cfg
@@ -1,8 +1,5 @@
-set kernel=/boot/vmlinuz
 if [ -n "$recoverylabel" ]; then
     set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.cos.oemlabel=COS_OEM"
 else
     set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label cos-img/filename=$img panic=5 security=selinux selinux=1 rd.cos.oemlabel=COS_OEM rd.neednet=0 vga=795"
 fi
-
-set initramfs=/boot/initrd

--- a/images/debian/bootargs.cfg
+++ b/images/debian/bootargs.cfg
@@ -3,3 +3,9 @@ if [ -n "$recoverylabel" ]; then
 else
     set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label cos-img/filename=$img panic=5 security=selinux selinux=1 rd.cos.oemlabel=COS_OEM rd.neednet=0 vga=795"
 fi
+
+# grub.cfg now ships this but during upgrades we do not update the COS_GRUB partition, so no new grub.cfg is copied over there
+# We need to keep it for upgrades to work.
+# TODO: Deprecate in v2.8-v3.0
+set kernel=/boot/vmlinuz
+set initramfs=/boot/initrd

--- a/images/nvidia/bootargs.cfg
+++ b/images/nvidia/bootargs.cfg
@@ -1,9 +1,5 @@
-set kernel=/boot/vmlinuz
-
 if [ -n "$recoverylabel" ]; then
     set kernelcmd="console=tty1 console=ttyTCU0,115200 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.cos.oemtimeout=10"
 else
     set kernelcmd="console=tty1 console=ttyTCU0,115200 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux selinux=1 rd.cos.oemtimeout=10 rd.cos.oemlabel=COS_OEM"
 fi
-
-set initramfs=/boot/initrd

--- a/images/nvidia/bootargs.cfg
+++ b/images/nvidia/bootargs.cfg
@@ -3,3 +3,9 @@ if [ -n "$recoverylabel" ]; then
 else
     set kernelcmd="console=tty1 console=ttyTCU0,115200 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux selinux=1 rd.cos.oemtimeout=10 rd.cos.oemlabel=COS_OEM"
 fi
+
+# grub.cfg now ships this but during upgrades we do not update the COS_GRUB partition, so no new grub.cfg is copied over there
+# We need to keep it for upgrades to work.
+# TODO: Deprecate in v2.8-v3.0
+set kernel=/boot/vmlinuz
+set initramfs=/boot/initrd

--- a/images/opensuse/bootargs.cfg
+++ b/images/opensuse/bootargs.cfg
@@ -5,3 +5,9 @@ else
     # Boot arguments when the image is used as active/passive
     set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img rd.emergency=reboot rd.shell=0 panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1 fsck.mode=force fsck.repair=yes systemd.crash_reboot=yes"
 fi
+
+# grub.cfg now ships this but during upgrades we do not update the COS_GRUB partition, so no new grub.cfg is copied over there
+# We need to keep it for upgrades to work.
+# TODO: Deprecate in v2.8-v3.0
+set kernel=/boot/vmlinuz
+set initramfs=/boot/initrd

--- a/images/opensuse/bootargs.cfg
+++ b/images/opensuse/bootargs.cfg
@@ -1,4 +1,3 @@
-set kernel=/boot/vmlinuz
 if [ -n "$recoverylabel" ]; then
     # Boot arguments when the image is used as recovery
     set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel net.ifnames=1 rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.cos.oemlabel=COS_OEM"
@@ -6,5 +5,3 @@ else
     # Boot arguments when the image is used as active/passive
     set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img rd.emergency=reboot rd.shell=0 panic=5 security=selinux rd.cos.oemlabel=COS_OEM selinux=1 fsck.mode=force fsck.repair=yes systemd.crash_reboot=yes"
 fi
-
-set initramfs=/boot/initrd

--- a/images/redhat/bootargs.cfg
+++ b/images/redhat/bootargs.cfg
@@ -1,5 +1,3 @@
-set kernel=/boot/vmlinuz
-# temporarly disabling SELinux until we have a profile (https://github.com/kairos-io/kairos/issues/114)
 if [ -n "$recoverylabel" ]; then
     # Boot arguments when the image is used as recovery
     set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5 selinux=0 rd.cos.oemlabel=COS_OEM"
@@ -7,5 +5,3 @@ else
     # Boot arguments when the image is used as active/passive
     set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 rd.cos.oemlabel=COS_OEM selinux=0"
 fi
-
-set initramfs=/boot/initrd

--- a/images/redhat/bootargs.cfg
+++ b/images/redhat/bootargs.cfg
@@ -5,3 +5,9 @@ else
     # Boot arguments when the image is used as active/passive
     set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 rd.cos.oemlabel=COS_OEM selinux=0"
 fi
+
+# grub.cfg now ships this but during upgrades we do not update the COS_GRUB partition, so no new grub.cfg is copied over there
+# We need to keep it for upgrades to work.
+# TODO: Deprecate in v2.8-v3.0
+set kernel=/boot/vmlinuz
+set initramfs=/boot/initrd

--- a/images/rpi/bootargs.cfg
+++ b/images/rpi/bootargs.cfg
@@ -1,5 +1,3 @@
-set kernel=/boot/vmlinuz
-
 # Note on RPI bootargs
 # We additionally set modprobe.blacklist=vc4 as certain Displays are not supported by vc4.
 # As kairos main target is cloud and not graphics usage, we blacklist it to avoid 
@@ -17,5 +15,3 @@ if [ -n "$recoverylabel" ]; then
 else
     set kernelcmd="console=tty1 console=ttyS0,115200 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux selinux=1 modprobe.blacklist=vc4 rd.cos.oemtimeout=10 rd.cos.oemlabel=COS_OEM 8250.nr_uarts=1"
 fi
-
-set initramfs=/boot/initrd

--- a/images/rpi/bootargs.cfg
+++ b/images/rpi/bootargs.cfg
@@ -15,3 +15,9 @@ if [ -n "$recoverylabel" ]; then
 else
     set kernelcmd="console=tty1 console=ttyS0,115200 root=LABEL=$label net.ifnames=1 cos-img/filename=$img panic=5 security=selinux selinux=1 modprobe.blacklist=vc4 rd.cos.oemtimeout=10 rd.cos.oemlabel=COS_OEM 8250.nr_uarts=1"
 fi
+
+# grub.cfg now ships this but during upgrades we do not update the COS_GRUB partition, so no new grub.cfg is copied over there
+# We need to keep it for upgrades to work.
+# TODO: Deprecate in v2.8-v3.0
+set kernel=/boot/vmlinuz
+set initramfs=/boot/initrd


### PR DESCRIPTION
Currently bootargs is not provided with the framework images so its missing a very important piece to boot which results into BYOI being broken.

This patch adds the bootargs.cfg to the framework image. Also the config.txt to the rpi images.

Also drops the kernel/initramfs vars from the bootargs as they are set to the default now in the package.

Also moves the luet clean under the package list generation as it requires the database of luet to list the packages.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1770 

Requires: https://github.com/kairos-io/packages/pull/408
