### PR TITLE
:robot: Check that install/recovery services are off during active boot

### DIFF
--- a/tests/autoinstall_test.go
+++ b/tests/autoinstall_test.go
@@ -172,6 +172,23 @@ var _ = Describe("kairos autoinstall test", Label("autoinstall-test"), func() {
 				stateContains(vm, "system.os.name", "alpine", "opensuse", "ubuntu", "debian")
 				stateContains(vm, "kairos.flavor", "alpine", "opensuse", "ubuntu", "debian")
 			})
+
+			By("Checking install/recovery services are disabled", func() {
+				if !isFlavor(vm, "alpine") {
+					for _, service := range []string{"kairos-interactive", "kairos-recovery"} {
+						By(fmt.Sprintf("Checking that service %s is disabled", service), func() {})
+						Eventually(func() string {
+							out, _ := vm.Sudo(fmt.Sprintf("systemctl status %s", service))
+							return out
+						}, 3*time.Minute, 2*time.Second).Should(
+							And(
+								ContainSubstring(fmt.Sprintf("loaded (/etc/systemd/system/%s.service; disabled;", service)),
+								ContainSubstring("Active: inactive (dead)"),
+							),
+						)
+					}
+				}
+			})
 		})
 	})
 })

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -119,6 +119,22 @@ bundles:
 			}, 5*time.Minute, 10*time.Second).Should(ContainSubstring("peerguard"))
 
 			stateAssertVM(vm, "persistent.found", "true")
+			By("Checking install/recovery services are disabled", func() {
+				if !isFlavor(vm, "alpine") {
+					for _, service := range []string{"kairos-interactive", "kairos-recovery"} {
+						By(fmt.Sprintf("Checking that service %s is disabled", service), func() {})
+						Eventually(func() string {
+							out, _ := vm.Sudo(fmt.Sprintf("systemctl status %s", service))
+							return out
+						}, 3*time.Minute, 2*time.Second).Should(
+							And(
+								ContainSubstring(fmt.Sprintf("loaded (/etc/systemd/system/%s.service; disabled;", service)),
+								ContainSubstring("Active: inactive (dead)"),
+							),
+						)
+					}
+				}
+			})
 		})
 
 		Context("with config_url", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kairos-io/kairos/issues/2773
