### PR TITLE
Add target to transform kairos image into UKI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -201,7 +201,7 @@ jobs:
           category: ${{ matrix.flavor }}
   build-core-uki:
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - build-core
       - get-uki-matrix
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -194,7 +194,7 @@ jobs:
       - name: Build uki image 🔧
         run: |
           # Do fedora as its the smaller uki possible
-          earthly +uki-iso \
+          earthly +uki-dev-iso \
             --FAMILY=rhel \
             --FLAVOR=fedora \
             --FLAVOR_RELEASE=38 \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,25 @@ jobs:
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
           echo "::set-output name=matrix::{\"include\": $content }"
+  get-uki-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - run: |
+        sudo apt update && sudo apt install -y jq
+    - id: set-matrix
+      run: |
+          content=`cat ./.github/flavors.json | jq -r 'map(select(.arch == "amd64" and .variant == "core" and .flavor == "fedora"))'`
+          # the following lines are only required for multi line json
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          # end of optional handling for multi line json
+          echo "::set-output name=matrix::{\"include\": $content }"
 
   # The matrix for standard (provider) images
   get-standard-matrix:
@@ -182,6 +201,11 @@ jobs:
           category: ${{ matrix.flavor }}
   build-core-uki:
     runs-on: ubuntu-latest
+    needs: 
+      - build-core
+      - get-uki-matrix
+    strategy:
+      matrix: ${{ fromJson(needs.get-uki-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -194,13 +218,8 @@ jobs:
       - name: Build uki image 🔧
         run: |
           # Do fedora as its the smaller uki possible
-          earthly +uki-dev-iso \
-            --FAMILY=rhel \
-            --FLAVOR=fedora \
-            --FLAVOR_RELEASE=38 \
-            --VARIANT=core \
-            --MODEL=generic \
-            --BASE_IMAGE=fedora:38
+          earthly +uki-iso \
+            --BASE_IMAGE=quay.io/kairos/fedora:${{ matrix.flavorRelease }}-${{ matrix.variant }}-${{ matrix.arch }}-${{ matrix.model }}-${{ github.ref_name }}
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -41,15 +41,25 @@ jobs:
         with:
           repository: quay.io/kairos/packages
           packages: utils/earthly
-      - name: Build uki ISO 🔧
+      - name: Build base image 🔧
         run: | # known flavors to work with uki+encryption: fedora >= 38, ubuntu >= 23.10, anything with systemd 253
-          earthly +uki-dev-iso \
+          earthly +base-image \
             --FLAVOR=fedora \
             --FLAVOR_RELEASE=38 \
             --FAMILY=rhel \
             --MODEL=generic \
             --VARIANT=core \
             --BASE_IMAGE=fedora:38
+      - name: Push image to ttl.sh
+        env:
+          TEMP_IMAGE: ttl.sh/fedora-38-${{ github.head_ref || github.ref }}:24h
+        run: |
+          docker tag $(cat build/IMAGE) $TEMP_IMAGE
+          docker push $TEMP_IMAGE
+      - name: Build uki ISO 🔧
+        run: |
+          earthly +uki-iso \
+            --BASE_IMAGE=ttl.sh/fedora-38-${{ github.head_ref || github.ref }}:24h
       - name: Create datasource iso 🔧
         run: |
           earthly +datasource-iso --CLOUD_CONFIG=tests/assets/autoinstall.yaml

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -43,7 +43,7 @@ jobs:
           packages: utils/earthly
       - name: Build uki ISO 🔧
         run: | # known flavors to work with uki+encryption: fedora >= 38, ubuntu >= 23.10, anything with systemd 253
-          earthly +uki-iso \
+          earthly +uki-dev-iso \
             --FLAVOR=fedora \
             --FLAVOR_RELEASE=38 \
             --FAMILY=rhel \

--- a/Earthfile
+++ b/Earthfile
@@ -32,6 +32,8 @@ ARG HADOLINT_VERSION=2.12.0-alpine
 ARG RENOVATE_VERSION=37
 # renovate: datasource=docker depName=koalaman/shellcheck-alpine versioning=docker
 ARG SHELLCHECK_VERSION=v0.9.0
+# renovate: datasource=docker depName=quay.io/kairos/enki versioning=docker
+ARG ENKI_VERSION=v0.0.8
 
 ARG IMAGE_REPOSITORY_ORG=quay.io/kairos
 
@@ -318,7 +320,7 @@ image-rootfs:
 
 ## UKI Stuff Start
 enki-image:
-    FROM  quay.io/kairos/enki:v0.0.8
+    FROM  quay.io/kairos/enki:${ENKI_VERSION}
     SAVE ARTIFACT /enki enki
 
 uki-iso:
@@ -333,7 +335,6 @@ uki-iso:
         RUN echo $BASE_IMAGE > /IMAGE
 
         RUN --no-cache enki build-uki $(cat /IMAGE) /tmp/kairos.uki.iso /keys
-        RUN ls -las /tmp
         SAVE ARTIFACT /tmp/kairos.uki.iso kairos.uki.iso AS LOCAL build/$ISO_NAME.uki.iso
 
 # WARNING the following targets are just for development purposes, use them at your own risk

--- a/Earthfile
+++ b/Earthfile
@@ -343,32 +343,152 @@ uki-tools-image:
 # This is for easy testing SecureBoot locally for development purposes
 # Installing this keys in other place than a VM for testing SecureBoot is irresponsible
 
+# Base uki artifacts
+# we need:
+# kernel
+# initramfs
+# cmdline
+# os-release
+# uname
+uki-base:
+    WORKDIR build
+    # Build kernel,uname, etc artifacts
+    FROM +base-image --BUILD_INITRD=false
+
+    RUN /usr/bin/immucore version
+    RUN /usr/bin/kairos-agent version
+    RUN ln -s /usr/bin/immucore /init
+    RUN mkdir -p /oem # be able to mount oem under here if found
+    RUN mkdir -p /efi # mount the esp under here if found
+    RUN mkdir -p /usr/local/cloud-config/ # for install/upgrade they copy stuff there
+    # Put it under /tmp otherwise initramfs will contain itself. /tmp is excluded from the find
+    RUN find . \( -path ./sys -prune -o -path ./run -prune -o -path ./dev -prune -o -path ./tmp -prune -o -path ./proc -prune \) -o -print | cpio -R root:root -H newc -o | gzip -2 > /tmp/initramfs.cpio.gz
+    RUN echo "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.debug rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0" > Cmdline
+    RUN basename $(ls /boot/vmlinuz-* |grep -v rescue | head -n1)| sed --expression "s/vmlinuz-//g" > Uname
+    SAVE ARTIFACT /tmp/initramfs.cpio.gz initrd
+    SAVE ARTIFACT Cmdline Cmdline
+    SAVE ARTIFACT Uname Uname
+    SAVE ARTIFACT /boot/vmlinuz Kernel
+    SAVE ARTIFACT /etc/os-release Osrelease
+
+# Now build, measure and sign the uki image
+uki-build:
+    FROM +uki-tools-image
+    WORKDIR /build
+    COPY tests/keys/* .
+    COPY +uki-base/initrd .
+    COPY +uki-base/Kernel .
+    COPY +uki-base/Cmdline .
+    COPY +uki-base/Uname .
+    COPY +uki-base/Osrelease .
+
+    COPY +git-version/GIT_VERSION ./
+    ARG KAIROS_VERSION=$(cat GIT_VERSION)
+
+    ARG UNAME=$(cat Uname)
+    RUN /usr/lib/systemd/ukify Kernel initrd \
+        --cmdline=@Cmdline \
+        --os-release=@Osrelease \
+        --uname="${UNAME}" \
+        --stub /usr/lib/systemd/boot/efi/linuxx64.efi.stub \
+        --secureboot-private-key DB.key \
+        --secureboot-certificate DB.crt \
+        --pcr-private-key tpm2-pcr-private.pem \
+        --measure \
+        --output uki.signed.efi
+    RUN sbsign --key DB.key --cert DB.crt --output systemd-bootx64.signed.efi /usr/lib/systemd/boot/efi/systemd-bootx64.efi
+    RUN printf 'title Kairos %s\nefi /EFI/kairos/%s.efi\nversion %s' ${KAIROS_VERSION} ${KAIROS_VERSION} ${KAIROS_VERSION} > ${KAIROS_VERSION}.conf
+    RUN printf 'default @saved\ntimeout 5\nconsole-mode max\neditor no\n' > loader.conf
+    SAVE ARTIFACT PK.der PK.der
+    SAVE ARTIFACT KEK.der KEK.der
+    SAVE ARTIFACT DB.der DB.der
+    SAVE ARTIFACT systemd-bootx64.signed.efi systemd-bootx64.signed.efi
+    SAVE ARTIFACT uki.signed.efi uki.signed.efi
+    SAVE ARTIFACT ${KAIROS_VERSION}.conf ${KAIROS_VERSION}.conf
+    SAVE ARTIFACT loader.conf loader.conf
+
+# Base target to set the directory structure for the image artifacts
+# as we need to create several dirs and copy files into them
+# Then we generate the image from scratch to not ring anything else
+uki-image-artifacts:
+    FROM +uki-tools-image
+    COPY +git-version/GIT_VERSION ./
+    ARG KAIROS_VERSION=$(cat GIT_VERSION)
+
+    COPY +uki-build/systemd-bootx64.signed.efi /output/efi/EFI/BOOT/BOOTX64.EFI
+    COPY +uki-build/uki.signed.efi /output/efi/EFI/kairos/${KAIROS_VERSION}.efi
+    COPY +uki-build/${KAIROS_VERSION}.conf /output/efi/loader/entries/${KAIROS_VERSION}.conf
+    COPY +uki-build/loader.conf /output/efi/loader/loader.conf
+    COPY +uki-build/PK.der /output/efi/loader/keys/kairos/PK.der
+    COPY +uki-build/KEK.der /output/efi/loader/keys/kairos/KEK.der
+    COPY +uki-build/DB.der /output/efi/loader/keys/kairos/DB.der
+    SAVE ARTIFACT /output/efi efi
+
+# This is the final artifact, only the files on it
+uki-image:
+    COPY +base-image/IMAGE .
+    ARG _CIMG=$(cat ./IMAGE)
+    FROM scratch
+    COPY +uki-image-artifacts/efi /
+    SAVE IMAGE --push $_CIMG.uki
+
+uki-iso:
+    # +base-image will be called again by +uki but will be cached.
+    # We just use it here to take a shortcut to the artifact name
+    FROM +base-image
+    WORKDIR /build
+    ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+
+    COPY +git-version/GIT_VERSION ./
+    ARG KAIROS_VERSION=$(cat GIT_VERSION)
+
+    ARG OSBUILDER_IMAGE
+    FROM $OSBUILDER_IMAGE
+    WORKDIR /build
+    COPY +uki-build/systemd-bootx64.signed.efi .
+    COPY +uki-build/uki.signed.efi .
+    COPY +uki-build/${KAIROS_VERSION}.conf .
+    COPY +uki-build/loader.conf .
+    COPY +uki-build/PK.der .
+    COPY +uki-build/KEK.der .
+    COPY +uki-build/DB.der .
+    RUN mkdir -p /tmp/efi
+    RUN ls -ltra /build
+    # get the size of the artifacts
+    ARG SIZE=$(du -sm /build | cut -f1)
+    RUN ls -ltra /build
+    # Create just the size we need + 50MB just in case?
+    RUN dd if=/dev/zero of=/tmp/efi/efiboot.img bs=1M count=$((SIZE + 50))
+    RUN mkfs.msdos -F 32 /tmp/efi/efiboot.img
+    RUN mmd -i /tmp/efi/efiboot.img ::EFI
+    RUN mmd -i /tmp/efi/efiboot.img ::EFI/BOOT
+    RUN mmd -i /tmp/efi/efiboot.img ::EFI/kairos
+    RUN mmd -i /tmp/efi/efiboot.img ::EFI/tools
+    RUN mmd -i /tmp/efi/efiboot.img ::loader
+    RUN mmd -i /tmp/efi/efiboot.img ::loader/entries
+    RUN mmd -i /tmp/efi/efiboot.img ::loader/keys
+    RUN mmd -i /tmp/efi/efiboot.img ::loader/keys/kairos
+    RUN mcopy -i /tmp/efi/efiboot.img PK.der ::loader/keys/kairos/PK.der
+    RUN mcopy -i /tmp/efi/efiboot.img KEK.der ::loader/keys/kairos/KEK.der
+    RUN mcopy -i /tmp/efi/efiboot.img DB.der ::loader/keys/kairos/DB.der
+    RUN mcopy -i /tmp/efi/efiboot.img ${KAIROS_VERSION}.conf ::loader/entries/${KAIROS_VERSION}.conf
+    RUN mcopy -i /tmp/efi/efiboot.img loader.conf ::loader/loader.conf
+    RUN mcopy -i /tmp/efi/efiboot.img uki.signed.efi ::EFI/kairos/${KAIROS_VERSION}.efi
+    RUN mcopy -i /tmp/efi/efiboot.img systemd-bootx64.signed.efi ::EFI/BOOT/BOOTX64.EFI
+    RUN xorriso -as mkisofs -V 'UKI_ISO_INSTALL' -e efiboot.img -no-emul-boot -o $ISO_NAME.iso /tmp/efi
+    SAVE ARTIFACT /build/$ISO_NAME.iso kairos.iso AS LOCAL build/$ISO_NAME.uki.iso
+
 enki-image:
     FROM  quay.io/kairos/enki:v0.0.8
     SAVE ARTIFACT /enki enki
 
+# Uki stuff End
 uki-enki:
         ARG --required BASE_IMAGE # BASE_IMAGE is existing kairos image which needs to be converted to uki
         FROM $BASE_IMAGE
         ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
-    FROM +uki-tools-image
-    FROM +uki-tools-image
-    WORKDIR /build
-    COPY tests/keys/* .
-    COPY +uki-base/initrd .
-    COPY +uki-base/Kernel .
-    COPY +uki-base/Cmdline .
-    COPY +uki-base/Uname .
-    COPY +uki-base/Osrelease .
         FROM +uki-tools-image
-    WORKDIR /build
-    COPY tests/keys/* .
-    COPY +uki-base/initrd .
-    COPY +uki-base/Kernel .
-    COPY +uki-base/Cmdline .
-    COPY +uki-base/Uname .
-    COPY +uki-base/Osrelease .
 
         COPY +enki-image/enki /usr/bin/enki
         COPY ./tests/keys /keys
@@ -377,9 +497,6 @@ uki-enki:
         RUN --no-cache enki build-uki $(cat /IMAGE) /tmp/fedora.uki.iso /keys
         RUN ls -las /tmp
         SAVE ARTIFACT /tmp/fedora.uki.iso fedora.uki.iso AS LOCAL build/$ISO_NAME.uki.iso
-# Uki stuff End
-
-
 
 ###
 ### Artifacts targets (ISO, netboot, ARM)


### PR DESCRIPTION
This new target requires to pass an existing kairos image, which means it's a two step proces e.g.

```
earthly --push +base-image --....
earhtly +uki-enki --BASE_IMAGE=<pushed-image-from-previous-step>
```

I first tried to have it in a single step but I'm not sure if it's possible since enki cannot access the local registry from Earthly. Even when using `WITH DOCKER` this is problematic because our uki building image is on fedora. We have to use fedora because Ubuntu does not have the latest packages e.g. ukify. However, Earthly complains that it doesn't know the distro, so considers it's a Debian and then proceeds unsuccessfully to try to install packages via `apt`.

Please let me know if I'm missing something here. And if it's not possible, then the question for me is really, about why we are doing this on Earthly since we are trying to move away from it for the Factory.

Relates to #870
Fixes #2170 
