### PR TITLE
:bug: Move nfs-utils to common build target in opensuse flavor

### DIFF
--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -60,6 +60,7 @@ RUN zypper in --force-resolution -y \
     mdadm \
     multipath-tools \
     nano \
+    nfs-utils \
     nohang \
     open-iscsi \
     openssh \
@@ -92,7 +93,6 @@ RUN zypper in --force-resolution -y \
     grub2-x86_64-efi \
     kernel-firmware-all \
     nethogs \
-    nfs-utils \
     patch \
     systemd-sysvinit \
     && zypper cc

--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -61,6 +61,7 @@ RUN zypper in --force-resolution -y \
     mdadm \
     multipath-tools \
     nano \
+    nfs-utils \
     nohang \
     open-iscsi \
     openssh \
@@ -93,7 +94,6 @@ RUN zypper in --force-resolution -y \
     grub2-x86_64-efi \
     kernel-firmware-all \
     nethogs \
-    nfs-utils \
     patch \
     systemd-sysvinit \
     && zypper cc


### PR DESCRIPTION
relates to issue #1538 and pr #2340

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
