### PR TITLE
Change where systemd-sysext extensions are installed

### DIFF
--- a/tests/assets/live-overlay.tmpl
+++ b/tests/assets/live-overlay.tmpl
@@ -6,6 +6,6 @@ install:
   grub_options:
     extra_cmdline: foobarzz
   bundles:
-  - rootfs_path: /usr/local/lib/extensions/kubo
+  - rootfs_path: /var/lib/extensions/kubo
     targets:
     - container://${BUNDLE_IMAGE}

--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -70,7 +70,7 @@ var _ = Describe("kairos bundles test", Label("bundles-test"), func() {
 					out, _ = vm.Sudo("cat /oem/90_custom.yaml")
 					result = result + fmt.Sprintf("90_custom.yaml:\n%s\n", out)
 
-					out, _ = vm.Sudo("cat /usr/local/lib/extensions/kubo/usr/lib/extension-release.d/extension-release.kubo")
+					out, _ = vm.Sudo("cat /var/lib/extensions/kubo/usr/lib/extension-release.d/extension-release.kubo")
 					result = result + fmt.Sprintf("extension-release.kubo:\n%s\n", out)
 
 					out, _ = vm.Sudo("systemd-sysext status")


### PR DESCRIPTION
Part of: https://github.com/kairos-io/kairos/issues/1821

Needs this: https://github.com/kairos-io/packages/pull/437 (merged here: https://github.com/kairos-io/kairos/pull/1822)

TODO: Documentation update. E.g. https://kairos.io/docs/advanced/livelayering/#installing-extensions
