### PR TITLE
Build and release multi arch framework images

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -49,16 +49,16 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.get-core-matrix.outputs.matrix)}}
   framework:
-    uses: ./.github/workflows/reusable-build-framework-flavor.yaml
+    uses: ./.github/workflows/reusable-build-framework.yaml
     secrets: inherit
     with:
-      flavor: ${{ matrix.flavor }}
+      security_profile: ${{ matrix.security_profile }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - flavor: "generic"
-          - flavor: "fips"
+          - security_profile: "generic"
+          - security_profile: "fips"
   install:
     uses: ./.github/workflows/reusable-install-test.yaml
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flavor:
+        security_profile:
           - "generic"
           - "fips"
     steps:
@@ -92,7 +92,7 @@ jobs:
                 insecure = true
                 http = true
           EOF
-          earthly +build-framework-image --FRAMEWORK_FLAVOR=${{ matrix.flavor }}
+          earthly +multi-build-framework-image --SECURITY_PROFILE=${{ matrix.security_profile }}
       - name: Push to quay
         env:
           COSIGN_YES: true

--- a/.github/workflows/reusable-build-framework.yaml
+++ b/.github/workflows/reusable-build-framework.yaml
@@ -3,7 +3,7 @@ name: Reusable workflow that builds a specific Kairos framework image flavor
 on:
   workflow_call:
     inputs:
-      flavor:
+      security_profile:
         required: true
         type: string
 
@@ -31,9 +31,7 @@ jobs:
           sudo iptables -I OUTPUT -d 169.254.169.254 -j DROP
       - name: Build framework image 🔧
         env:
-          FLAVOR: ${{ inputs.flavor }}
-          IMAGE: "quay.io/kairos/framework"
-          TAG: "master_${{ inputs.flavor }}"
+          ARTIFACT: "quay.io/kairos/framework:master_${{ inputs.security_profile }}"
           COSIGN_YES: true
         run: |
           # Configure earthly to use the docker mirror in CI
@@ -48,6 +46,6 @@ jobs:
                 insecure = true
                 http = true
           EOF
-          earthly +build-framework-image --FRAMEWORK_FLAVOR=${FLAVOR} --VERSION=master
-          docker push "$IMAGE:$TAG" # Otherwise .RepoDigests will be empty for some reason
-          cosign sign $(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE:$TAG")
+          earthly +multi-build-framework-image --SECURITY_PROFILE=${{ inputs.security_profile }} --VERSION=master
+          docker push "$ARTIFACT" # Otherwise .RepoDigests will be empty for some reason
+          cosign sign $(docker image inspect --format='{{index .RepoDigests 0}}' "$ARTIFACT")

--- a/Earthfile
+++ b/Earthfile
@@ -264,7 +264,12 @@ luet:
 framework:
     FROM golang:alpine
 
-    ARG --required SECURITY_PROFILE
+    ARG SECURITY_PROFILE
+    IF [ "$SECURITY_PROFILE" = "fips" ]
+        ARG _SECUIRTY_PROFILE=fips
+    ELSE
+        ARG _SECUIRTY_PROFILE=generic
+    END
 
     WORKDIR /build
 
@@ -273,7 +278,7 @@ framework:
 
     RUN go mod download
     COPY framework-profile.yaml /build
-    RUN go run main.go ${SECURITY_PROFILE} framework-profile.yaml /framework
+    RUN go run main.go ${_SECURITY_PROFILE} framework-profile.yaml /framework
 
     RUN mkdir -p /framework/etc/kairos/
     RUN luet database --system-target /framework get-all-installed --output /framework/etc/kairos/versions.yaml

--- a/Earthfile
+++ b/Earthfile
@@ -266,9 +266,9 @@ framework:
 
     ARG SECURITY_PROFILE
     IF [ "$SECURITY_PROFILE" = "fips" ]
-        ARG _SECUIRTY_PROFILE=fips
+        ARG _SECURITY_PROFILE=fips
     ELSE
-        ARG _SECUIRTY_PROFILE=generic
+        ARG _SECURITY_PROFILE=generic
     END
 
     WORKDIR /build


### PR DESCRIPTION
currently we only release amd64 framework images. Making them multi arch allows us to take advantage of the pre-built frameworks in arm. this will be particularly useful for the extraction of the earthly logic into dockerfiles related to #1897 