### PR TITLE
Remove AlmaLinux from building

### DIFF
--- a/.github/flavors.json
+++ b/.github/flavors.json
@@ -340,26 +340,6 @@
         "worker": "self-hosted"
     },
     {
-        "family": "rhel",
-        "flavor": "almalinux",
-        "flavorRelease": "9",
-        "variant": "standard",
-        "model": "generic",
-        "baseImage": "almalinux:9",
-        "arch": "amd64",
-        "worker": "self-hosted"
-    },
-    {
-        "family": "rhel",
-        "flavor": "almalinux",
-        "flavorRelease": "9",
-        "variant": "core",
-        "model": "generic",
-        "baseImage": "almalinux:9",
-        "arch": "amd64",
-        "worker": "self-hosted"
-    },
-    {
         "family": "nvidia",
         "flavor": "ubuntu",
         "flavorRelease": "20.04",


### PR DESCRIPTION
Now that we have the families to build, we can kinda trust that maintaining the rocky flavor will automatically give us alma.

Would be great if we can build everything all the time but it's expensive and I don't see any users relying on Alma, plus they can still build on their own with our recipe