### PR TITLE
:sparkles: Enable secureboot for all flavors (minus alpine)

### DIFF
--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -48,6 +48,16 @@ jobs:
     with:
       flavor: ubuntu
       flavor_release: "23.10"
+      secureboot: false
+    needs:
+      - core
+
+  install-secureboot:
+    uses: ./.github/workflows/reusable-install-test.yaml
+    with:
+      flavor: ubuntu
+      flavor_release: "23.10"
+      secureboot: true
     needs:
       - core
 

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -94,6 +94,33 @@ jobs:
         include:
           - flavor: opensuse
             flavorRelease: leap-15.5
+            secureboot: false
+  install-secureboot:
+    uses: ./.github/workflows/reusable-install-test.yaml
+    with:
+      flavor: ${{ matrix.flavor }}
+      flavor_release: ${{ matrix.flavorRelease }}
+      secureboot: true
+    needs:
+      - core
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - flavor: "opensuse"
+            flavorRelease: "leap-15.5"
+          - flavor: "opensuse"
+            flavorRelease: "tumbleweed"
+          - flavor: "debian"
+            flavorRelease: "bookworm"
+          - flavor: "ubuntu"
+            flavorRelease: "20.04"
+          - flavor: "ubuntu"
+            flavorRelease: "22.04"
+          - flavor: "ubuntu"
+            flavorRelease: "23.10"
+          - flavor: "fedora"
+            flavorRelease: "38"
   zfs:
     uses: ./.github/workflows/reusable-zfs-test.yaml
     with:

--- a/.github/workflows/reusable-install-test.yaml
+++ b/.github/workflows/reusable-install-test.yaml
@@ -65,7 +65,7 @@ jobs:
           export ISO=$PWD/$(ls *.iso)
           echo "ISO is: $ISO"
           cp tests/go.* .
-          go run github.com/onsi/ginkgo/v2/ginkgo --label-filter "install-test" --fail-fast -r ./tests
+          go run github.com/onsi/ginkgo/v2/ginkgo -v --label-filter "install-test" --fail-fast -r ./tests
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/reusable-install-test.yaml
+++ b/.github/workflows/reusable-install-test.yaml
@@ -9,6 +9,9 @@ on:
       flavor_release:
         required: true
         type: string
+      secureboot:
+        required: false
+        type: boolean
 
 jobs:
   test:
@@ -55,6 +58,9 @@ jobs:
           CREATE_VM: true
           FLAVOR: ${{ inputs.flavor }}
         run: |
+          if [ "${{ inputs.secureboot }}" = "true" ]; then
+            export FIRMWARE=/usr/share/OVMF/OVMF_CODE.fd
+          fi
           ls *.iso
           export ISO=$PWD/$(ls *.iso)
           echo "ISO is: $ISO"
@@ -63,6 +69,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: ${{ inputs.flavor }}-vbox.logs.zip
+          name: ${{ inputs.flavor }}.logs.zip
           path: tests/**/logs/*
           if-no-files-found: warn

--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -97,6 +97,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pynvim \
     rsync \
     shared-mime-info \
+    shim-signed \
     snapd \
     squashfs-tools \
     sudo \

--- a/images/Dockerfile.kairos-debian
+++ b/images/Dockerfile.kairos-debian
@@ -96,6 +96,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pynvim \
     rsync \
     shared-mime-info \
+    shim-signed \
     snapd \
     squashfs-tools \
     sudo \

--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -60,6 +60,7 @@ RUN zypper in --force-resolution -y \
     mdadm \
     multipath-tools \
     nano \
+    nohang \
     open-iscsi \
     openssh \
     open-vm-tools \

--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -60,7 +60,6 @@ RUN zypper in --force-resolution -y \
     mdadm \
     multipath-tools \
     nano \
-    nohang \
     open-iscsi \
     openssh \
     open-vm-tools \
@@ -71,6 +70,7 @@ RUN zypper in --force-resolution -y \
     procps \
     rng-tools \
     rsync \
+    shim \
     squashfs \
     strace \
     sudo \

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -79,6 +79,7 @@ RUN apt-get update \
     openssh-server \
     parted \
     rsync \
+    shim-signed \
     snapd \
     snmpd \
     squashfs-tools \

--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -61,7 +61,6 @@ RUN zypper in --force-resolution -y \
     mdadm \
     multipath-tools \
     nano \
-    nohang \
     open-iscsi \
     openssh \
     open-vm-tools \
@@ -72,6 +71,7 @@ RUN zypper in --force-resolution -y \
     procps \
     rng-tools \
     rsync \
+    shim \
     squashfs \
     strace \
     sudo \

--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -61,6 +61,7 @@ RUN zypper in --force-resolution -y \
     mdadm \
     multipath-tools \
     nano \
+    nohang \
     open-iscsi \
     openssh \
     open-vm-tools \

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -80,6 +80,7 @@ RUN apt-get update \
     openssh-server \
     parted \
     rsync \
+    shim-signed \
     snapd \
     snmpd \
     squashfs-tools \

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -69,6 +69,9 @@ var _ = Describe("kairos install test", Label("install-test"), func() {
 
 	Context("install", func() {
 		It("cloud-config syntax mixed with extended syntax", func() {
+
+			expectSecureBootEnabled(vm)
+
 			_ = testInstall(`#cloud-config
 install:
   bind_mounts:
@@ -93,6 +96,8 @@ bundles:
   targets:
   - container://quay.io/mocaccino/extra:edgevpn-utils-0.15.0
 `, vm)
+
+			expectSecureBootEnabled(vm)
 
 			Eventually(func() string {
 				out, _ := vm.Sudo("cat /etc/foo")

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -304,6 +304,19 @@ func expectRebootedToActive(vm VM) {
 	})
 }
 
+func expectSecureBootEnabled(vm VM) {
+	// Check for secureboot before install, based on firmware env var
+	// if we set, then the test suite will load the secureboot firmware
+	secureboot := os.Getenv("FIRMWARE")
+
+	if secureboot == "true" {
+		By("checking that secureboot is enabled", func() {
+			out, _ := vm.Sudo("dmesge | grep -i secure")
+			Expect(out).To(ContainSubstring("Secure boot enabled"))
+		})
+	}
+}
+
 // return the PID of the swtpm (to be killed later) and the state directory
 func emulateTPM(stateDir string) {
 	t := path.Join(stateDir, "tpm")

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -309,9 +309,9 @@ func expectSecureBootEnabled(vm VM) {
 	// if we set, then the test suite will load the secureboot firmware
 	secureboot := os.Getenv("FIRMWARE")
 
-	if secureboot == "true" {
+	if secureboot != "" {
 		By("checking that secureboot is enabled", func() {
-			out, _ := vm.Sudo("dmesge | grep -i secure")
+			out, _ := vm.Sudo("dmesg | grep -i secure")
 			Expect(out).To(ContainSubstring("Secure boot enabled"))
 		})
 	}


### PR DESCRIPTION
This PR brings new deps, bumps builders and agent to bring secureboot in all flavors but alpine (more ont hat below)

Currently to enable secureboot in a given X flavor we need to make sure to use the artifacts from that falvor specifically as they are all signed with the distro owner key, so the chain of validation works as expected.

shim (dual signed Microsoft and distro owner) -> grub (distro owner signed) -> kernel (distro owner signed)

So unless there comes a time where the shim is signed by Microsoft and ALL the distro owners (so you can chainload all grubs and kernel signed by all of them) we need to specifically use the distro artifacts so the signatures match.

This PR brings a new enki version(inside osbuilder) which builds the iso using the specifci distro artifacts (instead of generic ones as we used to do).

It also makes sure that all distros include the grub and shim signed artifacts in the base images.

Also brings a new framework that drops the generic grub artifacts (not used) and it also brings a new agent that uses those new artifacts during installation instead of the generic ones.

Unfortunately Alpine does not provide signed artifacts so SecureBoot is not supported under Alpine until they provide those. We still use our generic artifacts to enable uefi support for Alpine

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
