### PR TITLE
Remove snap from Ubuntu based images

### DIFF
--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -88,7 +88,6 @@ RUN  apt-get update \
     openssh-server \
     parted \
     rsync \
-    snapd \
     sudo \
     systemd \
     systemd-timesyncd \

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -89,7 +89,6 @@ RUN  apt-get update \
     openssh-server \
     parted \
     rsync \
-    snapd \
     sudo \
     systemd \
     systemd-timesyncd \


### PR DESCRIPTION
Originally requested by @santhoshdaivajna 

I indeed think snap should not be part of the base image but instead users who rely on it should have their own images and pass it through the kairos factory. However, it's already out there so I'm also wondering how we should inform users about it? Does it suffice to simply put a release note? @mudler 

Fixes #2414
