### PR TITLE
Check for duplicate entries in generated Kairos config

### DIFF
--- a/framework-profile.yaml
+++ b/framework-profile.yaml
@@ -48,9 +48,9 @@ repositories:
     priority: 2
     urls:
       - "quay.io/kairos/packages"
-    reference: 20231122160509-repository.yaml
+    reference: 20231123154748-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
-    reference: 20231122162944-repository.yaml
+    reference: 20231123162059-repository.yaml

--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -83,6 +83,13 @@ var _ = Describe("kairos bundles test", Label("bundles-test"), func() {
 				Expect(err).ToNot(HaveOccurred(), ipfsV)
 				Expect(ipfsV).To(ContainSubstring("0.15.0"))
 			})
+
+			By("checking that there are no duplicate entries in the config (issue#2019)", func() {
+				out, _ := vm.Sudo("cat /oem/90_custom.yaml")
+				// https://pkg.go.dev/regexp/syntax
+				// ?s -> "let . match \n (default false)"
+				Expect(out).ToNot(MatchRegexp("(?s)ttl.sh.*ttl.sh"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
fixed here: https://github.com/kairos-io/kairos-sdk/pull/58

This commit makes sure we test this for regressions and pulls the fix in.

Fixes #2019
