### PR TITLE
Introduce release_matcher to overwrite flavor release

### DIFF
--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -153,6 +153,7 @@ jobs:
       flavor: ubuntu
       flavor_release: "23.10"
       family: "ubuntu"
+      release_matcher: "23.04" # introduced so tests can be green while we wait for the kairos release with the latest flavor release
     needs:
       - core
 

--- a/.github/workflows/reusable-upgrade-latest-test.yaml
+++ b/.github/workflows/reusable-upgrade-latest-test.yaml
@@ -12,10 +12,15 @@ on:
       family:
         required: true
         type: string
+      release_matcher:
+        required: false
+        type: string
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      MATCHER: ${{ inputs.release_matcher || inputs.flavor_release }}
     steps:
       - name: Release space from worker
         run: |
@@ -57,7 +62,7 @@ jobs:
           # A flag to set the download target as latest release
           # The default value is 'false'
           latest: true
-          fileName: 'kairos-${{ inputs.flavor }}-${{ inputs.flavor_release }}*core-amd64-generic*.iso'
+          fileName: 'kairos-${{ inputs.flavor }}-${{ env.MATCHER }}*core-amd64-generic*.iso'
           out-file-path: ""
       - name: Display structure of downloaded files
         run: ls -las .
@@ -73,7 +78,7 @@ jobs:
       - run: |
           # release-downloader globing matches more than one iso. Make sure
           # we use the right one.
-          ISO=$(ls kairos-${{ inputs.family }}-${{ inputs.flavor_release }}*core-amd64-generic-v*.iso | grep -v ipxe | head -n 1)
+          ISO=$(ls kairos-${{ inputs.family }}-${{ env.MATCHER }}*core-amd64-generic-v*.iso | grep -v ipxe | head -n 1)
           earthly +run-qemu-test --PREBUILT_ISO=$ISO \
             --CONTAINER_IMAGE=ttl.sh/kairos-${{ inputs.flavor }}-${{ inputs.flavor_release }}-${{ github.sha }}:24h \
             --TEST_SUITE=upgrade-latest-with-cli


### PR DESCRIPTION
This is necessary to have tests which depend on the latest release, e.g. Ubuntu 23.04, and want to upgrade to the latest build, e.g. Ubuntu 23.10