### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -28,7 +28,7 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-          echo "::set-output name=matrix::{\"include\": $content }"
+          echo "matrix={\"include\": $content }" >> $GITHUB_OUTPUT
 
   # The matrix for standard (provider) images
   get-standard-matrix:
@@ -55,7 +55,7 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-          echo "::set-output name=matrix::{\"include\": $content }"
+          echo "matrix={\"include\": $content }" >> $GITHUB_OUTPUT
 
   build-arm-core:
     uses: ./.github/workflows/reusable-docker-arm-build.yaml

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -31,7 +31,7 @@ jobs:
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
           # end of optional handling for multi line json
-          echo "::set-output name=matrix::{\"include\": $content }"
+          echo "matrix={\"include\": $content }" >> $GITHUB_OUTPUT
 
   get-framework-matrix:
     runs-on: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
           # end of optional handling for multi line json
-          echo "::set-output name=matrix::{\"include\": $content }"
+          echo "matrix={\"include\": $content }" >> $GITHUB_OUTPUT
 
   core:
     uses: ./.github/workflows/reusable-build-flavor.yaml

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -20,7 +20,7 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-          echo "::set-output name=matrix::{\"include\": $content }"
+          echo "matrix={\"include\": $content }" >> $GITHUB_OUTPUT
 
   # The matrix for standard (provider) images
   get-standard-matrix:
@@ -47,7 +47,7 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-          echo "::set-output name=matrix::{\"include\": $content }"
+          echo "matrix={\"include\": $content }" >> $GITHUB_OUTPUT
 
   build-arm-core:
     runs-on: ${{ matrix.worker }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-          echo "::set-output name=matrix::{\"include\": $content }"
+          echo "matrix={\"include\": $content }" >> $GITHUB_OUTPUT
 
   # The matrix for standard (provider) images
   get-standard-matrix:
@@ -52,7 +52,7 @@ jobs:
           content="${content//$'\r'/'%0D'}"
 
           # end of optional handling for multi line json
-          echo "::set-output name=matrix::{\"include\": $content }"
+          echo "matrix={\"include\": $content }" >> $GITHUB_OUTPUT
 
   get-framework-matrix:
     runs-on: ubuntu-latest
@@ -70,7 +70,7 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-          echo "::set-output name=matrix::{\"include\": $content }"
+          echo "matrix={\"include\": $content }" >> $GITHUB_OUTPUT
 
   build-framework:
     runs-on: kvm


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=matrix::{\"include\": $content }"
```

**TO-BE**

```yaml
echo "matrix={\"include\": $content }" >> $GITHUB_OUTPUT
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1870 
