### PR TITLE
fix pipeline issues during release of v2.5.0

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -108,7 +108,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -92,7 +92,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
@@ -165,7 +170,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
@@ -293,7 +303,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -264,7 +264,7 @@ jobs:
           sudo tar cvf "${filename}-scan-reports.tar.gz" *.json
           mv *.tar.gz ../release/
           cd ..
-          sudo rm -rf release/IMAGE release/versions.yaml
+          sudo rm -rf release/VERSION release/IMAGE release/versions.yaml
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/reusable-build-base-image.yaml
+++ b/.github/workflows/reusable-build-base-image.yaml
@@ -60,7 +60,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/reusable-build-flavor.yaml
+++ b/.github/workflows/reusable-build-flavor.yaml
@@ -52,7 +52,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/reusable-build-provider.yaml
+++ b/.github/workflows/reusable-build-provider.yaml
@@ -52,7 +52,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/reusable-docker-arm-build.yaml
+++ b/.github/workflows/reusable-docker-arm-build.yaml
@@ -54,7 +54,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/reusable-encryption-test.yaml
+++ b/.github/workflows/reusable-encryption-test.yaml
@@ -38,7 +38,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/reusable-qemu-acceptance-test.yaml
+++ b/.github/workflows/reusable-qemu-acceptance-test.yaml
@@ -35,7 +35,12 @@ jobs:
         sudo apt-get remove -y '^ghc-.*' || true
         sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
         sudo apt-get remove -y 'php.*' || true
-        sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+        sudo apt-get remove -y hhvm || true
+        sudo apt-get remove -y powershell || true
+        sudo apt-get remove -y firefox || true
+        sudo apt-get remove -y monodoc-manual || true
+        sudo apt-get remove -y msbuild || true
+        sudo apt-get remove -y microsoft-edge-stable || true
         sudo apt-get remove -y '^google-.*' || true
         sudo apt-get remove -y azure-cli || true
         sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/reusable-qemu-netboot-test.yaml
+++ b/.github/workflows/reusable-qemu-netboot-test.yaml
@@ -44,7 +44,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/reusable-upgrade-latest-test.yaml
+++ b/.github/workflows/reusable-upgrade-latest-test.yaml
@@ -40,7 +40,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true

--- a/.github/workflows/reusable-upgrade-with-cli-test.yaml
+++ b/.github/workflows/reusable-upgrade-with-cli-test.yaml
@@ -32,7 +32,12 @@ jobs:
           sudo apt-get remove -y '^ghc-.*' || true
           sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
           sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm powershell firefox monodoc-manual msbuild || true
+          sudo apt-get remove -y hhvm || true
+          sudo apt-get remove -y powershell || true
+          sudo apt-get remove -y firefox || true
+          sudo apt-get remove -y monodoc-manual || true
+          sudo apt-get remove -y msbuild || true
+          sudo apt-get remove -y microsoft-edge-stable || true
           sudo apt-get remove -y '^google-.*' || true
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true


### PR DESCRIPTION
removes VERSION file so it doesn't get released because it causes jobs to step on each others toes

remove more packages from worker

I wanted to use a reusable job for the releasing so we only have to change in one place but it was failing, so I'll open a ticket for that