### PR TITLE
Remove duplicated zfs installation on rhel

### DIFF
--- a/images/Dockerfile.kairos-rhel
+++ b/images/Dockerfile.kairos-rhel
@@ -72,8 +72,7 @@ RUN dnf install -y \
     systemd-networkd \
     systemd-resolved \
     tar \
-    which \
-    zfs && dnf clean all
+    which && dnf clean all
 
 FROM common AS all
 RUN mkdir -p /run/lock

--- a/images/Dockerfile.rhel
+++ b/images/Dockerfile.rhel
@@ -74,7 +74,7 @@ RUN dnf install -y \
     systemd-resolved \
     tar \
     which \
-    zfs && dnf clean all
+    && dnf clean all
 
 FROM common AS all
 RUN mkdir -p /run/lock


### PR DESCRIPTION
Probably missed when refactoring to install different pacakges depending on whether the base image is using epel or fedora base