### PR TITLE
:bug: Do not recompress compressed firmware

### DIFF
--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -245,8 +245,8 @@ FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-20.04
 ###############################################################
 FROM ${FLAVOR}-${FLAVOR_RELEASE} AS all
 
-# compress firmware
-RUN find /usr/lib/firmware -type f -execdir zstd --rm -9 {} \+
+# compress firmware (from 23.10, fw files come compressed)
+RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \+
 # compress modules
 RUN find /usr/lib/modules -type f -name "*.ko" -execdir zstd --rm -9 {} \+
 

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -246,8 +246,8 @@ FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-20.04
 ###############################################################
 FROM ${FLAVOR}-${FLAVOR_RELEASE} AS all
 
-# compress firmware
-RUN find /usr/lib/firmware -type f -execdir zstd --rm -9 {} \+
+# compress firmware (from 23.10, fw files come compressed)
+RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \+
 # compress modules
 RUN find /usr/lib/modules -type f -name "*.ko" -execdir zstd --rm -9 {} \+
 


### PR DESCRIPTION
Since ubuntu 23.10 firmware files now come pre-compressed in the packages so we would recompress them again. Fix the find to not take into account already compressed files

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2236 

