### PR TITLE
:robot: Fix provider tests

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -271,9 +271,10 @@ jobs:
           - flavor: "opensuse"
             flavorRelease: "leap-15.5"
             label: "provider-qrcode-install"
-          - flavor: "opensuse"
-            flavorRelease: "leap-15.5"
-            label: "provider-upgrade"
+          # Requires at least 1 release with the newer repositories to work as this test checks the release list
+          #- flavor: "opensuse"
+          #  flavorRelease: "leap-15.5"
+          #  label: "provider-upgrade"
           - flavor: "opensuse"
             flavorRelease: "leap-15.5"
             label: "provider-decentralized-k8s"

--- a/tests/provider_decentralized_test.go
+++ b/tests/provider_decentralized_test.go
@@ -131,7 +131,7 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 				*/
 			} else {
 				Eventually(func() string {
-					out, _ = vm.Sudo("systemctl status kairos-agent")
+					out, _ = vm.Sudo("cat /var/log/kairos/agent-provider.log")
 					return out
 				}, 45*time.Minute, 1*time.Second).Should(
 					Or(

--- a/tests/provider_upgrade_k8s_test.go
+++ b/tests/provider_upgrade_k8s_test.go
@@ -73,6 +73,11 @@ var _ = Describe("k3s upgrade test", Label("provider", "provider-upgrade-k8s"), 
 			}, 30*time.Second, 10*time.Second).Should(And(
 				ContainSubstring("kairos"),
 				ContainSubstring("kairos-agent")))
+			Eventually(func() string {
+				var out string
+				out, _ = vm.Sudo("rc-service kairos-agent status")
+				return out
+			}, 900*time.Second, 10*time.Second).Should(ContainSubstring("status: started"))
 		} else {
 			Eventually(func() string {
 				out, _ := vm.Sudo("systemctl status kairos-agent")
@@ -87,16 +92,6 @@ var _ = Describe("k3s upgrade test", Label("provider", "provider-upgrade-k8s"), 
 				"loaded (/usr/lib/systemd/system/systemd-timesyncd.service; enabled; vendor preset: disabled)"))
 		}
 
-		By("checking if kairos-agent has started")
-		Eventually(func() string {
-			var out string
-			if isFlavor(vm, "alpine") {
-				out, _ = vm.Sudo("rc-service kairos-agent status")
-			} else {
-				out, _ = vm.Sudo("systemctl status kairos-agent")
-			}
-			return out
-		}, 900*time.Second, 10*time.Second).Should(Or(ContainSubstring("One time bootstrap starting"), ContainSubstring("status: started")))
 		By("Checking agent provider correct start")
 		Eventually(func() string {
 			out, _ := vm.Sudo("cat /var/log/kairos/agent-provider.log")


### PR DESCRIPTION
 - disable version list test until we have a release with the new repos
 - agent no longer tails the provider logs, thats the provider task so check for the start logs in the provider log directly

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
