### PR TITLE
Add more space on v3.0 releases

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -136,6 +136,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -442,6 +442,7 @@ jobs:
       - name: Build iso  🔧
         run: |
           INIT=$([[ "${{ matrix.flavor }}" == "alpine" ]] && echo "openrc" || echo "systemd")
+          earthly --platform=linux/arm64 +extract-framework-profile
           K3S_VERSION=$(sudo luet --config framework-profile.yaml search -o json k8s/k3s  | jq --arg INIT "$INIT" '.packages | map(select(.name == "k3s-" + $INIT)) | map(.version) | unique | last' | tr -d '"')
           earthly -P +all-arm-generic \
             --FLAVOR=${{ matrix.flavor }} \

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -112,6 +112,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo
@@ -190,6 +194,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo
@@ -323,6 +331,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,6 +137,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo
@@ -251,6 +255,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo
@@ -372,6 +380,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/.github/workflows/reusable-build-flavor.yaml
+++ b/.github/workflows/reusable-build-flavor.yaml
@@ -62,6 +62,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/.github/workflows/reusable-build-provider.yaml
+++ b/.github/workflows/reusable-build-provider.yaml
@@ -62,6 +62,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/.github/workflows/reusable-docker-arm-build.yaml
+++ b/.github/workflows/reusable-docker-arm-build.yaml
@@ -64,6 +64,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/.github/workflows/reusable-encryption-test.yaml
+++ b/.github/workflows/reusable-encryption-test.yaml
@@ -48,6 +48,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/.github/workflows/reusable-qemu-acceptance-test.yaml
+++ b/.github/workflows/reusable-qemu-acceptance-test.yaml
@@ -45,6 +45,10 @@ jobs:
         sudo apt-get remove -y azure-cli || true
         sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
         sudo apt-get remove -y '^gfortran-.*' || true
+        sudo apt-get remove -y 'vim-runtime' || true
+        sudo apt-get remove -y '^gcc-*' || true
+        sudo apt-get remove -y '^g++-*' || true
+        sudo apt-get remove -y '^cpp-*' || true
         sudo apt-get autoremove -y
         sudo apt-get clean
         echo

--- a/.github/workflows/reusable-qemu-netboot-test.yaml
+++ b/.github/workflows/reusable-qemu-netboot-test.yaml
@@ -54,6 +54,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/.github/workflows/reusable-upgrade-latest-test.yaml
+++ b/.github/workflows/reusable-upgrade-latest-test.yaml
@@ -50,6 +50,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/.github/workflows/reusable-upgrade-with-cli-test.yaml
+++ b/.github/workflows/reusable-upgrade-with-cli-test.yaml
@@ -42,6 +42,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -47,6 +47,10 @@ jobs:
           sudo apt-get remove -y azure-cli || true
           sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
           sudo apt-get remove -y '^gfortran-.*' || true
+          sudo apt-get remove -y 'vim-runtime' || true
+          sudo apt-get remove -y '^gcc-*' || true
+          sudo apt-get remove -y '^g++-*' || true
+          sudo apt-get remove -y '^cpp-*' || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           echo

--- a/Earthfile
+++ b/Earthfile
@@ -9,7 +9,7 @@ ARG LUET_VERSION=0.35.1
 # renovate: datasource=docker depName=aquasec/trivy
 ARG TRIVY_VERSION=0.50.1
 # renovate: datasource=github-releases depName=kairos-io/kairos-framework
-ARG KAIROS_FRAMEWORK_VERSION=v2.7.32
+ARG KAIROS_FRAMEWORK_VERSION=v2.7.33
 ARG COSIGN_SKIP=".*quay.io/kairos/.*"
 # TODO: rename ISO_NAME to something like ARTIFACT_NAME because there are place where we use ISO_NAME to refer to the artifact name
 


### PR DESCRIPTION
I hope this fixes the issue with the building of ubuntu 22 arm, if it works then it will also need to be merged on master but I think some workflows changed a bit so might be easier to just do in a different commit than to cherry pick

```
2024-05-14T23:20:31.4790490Z 208517     gcc-13
2024-05-14T23:20:31.4791190Z 193002     g++-13
2024-05-14T23:20:31.4791701Z 181224     cpp-13
2024-05-14T23:20:31.4792392Z 123578     linux-modules-6.5.0-1018-azure
2024-05-14T23:20:31.4792842Z 115583     containerd.io
2024-05-14T23:20:31.4793143Z 98484      snapd
2024-05-14T23:20:31.4793569Z 94367      docker-ce
2024-05-14T23:20:31.4793972Z 81895      linux-azure-6.5-headers-6.5.0-1018
2024-05-14T23:20:31.4794409Z 70069      gcc-12
2024-05-14T23:20:31.4794811Z 52747      gcc-11
2024-05-14T23:20:31.4795099Z 52609      gcc-10
2024-05-14T23:20:31.4795390Z 50291      kubectl
2024-05-14T23:20:31.4795775Z 48298      gh
2024-05-14T23:20:31.4796119Z 46016      libicu-dev
2024-05-14T23:20:31.4796529Z 44711      containernetworking-plugins
2024-05-14T23:20:31.4797000Z 43394      r-base-core
2024-05-14T23:20:31.4797348Z 37259      g++-12
2024-05-14T23:20:31.4797664Z 37161      podman
2024-05-14T23:20:31.4798051Z 35691      docker-ce-cli
2024-05-14T23:20:31.4798395Z 34554      cpp-12
2024-05-14T23:20:31.4798675Z 34444      libicu70
2024-05-14T23:20:31.4799065Z 32783      vim-runtime
2024-05-14T23:20:31.4799394Z 30796      git
2024-05-14T23:20:31.4799754Z 30350      g++-9
2024-05-14T23:20:31.4800026Z 29899      gcc-9
2024-05-14T23:20:31.4800352Z 28891      g++-11
2024-05-14T23:20:31.4800712Z 28445      libperl5.34
2024-05-14T23:20:31.4801049Z 28354      g++-10
2024-05-14T23:20:31.4801369Z 28029      cpp-9
2024-05-14T23:20:31.4801747Z 26407      python-babel-localedata
```