### PR TITLE
🤖 Fix some tests failing for k8s and run install under qemu

### DIFF
--- a/.github/flavors.json
+++ b/.github/flavors.json
@@ -2,40 +2,5 @@
     {
         "flavor": "opensuse-leap",
         "standard": "true"
-    },
-    {
-        "flavor": "opensuse-tumbleweed",
-        "standard": "true"
-    },
-    {
-        "flavor": "ubuntu",
-        "standard": "true"
-    },
-    {
-        "flavor": "ubuntu-20-lts",
-        "standard": "true"
-    },
-    {
-        "flavor": "ubuntu-22-lts",
-        "standard": "true"
-    },
-    {
-        "flavor": "alpine",
-        "standard": "true"
-    },
-    {
-        "flavor": "fedora",
-        "standard": "true"
-    },
-    {
-        "flavor": "debian",
-        "standard": "true"
-    },
-    {
-        "flavor": "rockylinux",
-        "standard": "true"
-    },
-    {
-        "flavor": "almalinux"
     }
 ]

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -24,6 +24,7 @@ jobs:
     uses: ./.github/workflows/reusable-install-test.yaml
     with:
       flavor: ubuntu
+      label: "install-test"
     needs:
       - core
 
@@ -31,6 +32,7 @@ jobs:
     uses: ./.github/workflows/reusable-install-test.yaml
     with:
       flavor: alpine
+      label: "install-test"
     needs:
       - core-alpine
 

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,5 +1,6 @@
 name: Build and test images
 on:
+  pull_request: 
   push:
     branches:
       - master

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,6 +1,6 @@
 name: Build and test images
 on:
-  pull_request: 
+  pull_request:
   push:
     branches:
       - master
@@ -242,7 +242,6 @@ jobs:
       - encryption
       - various
       - standard-upgrade-latest
-      - test-uki
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -57,13 +57,16 @@ jobs:
     uses: ./.github/workflows/reusable-install-test.yaml
     with:
       flavor: ${{ matrix.flavor }}
+      label: ${{ matrix.label }}
     needs:
       - core
     strategy:
       fail-fast: true
       matrix:
-        include:
-          - flavor: opensuse-leap
+        label:
+          - "install-test"
+        flavor:
+          - opensuse-leap
   zfs:
     uses: ./.github/workflows/reusable-zfs-test.yaml
     with:
@@ -183,7 +186,7 @@ jobs:
       matrix:
         flavor:
           - "opensuse-leap"
-          - "alpine-opensuse-leap"
+          - "alpine"
   various:
     uses: ./.github/workflows/reusable-provider-tests.yaml
     with:
@@ -202,12 +205,12 @@ jobs:
           - "provider-upgrade-k8s"
         flavor:
           - "opensuse-leap"
-          - "alpine-opensuse-leap"
+          - "alpine"
         exclude: # looks like only the k8s stuff is tested on both flavors
           - label: "provider-qrcode-install"
-            flavor: "alpine-opensuse-leap"
+            flavor: "alpine"
           - label: "provider-upgrade"
-            flavor: "alpine-opensuse-leap"
+            flavor: "alpine"
   standard-upgrade-latest:
     uses: ./.github/workflows/reusable-provider-upgrade-latest-test.yaml
     with:
@@ -220,50 +223,6 @@ jobs:
       matrix:
         flavor:
           - "opensuse-leap"
-          - "alpine-opensuse-leap"
-  test-uki:
-    runs-on: kvm
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: tests/go.mod
-          cache-dependency-path: tests/go.sum
-      - name: Enable KVM group perms
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libvirt-clients libvirt-daemon-system libvirt-daemon virtinst bridge-utils qemu qemu-system-x86 qemu-system-x86 qemu-utils qemu-kvm acl udev
-
-          # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
-          # echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          # sudo udevadm control --reload-rules
-          # sudo udevadm trigger --name-match=kvm
-          # sudo usermod -a -G kvm,libvirt $USER
-          #
-          # TODO: Switch back to the above solution when we switch to the github runners
-          # https://askubuntu.com/a/1081326
-          sudo setfacl -m u:runner:rwx /dev/kvm
-      - name: Install earthly
-        uses: Luet-lab/luet-install-action@v1.1
-        with:
-          repository: quay.io/kairos/packages
-          packages: utils/earthly
-      - name: Build uki disk 🔧
-        run: |
-          # Do fedora as its the smaller uki possible
-          earthly +prepare-uki-disk-image --FLAVOR=fedora
-      - name: Run tests
-        env:
-          USE_QEMU: true
-          KVM: true
-          MEMORY: 4000
-          CPUS: 2
-          FIRMWARE: /usr/share/OVMF/OVMF_CODE.fd
-        run: |
-          export UKI_DRIVE=${PWD}/build/disk.img
-          cp tests/go.* .
-          go run github.com/onsi/ginkgo/v2/ginkgo -v --label-filter "uki" --fail-fast -r ./tests/
   notify:
     runs-on: ubuntu-latest
     if: failure()

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -155,7 +155,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - flavor: alpine
+          # - flavor: alpine # enable once we have 1 alpine pure release, otherwise it cant find the latest released version for that flavor
           - flavor: opensuse-leap
           # - flavor: "ubuntu"
           # - flavor: "ubuntu"

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -43,17 +43,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.get-matrix.outputs.matrix)}}
-  framework:
-    uses: ./.github/workflows/reusable-build-framework-flavor.yaml
-    secrets: inherit
-    with:
-      flavor: ${{ matrix.flavor }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - flavor: "generic"
-          - flavor: "fips"
   install:
     uses: ./.github/workflows/reusable-install-test.yaml
     with:
@@ -68,17 +57,6 @@ jobs:
           - "install-test"
         flavor:
           - opensuse-leap
-  zfs:
-    uses: ./.github/workflows/reusable-zfs-test.yaml
-    with:
-      flavor: ${{ matrix.flavor }}
-    needs:
-      - core
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - flavor: "ubuntu"
   acceptance:
     uses: ./.github/workflows/reusable-qemu-acceptance-test.yaml
     with:
@@ -89,49 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - flavor: "alpine"
           - flavor: "opensuse-leap"
-          - flavor: "opensuse-tumbleweed"
-          - flavor: "ubuntu"
-          - flavor: "debian"
-          - flavor: "ubuntu-20-lts"
-          - flavor: "ubuntu-22-lts"
-  bundles:
-    uses: ./.github/workflows/reusable-qemu-bundles-test.yaml
-    with:
-      flavor: ${{ matrix.flavor }}
-    needs:
-      - core
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - flavor: opensuse-tumbleweed # Kubo test needs systemd version 252+ which atm is not available in Leap
-  reset:
-    uses: ./.github/workflows/reusable-qemu-reset-test.yaml
-    with:
-      flavor: ${{ matrix.flavor }}
-    needs:
-      - core
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - flavor: alpine
-          - flavor: opensuse-leap
-  netboot:
-    uses: ./.github/workflows/reusable-qemu-netboot-test.yaml
-    with:
-      flavor: ${{ matrix.flavor }}
-    needs:
-      - core
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - flavor: alpine
-          - flavor: opensuse-leap
-          - flavor: ubuntu
   upgrade:
     uses: ./.github/workflows/reusable-upgrade-with-cli-test.yaml
     with:
@@ -143,7 +79,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - flavor: alpine
           - flavor: opensuse-leap
   upgrade-latest:
     uses: ./.github/workflows/reusable-upgrade-latest-test.yaml
@@ -174,8 +109,6 @@ jobs:
           - "local-encryption"
           - "remote-auto"
           - "remote-static"
-          - "remote-https-pinned"
-          - "remote-https-bad-cert"
         flavor:
           - "opensuse-leap"
   standard:
@@ -187,7 +120,6 @@ jobs:
       matrix:
         flavor:
           - "opensuse-leap"
-          - "alpine"
   various:
     uses: ./.github/workflows/reusable-provider-tests.yaml
     with:
@@ -200,18 +132,11 @@ jobs:
       max-parallel: 2
       matrix:
         label:
-          - "provider-qrcode-install"
           - "provider-upgrade"
           - "provider-decentralized-k8s"
           - "provider-upgrade-k8s"
         flavor:
           - "opensuse-leap"
-          - "alpine"
-        exclude: # looks like only the k8s stuff is tested on both flavors
-          - label: "provider-qrcode-install"
-            flavor: "alpine"
-          - label: "provider-upgrade"
-            flavor: "alpine"
   standard-upgrade-latest:
     uses: ./.github/workflows/reusable-provider-upgrade-latest-test.yaml
     with:
@@ -224,73 +149,3 @@ jobs:
       matrix:
         flavor:
           - "opensuse-leap"
-  notify:
-    runs-on: ubuntu-latest
-    if: failure()
-    needs:
-      - core
-      - standard
-      - framework
-      - install
-      - zfs
-      - acceptance
-      - bundles
-      - reset
-      - netboot
-      - upgrade
-      - upgrade-latest
-      - encryption
-      - various
-      - standard-upgrade-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: |
-          git fetch --prune --unshallow
-      - name: save commit-message
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} && failure()
-        run: echo "COMMIT_MSG=$(git log -1 --pretty=format:%s)" >> $GITHUB_ENV
-      - name: notify if failure
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} && failure()
-        uses: slackapi/slack-github-action@v1.24.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-        with:
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Job failure on master branch for job ${{ github.job }} in workflow \"${{ github.workflow }}\"\n\nCommit message is \"${{ env.COMMIT_MSG }}\"\n\n Commit sha is <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": ":thisisfine: Failed Run",
-                        "emoji": true
-                      },
-                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    },
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": ":kairos: Repository link",
-                        "emoji": true
-                      },
-                      "url": "https://github.com/${{ github.repository }}"
-                    }
-                  ]
-                }
-              ]
-            }

--- a/.github/workflows/reusable-install-test.yaml
+++ b/.github/workflows/reusable-install-test.yaml
@@ -6,10 +6,13 @@ on:
       flavor:
         required: true
         type: string
+      label:
+        required: true
+        type: string
 
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: kvm
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -21,26 +24,44 @@ jobs:
           name: kairos-${{ inputs.flavor }}.iso.zip
       - name: Display structure of downloaded files
         run: ls -las .
-      - name: Install deps
-        run: |
-          brew install cdrtools jq gsed
       - name: Install Go
         uses: actions/setup-go@v4
         with:
           go-version-file: tests/go.mod
           cache-dependency-path: tests/go.sum
-      - name: Ginkgo
+      - name: Block all traffic to metadata ip  # For cloud runners, the metadata ip can interact with our test machines
         run: |
-          export ISO=$(ls $PWD/kairos-core-*${{ inputs.flavor }}*.iso)
-          export GOPATH="/Users/runner/go"
-          export PATH=$PATH:$GOPATH/bin
-          export CREATE_VM=true
-          export FLAVOR=${{ inputs.flavor }}
-          cd tests
-          go run github.com/onsi/ginkgo/v2/ginkgo --label-filter "install-test" --fail-fast -r ./...
+          sudo iptables -I INPUT -s 169.254.169.254 -j DROP
+          sudo iptables -I OUTPUT -d 169.254.169.254 -j DROP
+      - name: Enable KVM group perms
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libvirt-clients libvirt-daemon-system libvirt-daemon virtinst bridge-utils qemu qemu-system-x86 qemu-system-x86 qemu-utils qemu-kvm acl udev
+
+          # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
+          # echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          # sudo udevadm control --reload-rules
+          # sudo udevadm trigger --name-match=kvm
+          # sudo usermod -a -G kvm,libvirt $USER
+          #
+          # TODO: Switch back to the above solution when we switch to the github runners
+          # https://askubuntu.com/a/1081326
+          sudo setfacl -m u:runner:rwx /dev/kvm
+      - name: Run tests
+        env:
+          KVM: true
+          USE_QEMU: true
+          MEMORY: 4000
+          CPUS: 2
+          DRIVE_SIZE: 30000
+          CONTAINER_IMAGE: ttl.sh/kairos-${{ inputs.flavor }}-${{ github.sha }}-provider:24h
+        run: |
+          export ISO=$PWD/$(ls *.iso)
+          cp tests/go.* .
+          go run github.com/onsi/ginkgo/v2/ginkgo -v --label-filter "${{ inputs.label }}" --fail-fast -r ./tests/
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: ${{ inputs.flavor }}-vbox.logs.zip
+          name: ${{ inputs.flavor }}-${{ inputs.label }}.logs.zip
           path: tests/**/logs/*
           if-no-files-found: warn

--- a/.github/workflows/reusable-provider-tests.yaml
+++ b/.github/workflows/reusable-provider-tests.yaml
@@ -1,4 +1,4 @@
-name: Reusable workflow that runs provider tess
+name: Reusable workflow that runs provider tests
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-provider-upgrade-latest-test.yaml
+++ b/.github/workflows/reusable-provider-upgrade-latest-test.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           latest: true
           repository: "kairos-io/kairos"
-          fileName: 'kairos-standard-*${{ inputs.flavor }}-*k3s1.iso'
+          fileName: 'kairos-standard-${{ inputs.flavor }}-*k3s1.iso'
           out-file-path: ""
       - name: Run tests
         run: |
@@ -64,12 +64,13 @@ jobs:
           K3S_VERSION=$(sudo luet --config framework-profile.yaml search -o json k8s/k3s  | jq -r '.packages | map(.version) | unique | last' | cut -d+ -f1)
 
           export ISO=$PWD/$(ls *${K3S_VERSION}*.iso | head -n 1)
-          if [ -z "$ISO" ]; then
+          if [[ "$ISO" != *${K3S_VERSION}* ]]; then
             # IF we have bumped the versions they migth not match anymore and we have downloaded several versions
             # just ls in alphabetical order and get the latest
             export ISO=$PWD/$(ls -l *${{ inputs.flavor }}*.iso | tail -n 1)
-            if [ -z "$ISO" ]; then
+            if [[ "$ISO" != *.iso ]]; then
               echo "No ISO found"
+              ls -ltra
               exit 1
             fi
           fi

--- a/.github/workflows/reusable-provider-upgrade-latest-test.yaml
+++ b/.github/workflows/reusable-provider-upgrade-latest-test.yaml
@@ -64,5 +64,14 @@ jobs:
           K3S_VERSION=$(sudo luet --config framework-profile.yaml search -o json k8s/k3s  | jq -r '.packages | map(.version) | unique | last' | cut -d+ -f1)
 
           export ISO=$PWD/$(ls *${K3S_VERSION}*.iso | head -n 1)
+          if [ -z "$ISO" ]; then
+            # IF we have bumped the versions they migth not match anymore and we have downloaded several versions
+            # just ls in alphabetical order and get the latest
+            export ISO=$PWD/$(ls -l *${{ inputs.flavor }}*.iso | tail -n 1)
+            if [ -z "$ISO" ]; then
+              echo "No ISO found"
+              exit 1
+            fi
+          fi
           cp tests/go.* .
           go run github.com/onsi/ginkgo/v2/ginkgo -v --label-filter "provider-upgrade-latest-k8s-with-kubernetes" --fail-fast -r ./tests

--- a/.github/workflows/reusable-provider-upgrade-latest-test.yaml
+++ b/.github/workflows/reusable-provider-upgrade-latest-test.yaml
@@ -61,18 +61,6 @@ jobs:
           export DRIVE_SIZE=30000
           export CONTAINER_IMAGE=ttl.sh/kairos-${{ inputs.flavor }}-${{ github.sha }}-provider:24h
 
-          K3S_VERSION=$(sudo luet --config framework-profile.yaml search -o json k8s/k3s  | jq -r '.packages | map(.version) | unique | last' | cut -d+ -f1)
-
-          export ISO=$PWD/$(ls *${K3S_VERSION}*.iso | head -n 1)
-          if [[ "$ISO" != *${K3S_VERSION}* ]]; then
-            # IF we have bumped the versions they migth not match anymore and we have downloaded several versions
-            # just ls in alphabetical order and get the latest
-            export ISO=$PWD/$(ls -l *${{ inputs.flavor }}*.iso | tail -n 1)
-            if [[ "$ISO" != *.iso ]]; then
-              echo "No ISO found"
-              ls -ltra
-              exit 1
-            fi
-          fi
+          export ISO=$PWD/$(ls -l *${{ inputs.flavor }}*.iso | tail -n 1)
           cp tests/go.* .
           go run github.com/onsi/ginkgo/v2/ginkgo -v --label-filter "provider-upgrade-latest-k8s-with-kubernetes" --fail-fast -r ./tests

--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -48,9 +48,9 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20231023123951-repository.yaml
+    reference: 20231024092429-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20231023073447-repository.yaml
+    reference: 20231024092451-repository.yaml

--- a/tests/upgrade_latest_cli_test.go
+++ b/tests/upgrade_latest_cli_test.go
@@ -59,7 +59,7 @@ var _ = Describe("k3s upgrade manual test", Label("upgrade-latest-with-cli"), fu
 			Expect(currentVersion).To(ContainSubstring("v"))
 
 			By(fmt.Sprintf("Upgrading to: %s", containerImage))
-			out, err := vm.Sudo("kairos-agent upgrade --force --image " + containerImage)
+			out, err := vm.Sudo("kairos-agent --debug upgrade --force --image " + containerImage)
 			Expect(err).ToNot(HaveOccurred(), string(out))
 			Expect(out).To(ContainSubstring("Upgrade completed"))
 			Expect(out).To(ContainSubstring(containerImage))
@@ -78,6 +78,7 @@ var _ = Describe("k3s upgrade manual test", Label("upgrade-latest-with-cli"), fu
 				return v
 				// TODO: Add regex semver check here
 			}, 30*time.Minute, 10*time.Second).ShouldNot(Equal(currentVersion))
+
 		})
 	})
 })


### PR DESCRIPTION
Fix tests missing the k8s version due to it being bumped on the
packages.
It will now try to use the usual method and if nothing is found resort
to a simple ls to get the latest version downloaded of the iso.

Alos make the install test run under qemu instead of vbox which is
terrible and slow and fails half of the time.

Signed-off-by: Itxaka <itxaka@kairos.io><!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
