### PR TITLE
:penguin: Disable make cache timer on fedora

### DIFF
--- a/images/Dockerfile.kairos-rhel
+++ b/images/Dockerfile.kairos-rhel
@@ -95,6 +95,7 @@ RUN systemctl enable getty@tty3.service
 RUN systemctl enable systemd-networkd
 RUN systemctl enable systemd-resolved
 RUN systemctl disable dnf-makecache.service
+RUN systemctl disable dnf-makecache.timer
 RUN systemctl enable sshd
 
 FROM --platform="linux/${TARGETARCH}" quay.io/kairos/framework:${FRAMEWORK_VERSION} AS framework

--- a/images/Dockerfile.rhel
+++ b/images/Dockerfile.rhel
@@ -96,4 +96,5 @@ RUN systemctl enable getty@tty3.service
 RUN systemctl enable systemd-networkd
 RUN systemctl enable systemd-resolved
 RUN systemctl disable dnf-makecache.service
+RUN systemctl disable dnf-makecache.timer
 RUN systemctl enable sshd


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
```
                 all | --> RUN systemctl disable dnf-makecache.timer
                 all | Removed "/etc/systemd/system/timers.target.wants/dnf-makecache.timer".
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2664 
