### PR TITLE
Add k3s test for arm release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -35,6 +35,7 @@ assignees: mudler
     - [ ] ARM images passive and recovery booting
     - [ ] ARM images reset works
     - [ ] ARM images /oem exists
+    - [ ] ARM K3s is running
 - [ ] **Stage 3 - Release**
   - [ ] Tag the release on master
   - [ ] Update the release with any known issues


### PR DESCRIPTION
We've had issues with FS expansion and with cgroups that both break k3s, plus it's the main software to test on a standard image 