### PR TITLE
:wrench: Adapt uki test

### DIFF
--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -50,7 +50,10 @@ jobs:
             --MODEL=generic \
             --VARIANT=core \
             --BASE_IMAGE=fedora:38
-      - name: Run tests
+      - name: Create datasource iso 🔧
+        run: |
+          earthly +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml
+      - name: Run tests 🔧
         env:
           USE_QEMU: true
           KVM: true
@@ -60,6 +63,7 @@ jobs:
           EMULATE_TPM: true
         run: |
           export ISO=$(ls $PWD/build/kairos-${{ env.FLAVOR }}-${{ env.FLAVOR_RELEASE }}-core-amd64-generic-*.uki.iso)
+          export DATASOURCE=${PWD}/build/datasource.iso
           cp tests/go.* .
           go run github.com/onsi/ginkgo/v2/ginkgo -v --label-filter "uki" --fail-fast -r ./tests/
       - uses: actions/upload-artifact@v4

--- a/tests/uki_test.go
+++ b/tests/uki_test.go
@@ -20,6 +20,9 @@ var _ = Describe("kairos UKI test", Label("uki"), Ordered, func() {
 	})
 
 	BeforeEach(func() {
+		if os.Getenv("DATASOURCE") == "" {
+			Fail("DATASOURCE must be set and it should be the absolute path to a datasource iso")
+		}
 		_, vm = startVM()
 		vm.EventuallyConnects(300)
 	})
@@ -48,7 +51,7 @@ var _ = Describe("kairos UKI test", Label("uki"), Ordered, func() {
 			Expect(out).ToNot(ContainSubstring("/dev/disk/by-label/COS_PERSISTENT"))
 		})
 		By("installing kairos", func() {
-			out, err := vm.Sudo(`kairos-agent --debug uki install --device /dev/vda`)
+			out, err := vm.Sudo(`kairos-agent --debug install`)
 			fmt.Println(string(out))
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).Should(ContainSubstring("Running after-install hook"))


### PR DESCRIPTION
Now that uki installs follow the normal install path we need to ensure we have a datasource like normal install tests

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
