### PR TITLE
Make sure test doesn't break when master matches the latest release

### DIFF
--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -153,7 +153,7 @@ jobs:
       flavor: ubuntu
       flavor_release: "23.10"
       family: "ubuntu"
-      release_matcher: "23.04" # introduced so tests can be green while we wait for the kairos release with the latest flavor release
+      release_matcher: "23.10" # introduced so tests can be green while we wait for the kairos release with the latest flavor release
     needs:
       - core
 

--- a/.github/workflows/reusable-encryption-test.yaml
+++ b/.github/workflows/reusable-encryption-test.yaml
@@ -80,7 +80,7 @@ jobs:
           LUET_NOLOCK=true sudo -E luet install -y container/kubectl utils/k3d utils/earthly
       - name: Download ISO
         id: iso
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.1
         with:
           name: kairos-${{ inputs.flavor }}-${{ inputs.flavor_release }}.iso.zip
       - name: Display structure of downloaded files

--- a/.github/workflows/reusable-install-test.yaml
+++ b/.github/workflows/reusable-install-test.yaml
@@ -19,7 +19,7 @@ jobs:
           git fetch --prune --unshallow
       - name: Download ISO
         id: iso
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.1
         with:
           name: kairos-${{ inputs.flavor }}-${{ inputs.flavor_release}}.iso.zip
       - name: Install Go

--- a/.github/workflows/reusable-provider-tests.yaml
+++ b/.github/workflows/reusable-provider-tests.yaml
@@ -55,7 +55,7 @@ jobs:
           repository: quay.io/kairos/packages
           packages: utils/earthly
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.1
         with:
           name: kairos-${{ inputs.flavor }}-${{ inputs.flavor_release }}-provider.iso.zip
       - name: Run tests

--- a/.github/workflows/reusable-qemu-acceptance-test.yaml
+++ b/.github/workflows/reusable-qemu-acceptance-test.yaml
@@ -59,7 +59,7 @@ jobs:
         git fetch --prune --unshallow
     - name: Download ISO
       id: iso
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v4.1.1
       with:
         name: kairos-${{ inputs.flavor }}-${{ inputs.flavor_release }}.iso.zip
     - name: Display structure of downloaded files

--- a/.github/workflows/reusable-qemu-bundles-test.yaml
+++ b/.github/workflows/reusable-qemu-bundles-test.yaml
@@ -19,7 +19,7 @@ jobs:
           git fetch --prune --unshallow
       - name: Download ISO
         id: iso
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.1
         with:
           name: kairos-${{ inputs.flavor }}-${{ inputs.flavor_release }}.iso.zip
       - name: Display structure of downloaded files

--- a/.github/workflows/reusable-qemu-reset-test.yaml
+++ b/.github/workflows/reusable-qemu-reset-test.yaml
@@ -19,7 +19,7 @@ jobs:
           git fetch --prune --unshallow
       - name: Download ISO
         id: iso
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.1
         with:
           name: kairos-${{ inputs.flavor }}-${{ inputs.flavor_release }}.iso.zip
       - name: Display structure of downloaded files

--- a/.github/workflows/reusable-upgrade-with-cli-test.yaml
+++ b/.github/workflows/reusable-upgrade-with-cli-test.yaml
@@ -61,7 +61,7 @@ jobs:
           git fetch --prune --unshallow
       - name: Download ISO
         id: iso
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.1
         with:
           name: kairos-${{ inputs.flavor }}-${{ inputs.flavor_release }}.iso.zip
       - name: Display structure of downloaded files

--- a/.github/workflows/reusable-zfs-test.yaml
+++ b/.github/workflows/reusable-zfs-test.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download ISO
         id: iso
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.1
         with:
           name: kairos-${{ inputs.flavor }}-${{ inputs.flavor_release }}.iso.zip
       - name: Display structure of downloaded files

--- a/Earthfile
+++ b/Earthfile
@@ -9,7 +9,7 @@ ARG LUET_VERSION=0.35.0
 # renovate: datasource=docker depName=aquasec/trivy
 ARG TRIVY_VERSION=0.48.2
 # renovate: datasource=github-releases depName=kairos-io/kairos-framework
-ARG KAIROS_FRAMEWORK_VERSION="v2.5.7"
+ARG KAIROS_FRAMEWORK_VERSION="v2.6.0"
 ARG COSIGN_SKIP=".*quay.io/kairos/.*"
 # TODO: rename ISO_NAME to something like ARTIFACT_NAME because there are place where we use ISO_NAME to refer to the artifact name
 

--- a/tests/provider_upgrade_test.go
+++ b/tests/provider_upgrade_test.go
@@ -24,7 +24,7 @@ var _ = Describe("provider upgrade test", Label("provider", "provider-upgrade"),
 
 	Context("kairos-agent upgrade list-releases", func() {
 		It("returns at least one option to upgrade to", func() {
-			resultStr, _ := vm.Sudo(`kairos-agent upgrade list-releases | tail -1`)
+			resultStr, _ := vm.Sudo(`kairos-agent upgrade list-releases --all | tail -1`)
 
 			Expect(resultStr).To(ContainSubstring("quay.io/kairos"))
 		})


### PR DESCRIPTION
This test breaks when `master` branches matches the latest release exactly. That's because the previous version of the command, didn't find any newer releases, thus it didn't return any.

We introduced the `--all` flag to kairos-agent and now the test can get away with it by just listing all releases, older or newer (it doesn't return the current one for obvious reasons).