### PR TITLE
:art: Build alpine initrd during image building

### DIFF
--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -80,22 +80,14 @@ flavors:
     - common-packages
     - kairos-toolchain
     - openrc
-    - alpine-init
   alpine-arm-rpi:
     - common-packages
     - kairos-toolchain
     - openrc
-    - alpine-init-rpi
-# See https://github.com/kairos-io/packages/pull/67 for rationale
-alpine-init:
-  packages:
-    - distro-kernel/alpine
-alpine-init-rpi:
-  packages:
-    - distro-kernel/alpine-rpi
 openrc:
   packages:
     - init-svc/openrc
+    - initrd/alpine
 systemd-base:
   packages:
     - init-svc/systemd
@@ -147,9 +139,9 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20231018075943-repository.yaml
+    reference: 20231019093159-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20231018075844-repository.yaml
+    reference: 20231019092540-repository.yaml

--- a/images/Dockerfile.alpine
+++ b/images/Dockerfile.alpine
@@ -22,6 +22,7 @@ RUN apk --no-cache add  \
       coreutils \
       cryptsetup \
       curl \
+      device-mapper-udev \
       dbus \
       dmidecode \
       dosfstools \
@@ -29,8 +30,10 @@ RUN apk --no-cache add  \
       e2fsprogs-extra \
       efibootmgr \
       eudev \
+      eudev-hwids \
       fail2ban \
       findutils \
+      findmnt \
       gawk \
       gcompat \
       gettext \
@@ -76,6 +79,7 @@ RUN apk --no-cache add  \
       rbd-nbd \
       rng-tools \
       rsync \
+      sgdisk \
       smartmontools \
       squashfs-tools \
       strace \
@@ -88,6 +92,7 @@ RUN apk --no-cache add  \
       wireguard-tools \
       wpa_supplicant \
       xfsprogs \
+      xfsprogs-extra \
       xz
 
 ###############################################################
@@ -100,12 +105,15 @@ RUN apk --no-cache add  \
       bonding \
       bridge \
       rbd-nbd
+RUN apk --no-cache add linux-lts --no-scripts
 
 FROM common as rpicommon
 COPY rpi/config.txt /boot/config.txt
 
 FROM rpicommon AS rpi3
+RUN apk --no-cache add linux-rpi --no-scripts # use --no-scripts to avoid building initramfs
 FROM rpicommon AS rpi4
+RUN apk --no-cache add linux-rpi4 --no-scripts # use --no-scripts to avoid building initramfs
 
 
 ###############################################################


### PR DESCRIPTION
Instead of using a pre-packaged one we can just build it during image build like we do on dracut systems

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
