### PR TITLE
Remove 23.10 from the test pipelines

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -86,8 +86,6 @@ jobs:
           - flavor: "ubuntu"
             flavorRelease: "22.04"
           - flavor: "ubuntu"
-            flavorRelease: "23.10"
-          - flavor: "ubuntu"
             flavorRelease: "24.04"
           - flavor: "fedora"
             flavorRelease: "40"
@@ -127,8 +125,6 @@ jobs:
             flavorRelease: "20.04"
           - flavor: "ubuntu"
             flavorRelease: "22.04"
-          - flavor: "ubuntu"
-            flavorRelease: "23.10"
           - flavor: "ubuntu"
             flavorRelease: "24.04"
   bundles:
@@ -194,12 +190,6 @@ jobs:
             variant: core
             model: generic
             baseImage: opensuse/leap:15.5
-          - flavor: ubuntu
-            flavorRelease: "23.10"
-            family: ubuntu
-            variant: core
-            model: generic
-            baseImage: ubuntu:23.10
           - flavor: ubuntu
             flavorRelease: "24.04"
             family: ubuntu
@@ -297,10 +287,6 @@ jobs:
             flavorRelease: "3.19"
             family: alpine
             baseImage: alpine:3.19
-          - flavor: ubuntu
-            flavorRelease: "23.10"
-            family: ubuntu
-            baseImage: ubuntu:23.10
           - flavor: ubuntu
             flavorRelease: "24.04"
             family: ubuntu

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
         sudo apt update && sudo apt install -y jq
     - id: set-matrix
       run: |
-          content=`cat ./.github/flavors.json | jq -r 'map(select(.arch == "amd64" and .variant == "core" and (.flavor == "fedora" or (.flavor == "ubuntu" and (.flavorRelease == "23.10" or .flavorRelease == "24.04")))))'`
+          content=`cat ./.github/flavors.json | jq -r 'map(select(.arch == "amd64" and .variant == "core" and (.flavor == "fedora" or (.flavor == "ubuntu" and (.flavorRelease == "24.04")))))'`
           # the following lines are only required for multi line json
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -22,10 +22,6 @@ jobs:
       matrix:
         include:
           - flavor: ubuntu
-            flavor_release: "23.10"
-            base_image: "ubuntu:23.10"
-            family: ubuntu
-          - flavor: ubuntu
             flavor_release: "24.04"
             base_image: "ubuntu:24.04"
             family: ubuntu
@@ -123,13 +119,6 @@ jobs:
           docker push "$IMAGE$SUFFIX"
           image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE$SUFFIX")
           cosign sign $image_ref
-  test-uki-ubuntu:
-    uses: ./.github/workflows/reusable-uki-test.yaml
-    with:
-      base_image: ubuntu:23.10
-      family: ubuntu
-      flavor: ubuntu
-      flavor_release: "23.10"
   test-uki-ubuntu-lts:
     uses: ./.github/workflows/reusable-uki-test.yaml
     with:

--- a/.github/workflows/uki_branches.yaml
+++ b/.github/workflows/uki_branches.yaml
@@ -19,13 +19,6 @@ concurrency:
 env:
   FORCE_COLOR: 1
 jobs:
-  test-uki-ubuntu:
-    uses: ./.github/workflows/reusable-uki-tests.yaml
-    with:
-      base_image: ubuntu:23.10
-      family: ubuntu
-      flavor: ubuntu
-      flavor_release: 23.10
   test-uki-ubuntu-lts:
     uses: ./.github/workflows/reusable-uki-tests.yaml
     with:


### PR DESCRIPTION
It's still part of the flavors.json until we are sure we don't need to build more 23.10 images

relates to https://github.com/kairos-io/kairos/issues/2481