### PR TITLE
[POC] Use a single network dracut package

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -281,6 +281,9 @@ framework:
         END
     END
 
+    COPY kairos-network /framework/usr/lib/dracut/modules.d/29kairos-network
+    RUN mkdir -p /framework/etc/dracut.conf.d
+    COPY net.conf /framework/etc/dracut.conf.d/10-kairos-network.conf
     SAVE ARTIFACT --keep-own /framework/ framework
 
 build-framework-image:

--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -11,91 +11,74 @@ flavors:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy
   debian-arm-rpi:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy
   ubuntu:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy
   ubuntu-arm-rpi:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy
   ubuntu-20-lts-arm-nvidia-jetson-agx-orin:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy-compat
   ubuntu-20-lts-arm-rpi:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy-compat
   ubuntu-22-lts-arm-rpi:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy-compat
   ubuntu-22-lts:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy-compat
   ubuntu-20-lts:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy-compat
   fips-systemd:
     - common-packages
     - kairos-toolchain-fips
     - systemd-base
-    - dracut-network-legacy-compat
   fedora:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy-compat
   rockylinux:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy-compat
   almalinux:
     - common-packages
     - kairos-toolchain
     - systemd-base
-    - dracut-network-legacy-compat
   opensuse-tumbleweed:
     - common-packages
     - kairos-toolchain
     - systemd-base
     - systemd-latest
-    - dracut-network-legacy
   opensuse-tumbleweed-arm-rpi:
     - common-packages
     - kairos-toolchain
     - systemd-base
     - systemd-latest
-    - dracut-network-legacy
   opensuse-leap:
     - common-packages
     - kairos-toolchain
     - systemd-base
     - systemd-latest
-    - dracut-network-legacy
   opensuse-leap-arm-rpi:
     - common-packages
     - kairos-toolchain
     - systemd-base
     - systemd-latest
-    - dracut-network-legacy
   alpine-arm-rpi:
     - common-packages
     - kairos-toolchain
@@ -111,13 +94,6 @@ flavors:
     - kairos-toolchain
     - ubuntu-kernel
     - openrc
-# See https://github.com/kairos-io/packages/pull/67 for rationale
-dracut-network-legacy:
-  packages:
-    - dracut/network-legacy
-dracut-network-legacy-compat:
-  packages:
-    - dracut/network-legacy-compat
 openrc:
   packages:
     - init-svc/openrc

--- a/kairos-network/module-setup.sh
+++ b/kairos-network/module-setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# This module selects the proper network module to be used by dracut
+# while avoiding using systemd-networkd
+
+# called by dracut
+check() {
+    return 255
+}
+
+# called by dracut
+depends() {
+    is_qemu_virtualized && echo -n "qemu-net "
+
+    for module in network network-legacy; do
+        if dracut_module_included "$module"; then
+            network_handler="$module"
+            break
+        fi
+    done
+
+    if [ -z "$network_handler" ]; then
+        if check_module "network-legacy"; then
+            network_handler="network-legacy"
+        else
+            network_handler="network"
+        fi
+    fi
+    echo "kernel-network-modules $network_handler"
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    return 0
+}
+
+# called by dracut
+install() {
+    dracut_need_initqueue
+}

--- a/net.conf
+++ b/net.conf
@@ -1,0 +1,2 @@
+omit_dracutmodules+=" systemd-networkd "
+add_dracutmodules+=" kairos-network "


### PR DESCRIPTION
POC of using a single network package that loads and installs the needed module in dracut so we dont have to choose between network and network-legacy and can keep it down to just one package.

This checks the dracut module to check if it exists and if it does, it sets it as dependency of the kairos-network dracut module, so it includes the proper one on each.

This is also extensible, so we can include connman, NetworkManager and systemd-networkd at any moment.

This can be provided via luet packages and the other 2 network packages dropped altogether, so we can have just one package for all flavors, no need to manually choose and/or keep it.

Could even be included as part of the immucore dracut package so immucore deals with this directly and selects the proper network stuff, but that makes it dependent on immucore releases.


Tested with:
 - fedora
 - ubuntu
 - debian
 - opensuse-leap


All of them booted with `rd.neednet=1` and `rd.break=pre-pivot` to test inside initramfs. In all cases, the eth0 had an ip and external network connectivity.