### PR TITLE
:robot: Fix systemd-fips framework trying to copy non-existing file

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -278,9 +278,6 @@ framework:
         COPY ./images/bootargs.cfg /framework/etc/cos/bootargs.cfg
         IF [[ "$FLAVOR" =~ -rpi$ ]]
             COPY ./images/rpi/config.txt /framework/boot/config.txt
-        ELSE IF [[ "$FLAVOR" =~ ^fips-systemd* ]]
-            # Use a generic one like redhat which has selinux disabled so it can be used on all flavors??
-            COPY ./images/redhat/bootargs.cfg /framework/etc/cos/bootargs.cfg
         END
     END
 


### PR DESCRIPTION
It now should use the generic bootargs like the rest of the flavors

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
