### PR TITLE
Add permissions to reusable-provider-tests

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -340,6 +340,21 @@ jobs:
             baseImage: ubuntu:24.04
   various:
     uses: ./.github/workflows/reusable-provider-tests.yaml
+    permissions:
+      contents: write
+      security-events: write
+      id-token: write
+      actions: read
+      attestations: read
+      checks: read
+      deployments: read
+      discussions: read
+      issues: read
+      packages: read
+      pages: read
+      pull-requests: read
+      repository-projects: read
+      statuses: read
     with:
       flavor: ${{ matrix.flavor }}
       flavor_release: ${{ matrix.flavorRelease }}


### PR DESCRIPTION
This one does not run on PRs so I missed it :( there are still others that might break, specially on release since I haven't run those at all
