### PR TITLE
:arrow_up: Bump osbuilder tools

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -19,7 +19,7 @@ END
 ARG COSIGN_EXPERIMENTAL=0
 ARG CGO_ENABLED=0
 # renovate: datasource=docker depName=quay.io/kairos/osbuilder-tools versioning=semver-coerced
-ARG OSBUILDER_VERSION=v0.10.1
+ARG OSBUILDER_VERSION=v0.10.2
 ARG OSBUILDER_IMAGE=quay.io/kairos/osbuilder-tools:$OSBUILDER_VERSION
 ARG GOLINT_VERSION=1.52.2
 # renovate: datasource=docker depName=golang


### PR DESCRIPTION
So it has the proper grub packages which do not error out on memory

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
