### PR TITLE
:bug: Install cryptsetup for all arches in opensuse

### DIFF
--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -34,6 +34,7 @@ FROM ${FLAVOR_RELEASE}-repo AS common
 RUN zypper in --force-resolution -y \
     bash-completion \
     conntrack-tools \
+    cryptsetup \
     coreutils \
     curl \
     device-mapper \
@@ -88,7 +89,6 @@ RUN zypper in --force-resolution -y \
 
 FROM common as amd64
 RUN zypper in --force-resolution -y \
-    cryptsetup \
     grub2-i386-pc \
     grub2-x86_64-efi \
     kernel-firmware-all \

--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -35,6 +35,7 @@ FROM ${FLAVOR_RELEASE}-repo AS common
 RUN zypper in --force-resolution -y \
     bash-completion \
     conntrack-tools \
+    cryptsetup \
     coreutils \
     curl \
     device-mapper \
@@ -89,7 +90,6 @@ RUN zypper in --force-resolution -y \
 
 FROM common as amd64
 RUN zypper in --force-resolution -y \
-    cryptsetup \
     grub2-i386-pc \
     grub2-x86_64-efi \
     kernel-firmware-all \


### PR DESCRIPTION
Seems like we were only installing cryptsetup in amd64 and immucore dracut install requires cryptsetup. This caused the list of required binaries in the initramfs to fail in the middle and not install the next ones.

So in the case of arm64 (rpi) this mean that binaries were installed up to the cryptsetup, then it failed and didnt continued installing the required binaries, which were the ones being used to expand the partition to max size on boot.

This makes cryptsetup part of the common install for both arches

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2682 
