### PR TITLE
:bug: Fix bootargs matcher for rpi

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -273,20 +273,22 @@ framework:
     COPY +luet/luet /framework/usr/bin/luet
     COPY framework-profile.yaml /framework/etc/luet/luet.yaml
 
-    # Copy bootargs.cfg into the final framework as its needed to boot
-    IF [[ "$FLAVOR" =~ ^alpine* ]]
-        COPY ./images/alpine/bootargs.cfg /framework/etc/cos/bootargs.cfg
-    ELSE IF [[ "$FLAVOR" = "ubuntu-20-lts-arm-nvidia-jetson-agx-orin" ]]
-        COPY ./images/nvidia/bootargs.cfg /framework/etc/cos/bootargs.cfg
-    ELSE IF [[ "$FLAVOR" =~ "ubuntu" ]]
-        COPY ./images/debian/bootargs.cfg /framework/etc/cos/bootargs.cfg
-    ELSE IF [[ "$FLAVOR" =~ ^opensuse-leap$ ]] || [[ "$FLAVOR" =~ ^opensuse-tumbleweed$ ]] # Be specific so it doesnt match the arm-rpi flavors
-        COPY ./images/opensuse/bootargs.cfg /framework/etc/cos/bootargs.cfg
-    ELSE IF [[ "$FLAVOR" =~ ^rockylinux* ]] || [[ "$FLAVOR" =~ ^fedora* ]] || [[ "$FLAVOR" =~ ^almalinux* ]]
-        COPY ./images/redhat/bootargs.cfg /framework/etc/cos/bootargs.cfg
-    ELSE IF [[ "$FLAVOR" =~ -rpi$ ]]
-        COPY ./images/rpi/bootargs.cfg /framework/etc/cos/bootargs.cfg
-        COPY ./images/rpi/config.txt /framework/boot/config.txt
+    # Copy bootargs.cfg into the final framework as its needed to boot if its not there
+    IF [ ! -f /framework/etc/cos/bootargs.cfg ]
+        IF [[ "$FLAVOR" =~ ^alpine* ]]
+            COPY ./images/alpine/bootargs.cfg /framework/etc/cos/bootargs.cfg
+        ELSE IF [[ "$FLAVOR" = "ubuntu-20-lts-arm-nvidia-jetson-agx-orin" ]]
+            COPY ./images/nvidia/bootargs.cfg /framework/etc/cos/bootargs.cfg
+        ELSE IF [[ "$FLAVOR" =~ "ubuntu" ]] && [[ ! "$FLAVOR" =~ -rpi$ ]]
+            COPY ./images/debian/bootargs.cfg /framework/etc/cos/bootargs.cfg
+        ELSE IF [[ "$FLAVOR" =~ ^opensuse-leap$ ]] || [[ "$FLAVOR" =~ ^opensuse-tumbleweed$ ]] # Be specific so it doesnt match the arm-rpi flavors
+            COPY ./images/opensuse/bootargs.cfg /framework/etc/cos/bootargs.cfg
+        ELSE IF [[ "$FLAVOR" =~ ^rockylinux* ]] || [[ "$FLAVOR" =~ ^fedora* ]] || [[ "$FLAVOR" =~ ^almalinux* ]]
+            COPY ./images/redhat/bootargs.cfg /framework/etc/cos/bootargs.cfg
+        ELSE IF [[ "$FLAVOR" =~ -rpi$ ]]
+            COPY ./images/rpi/bootargs.cfg /framework/etc/cos/bootargs.cfg
+            COPY ./images/rpi/config.txt /framework/boot/config.txt
+        END
     END
 
     SAVE ARTIFACT --keep-own /framework/ framework


### PR DESCRIPTION
It was matching before on ubuntu flavours and copying the debian one all the time in rpi stuff

Also adds a check to copy it only if its not there already so we dont touch it on other artifacts

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
