### PR TITLE
Add scp to fedora

### DIFF
--- a/images/Dockerfile.kairos-rhel
+++ b/images/Dockerfile.kairos-rhel
@@ -60,6 +60,7 @@ RUN dnf install -y \
     lvm2 \
     nano \
     openssh-server \
+    openssh-clients \
     parted \
     polkit \
     qemu-guest-agent \

--- a/images/Dockerfile.rhel
+++ b/images/Dockerfile.rhel
@@ -61,6 +61,7 @@ RUN dnf install -y \
     lvm2 \
     nano \
     openssh-server \
+    openssh-clients \
     parted \
     polkit \
     qemu-guest-agent \


### PR DESCRIPTION
because the go-scp library used in peg needs it

https://github.com/bramvdbogaerde/go-scp/blob/0350bf9c320df7874b3d71271c07e3b5cd30c02d/client.go#L193


Fixes broken master test: https://github.com/kairos-io/kairos/actions/runs/7542286423/job/20535405662
