### PR TITLE
Run zst per file

### DIFF
--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -246,7 +246,8 @@ FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-20.04
 FROM ${FLAVOR}-${FLAVOR_RELEASE} AS all
 
 # compress firmware (from 23.10, fw files come compressed)
-RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \+
+# for some reason \+ is breaking. Using \; instead despite being slower
+RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \;
 # compress modules
 RUN find /usr/lib/modules -type f -name "*.ko" -execdir zstd --rm -9 {} \+
 

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -247,7 +247,8 @@ FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-20.04
 FROM ${FLAVOR}-${FLAVOR_RELEASE} AS all
 
 # compress firmware (from 23.10, fw files come compressed)
-RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \+
+# for some reason \+ is breaking. Using \; instead despite being slower
+RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \;
 # compress modules
 RUN find /usr/lib/modules -type f -name "*.ko" -execdir zstd --rm -9 {} \+
 


### PR DESCRIPTION
```
                 all *failed* |   2 files compressed : 46.04% (   808   B =>    372   B)
                 all *failed* | ./cdspr.jsn          : 46.90%   (   403 B =>    189 B, ./cdspr.jsn.zst) 
                 all *failed* | ./regulatory.db.p7s  : 89.93%   (  1.15 KiB =>   1.04 KiB, ./regulatory.db.p7s.zst) 
                 all *failed* | ./regulatory.db      : 43.57%   (  4.39 KiB =>   1.91 KiB, ./regulatory.db.zst) 
                 all *failed* | 310 files compressed : 25.29% (   908 KiB =>    230 KiB)
                 all *failed* |  11 files compressed : 21.31% (   474 KiB =>    101 KiB)
                 all *failed* | ERROR
                 all *failed* |       The command
                 all *failed* |           RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} +
                 all *failed* |       did not complete successfully. Exit code 1
                 
```

https://github.com/kairos-io/kairos/actions/runs/7843857719/job/21405083958