### PR TITLE
Fix missing hardcoded k3s build

### DIFF
--- a/images/Dockerfile.kairos
+++ b/images/Dockerfile.kairos
@@ -32,15 +32,6 @@ ARG MODEL
 ARG REGISTRY_AND_ORG="quay.io/kairos"
 ARG K3S_VERSION
 ARG TARGETARCH
-ARG OS_NAME=kairos-${VARIANT}-${FLAVOR}-${FLAVOR_RELEASE}
-ENV KAIROS_VERSION="${VERSION}${K3S_VERSION:+-k3s$K3S_VERSION}"
-ENV OS_VERSION=${KAIROS_VERSION}
-ENV OS_LABEL=${KAIROS_VERSION}
-RUN OS_LABEL=$(naming.sh container_artifact_label) \
-    OS_REPO=$(naming.sh container_artifact_repo) \
-    ARTIFACT=$(naming.sh bootable_artifact_name) \
-    envsubst >>/etc/os-release </usr/lib/os-release.tmpl
-RUN naming.sh container_artifact_name > /IMAGE
 
 RUN rm -rf /etc/machine-id
 


### PR DESCRIPTION
:warning: also required before cutting out the final release

This is a revert to something similar to what we were doing before. Ideally, this should not have to happen on the Earthfile but could be done in the Dockerfile. The main issue is that the KAIROS_VERSION, gets appended to the K3S_VERSION within the +version target (plus removing of the internal build number and hardcoding the k3s build number). The real solution to this would be to address https://github.com/kairos-io/kairos/issues/2058 as @jimmykarily pointed out.