### PR TITLE
:bug: Provide a generic bootargs in the framework for fips

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -288,6 +288,9 @@ framework:
         ELSE IF [[ "$FLAVOR" =~ -rpi$ ]]
             COPY ./images/rpi/bootargs.cfg /framework/etc/cos/bootargs.cfg
             COPY ./images/rpi/config.txt /framework/boot/config.txt
+        ELSE IF [[ "$FLAVOR" =~ ^fips-systemd* ]]
+            # Use a generic one like redhat which has selinux disabled so it can be used on all flavors??
+            COPY ./images/redhat/bootargs.cfg /framework/etc/cos/bootargs.cfg
         END
     END
 


### PR DESCRIPTION
Otherwise no bootargs are provided
