### PR TITLE
Add Ubuntu standard build on master

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -273,6 +273,10 @@ jobs:
             flavorRelease: "3.19"
             family: alpine
             baseImage: alpine:3.19
+          - flavor: ubuntu
+            flavorRelease: "23.10"
+            family: ubuntu
+            baseImage: ubuntu:23.10
   various:
     uses: ./.github/workflows/reusable-provider-tests.yaml
     with:


### PR DESCRIPTION
Currently, we don't build Ubuntu standard on master, we do have one on PR, but I think it's worth adding here since it's such a crucial flavor. Also, this avoids that in order to see the issues we have to re-run the release pipeline but can be caught on master.
