### PR TITLE
Use Ubuntu 22 LTS for ZFS test

### DIFF
--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -21,6 +21,17 @@ jobs:
       variant: core
       arch: amd64
 
+  core-ubuntu-lts:
+    uses: ./.github/workflows/reusable-build-flavor.yaml
+    with:
+      flavor: ubuntu
+      flavor_release: "22.04"
+      family: ubuntu
+      base_image: ubuntu:22.04
+      model: generic
+      variant: core
+      arch: amd64
+
   core-alpine:
     uses: ./.github/workflows/reusable-build-flavor.yaml
     with:

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -73,7 +73,7 @@ jobs:
     uses: ./.github/workflows/reusable-zfs-test.yaml
     with:
       flavor: ubuntu
-      flavor_release: "23.10"
+      flavor_release: "22.04"
     needs:
       - core
 

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -86,7 +86,7 @@ jobs:
       flavor: ubuntu
       flavor_release: "22.04"
     needs:
-      - core
+      - core-ubuntu-lts
 
   acceptance:
     uses: ./.github/workflows/reusable-qemu-acceptance-test.yaml

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -101,7 +101,7 @@ jobs:
       matrix:
         include:
           - flavor: "ubuntu"
-            flavorRelease: "23.10"
+            flavorRelease: "22.04"
   acceptance:
     uses: ./.github/workflows/reusable-qemu-acceptance-test.yaml
     with:


### PR DESCRIPTION
This is because zfs is not being installed on 23+ since it clashes
with nohang and it's not a requirement to have