### PR TITLE
Pass ARTIFACT down to os-release template

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -145,6 +145,8 @@ OSRELEASE:
 
     # quay.io/kairos/alpine or quay.io/kairos/ubuntu for example as this is just the repo
     ARG OS_REPO=$(./naming.sh container_artifact_repo)
+    ARG ARTIFACT=$(./naming.sh bootable_artifact_name)
+
     # kairos-core-alpine-3.18 or kairos-standard-ubuntu-20.04 for example
     ARG OS_NAME=kairos-${VARIANT}-${FLAVOR}-${FLAVOR_RELEASE}
 


### PR DESCRIPTION
so that KAIROS_ARTIFACT is set. Works with:

https://github.com/kairos-io/packages/pull/535

TODO: Bump the overlay files package when it's built

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
