### PR TITLE
Add a standard build to PRs

### DIFF
--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -32,6 +32,17 @@ jobs:
       variant: core
       arch: amd64
 
+  standard:
+    uses: ./.github/workflows/reusable-build-provider.yaml
+    with:
+      flavor: opensuse
+      flavor_release: "leap-15.5"
+      family: opensuse
+      base_image: opensuse/leap:15.5
+      model: generic
+      variant: standard
+      arch: amd64
+
   install:
     uses: ./.github/workflows/reusable-install-test.yaml
     with:


### PR DESCRIPTION
I recently had a PR which was green but when merged to master, the standard images started breaking. This adds at least a build of a standard image to avoid such scenarios
