### PR TITLE
:penguin: Disable pcrlock for all systemd distros

### DIFF
--- a/images/Dockerfile.kairos
+++ b/images/Dockerfile.kairos
@@ -109,7 +109,11 @@ RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 
+# Disable the make-policy service that its on by default on some systemd versions
+# it creates a pcrlock.json policy that conflicts with our mesurements when trying to enroll it
 RUN if [ "$(which-init.sh)" = "systemd" ]; then \
+      systemctl disable systemd-pcrlock-make-policy || true; \
+      systemctl mask systemd-pcrlock-make-policy || true; \
       journalctl --vacuum-size=1K || true; \
     fi
 

--- a/images/Dockerfile.kairos-alpine
+++ b/images/Dockerfile.kairos-alpine
@@ -260,7 +260,11 @@ RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 
+# Disable the make-policy service that its on by default on some systemd versions
+# it creates a pcrlock.json policy that conflicts with our mesurements when trying to enroll it
 RUN if [ "$(which-init.sh)" = "systemd" ]; then \
+      systemctl disable systemd-pcrlock-make-policy || true; \
+      systemctl mask systemd-pcrlock-make-policy || true; \
       journalctl --vacuum-size=1K || true; \
     fi
 

--- a/images/Dockerfile.kairos-debian
+++ b/images/Dockerfile.kairos-debian
@@ -273,7 +273,11 @@ RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 
+# Disable the make-policy service that its on by default on some systemd versions
+# it creates a pcrlock.json policy that conflicts with our mesurements when trying to enroll it
 RUN if [ "$(which-init.sh)" = "systemd" ]; then \
+      systemctl disable systemd-pcrlock-make-policy || true; \
+      systemctl mask systemd-pcrlock-make-policy || true; \
       journalctl --vacuum-size=1K || true; \
     fi
 

--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -269,7 +269,11 @@ RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 
+# Disable the make-policy service that its on by default on some systemd versions
+# it creates a pcrlock.json policy that conflicts with our mesurements when trying to enroll it
 RUN if [ "$(which-init.sh)" = "systemd" ]; then \
+      systemctl disable systemd-pcrlock-make-policy || true; \
+      systemctl mask systemd-pcrlock-make-policy || true; \
       journalctl --vacuum-size=1K || true; \
     fi
 

--- a/images/Dockerfile.kairos-rhel
+++ b/images/Dockerfile.kairos-rhel
@@ -208,7 +208,11 @@ RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 
+# Disable the make-policy service that its on by default on some systemd versions
+# it creates a pcrlock.json policy that conflicts with our mesurements when trying to enroll it
 RUN if [ "$(which-init.sh)" = "systemd" ]; then \
+      systemctl disable systemd-pcrlock-make-policy || true; \
+      systemctl mask systemd-pcrlock-make-policy || true; \
       journalctl --vacuum-size=1K || true; \
     fi
 

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -474,7 +474,11 @@ RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 
+# Disable the make-policy service that its on by default on some systemd versions
+# it creates a pcrlock.json policy that conflicts with our mesurements when trying to enroll it
 RUN if [ "$(which-init.sh)" = "systemd" ]; then \
+      systemctl disable systemd-pcrlock-make-policy || true; \
+      systemctl mask systemd-pcrlock-make-policy || true; \
       journalctl --vacuum-size=1K || true; \
     fi
 


### PR DESCRIPTION
the pcrlock service will generate a policy on boot which when adding our measurements policy, will also be read and clash. You can only either use a pcrlock policy or a measurements policy.

This disables the service until the pcrlock stuff is more stable and we can move to use it directly

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
