### PR TITLE
fix(orin): disable ISCSI in the initramfs generation

### DIFF
--- a/images/Dockerfile.nvidia
+++ b/images/Dockerfile.nvidia
@@ -98,6 +98,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 
 RUN apt-get remove -y unattended-upgrades
 
+# Disable ISCSI
+# (The kernel does not support it: https://github.com/kairos-io/kairos/issues/2467)
+RUN echo 'omit_dracutmodules+=" iscsi "' > /etc/dracut.conf.d/iscsi.conf
+
 # https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%20Linux%20Driver%20Package%20Development%20Guide/updating_jetson_and_host.html
 # root@orin:~# apt list --installed | grep nv
 # cuda-nvcc-11-4/stable,now 11.4.315-1 arm64 [installed]


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: https://github.com/kairos-io/kairos/issues/2467