### PR TITLE
Ubuntu 24.04 arm64 generic

### DIFF
--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -234,7 +234,14 @@ RUN apt-get update \
     systemd-hwe-hwdb \
     systemd-resolved \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 FROM ubuntu-latest AS ubuntu-24.04
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    isc-dhcp-common \
+    isc-dhcp-client \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 FROM ubuntu-latest AS ubuntu-23.10
 
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-22.04

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -24,6 +24,8 @@ ARG FRAMEWORK_VERSION=main
 ###############################################################
 ####                     Upstream Images                   ####
 ###############################################################
+FROM ${BASE_IMAGE} AS ubuntu-24.04-upstream
+
 FROM ${BASE_IMAGE} AS ubuntu-23.10-upstream
 
 FROM ${BASE_IMAGE} AS ubuntu-20.04-upstream
@@ -167,6 +169,7 @@ RUN [ -z "$(ls -A /lib/modules/)" ] && apt-get install -y --no-install-recommend
     linux-image-generic-hwe-22.04 || true
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
+FROM amd64-base-ubuntu-22.04 AS amd64-ubuntu-24.04
 FROM amd64-base-ubuntu-22.04 AS amd64-ubuntu-23.10
 FROM amd64-base-ubuntu-22.04 AS amd64-ubuntu-22.04
 FROM amd64-base-ubuntu-20.04 AS amd64-ubuntu-20.04
@@ -201,6 +204,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-modules-extra-raspi \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+FROM generic AS amd64-ubuntu-24.04-generic
 FROM generic AS amd64-ubuntu-23.10-generic
 FROM generic AS amd64-ubuntu-22.04-generic
 FROM generic AS amd64-ubuntu-20.04-generic
@@ -221,6 +225,15 @@ FROM ubuntu-20.04-upstream AS arm64-ubuntu-20.04-nvidia-jetson-agx-orin
 ###############################################################
 ####                Common to a Single Flavor              ####
 ###############################################################
+FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-24.04
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    dbus-user-session \
+    pkg-config \
+    systemd-hwe-hwdb \
+    systemd-resolved \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-23.10
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -225,7 +225,8 @@ FROM ubuntu-20.04-upstream AS arm64-ubuntu-20.04-nvidia-jetson-agx-orin
 ###############################################################
 ####                Common to a Single Flavor              ####
 ###############################################################
-FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-24.04
+# As soon as 24.04 is released, this can be renamed to ubuntu-24.04 directly and remove all 23.10 references
+FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-latest
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     dbus-user-session \
@@ -233,15 +234,8 @@ RUN apt-get update \
     systemd-hwe-hwdb \
     systemd-resolved \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-23.10
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    dbus-user-session \
-    pkg-config \
-    systemd-hwe-hwdb \
-    systemd-resolved \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM ubuntu-latest AS ubuntu-24.04
+FROM ubuntu-latest AS ubuntu-23.10
 
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-22.04
 RUN apt-get update

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -25,6 +25,8 @@ ARG FRAMEWORK_VERSION=main
 ###############################################################
 ####                     Upstream Images                   ####
 ###############################################################
+FROM ${BASE_IMAGE} AS ubuntu-24.04-upstream
+
 FROM ${BASE_IMAGE} AS ubuntu-23.10-upstream
 
 FROM ${BASE_IMAGE} AS ubuntu-20.04-upstream
@@ -168,6 +170,7 @@ RUN [ -z "$(ls -A /lib/modules/)" ] && apt-get install -y --no-install-recommend
     linux-image-generic-hwe-22.04 || true
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
+FROM amd64-base-ubuntu-22.04 AS amd64-ubuntu-24.04
 FROM amd64-base-ubuntu-22.04 AS amd64-ubuntu-23.10
 FROM amd64-base-ubuntu-22.04 AS amd64-ubuntu-22.04
 FROM amd64-base-ubuntu-20.04 AS amd64-ubuntu-20.04
@@ -202,6 +205,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-modules-extra-raspi \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+FROM generic AS amd64-ubuntu-24.04-generic
 FROM generic AS amd64-ubuntu-23.10-generic
 FROM generic AS amd64-ubuntu-22.04-generic
 FROM generic AS amd64-ubuntu-20.04-generic
@@ -222,6 +226,15 @@ FROM ubuntu-20.04-upstream AS arm64-ubuntu-20.04-nvidia-jetson-agx-orin
 ###############################################################
 ####                Common to a Single Flavor              ####
 ###############################################################
+FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-24.04
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    dbus-user-session \
+    pkg-config \
+    systemd-hwe-hwdb \
+    systemd-resolved \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-23.10
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -226,7 +226,8 @@ FROM ubuntu-20.04-upstream AS arm64-ubuntu-20.04-nvidia-jetson-agx-orin
 ###############################################################
 ####                Common to a Single Flavor              ####
 ###############################################################
-FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-24.04
+# As soon as 24.04 is released, this can be renamed to ubuntu-24.04 directly and remove all 23.10 references
+FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-latest
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     dbus-user-session \
@@ -234,15 +235,8 @@ RUN apt-get update \
     systemd-hwe-hwdb \
     systemd-resolved \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-23.10
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    dbus-user-session \
-    pkg-config \
-    systemd-hwe-hwdb \
-    systemd-resolved \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM ubuntu-latest AS ubuntu-24.04
+FROM ubuntu-latest AS ubuntu-23.10
 
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-22.04
 RUN apt-get update

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -235,7 +235,14 @@ RUN apt-get update \
     systemd-hwe-hwdb \
     systemd-resolved \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 FROM ubuntu-latest AS ubuntu-24.04
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    isc-dhcp-common \
+    isc-dhcp-client \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 FROM ubuntu-latest AS ubuntu-23.10
 
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-22.04


### PR DESCRIPTION
I was testing Ubuntu 24.04, and it works with amd64. It will need proper testing and also to add it to flavors.json. Adding that to the main ticket

relates to #2138
