### PR TITLE
:bug: Add missing deps for initramfs

### DIFF
--- a/images/Dockerfile.almalinux
+++ b/images/Dockerfile.almalinux
@@ -20,6 +20,7 @@ RUN dnf install -y \
     efibootmgr \
     epel-release \
     gawk \
+    gdisk \
     grub2 \
     grub2-efi-x64 \
     grub2-efi-x64-modules \

--- a/images/Dockerfile.rockylinux
+++ b/images/Dockerfile.rockylinux
@@ -20,6 +20,7 @@ RUN dnf install -y \
     efibootmgr \
     epel-release \
     gawk \
+    gdisk \
     grub2 \
     grub2-efi-x64 \
     grub2-efi-x64-modules \

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -50,6 +50,7 @@ RUN apt-get update \
     dracut \
     dracut-network \
     e2fsprogs \
+    fdisk \
     gawk \
     gdisk \
     grub2-common \


### PR DESCRIPTION
Some utils were missing ffrom initramfs which could lead to issues when running the stages

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
