### PR TITLE
:art: Provide bootargs via package

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -273,14 +273,6 @@ framework:
     COPY +luet/luet /framework/usr/bin/luet
     COPY framework-profile.yaml /framework/etc/luet/luet.yaml
 
-    # Copy bootargs.cfg into the final framework as its needed to boot if its not there
-    IF [ ! -f /framework/etc/cos/bootargs.cfg ]
-        COPY ./images/bootargs.cfg /framework/etc/cos/bootargs.cfg
-        IF [[ "$FLAVOR" =~ -rpi$ ]]
-            COPY ./images/rpi/config.txt /framework/boot/config.txt
-        END
-    END
-
     SAVE ARTIFACT --keep-own /framework/ framework
 
 build-framework-image:

--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -173,9 +173,9 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20231004151255-repository.yaml
+    reference: 20231009132401-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20231004150525-repository.yaml
+    reference: 20231009133042-repository.yaml


### PR DESCRIPTION
bootargs.cfg for grub and config.txt for rpi are now provided via luet packages

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
