### PR TITLE
:bug: Empty machine-id instead of removing it

### DIFF
--- a/images/Dockerfile.kairos
+++ b/images/Dockerfile.kairos
@@ -85,6 +85,12 @@ RUN luet database get-all-installed --output /etc/kairos/versions.yaml
 
 # TODO what about caches?
 RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
+
+# Set empty machine-id
+# This prevents systemd from thinking that the machine is on first boot
+# and recreating /etc/ dependencies in services and such
+# do this before initramfs so its in the initramfs
+RUN echo "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \
@@ -105,7 +111,6 @@ RUN kernel=$(ls /boot/Image* 2>/dev/null | head -n1) && if [ -e "$kernel" ]; the
 # this is generally present on rhel based systems, but it doesn't hurt to remove in any case
 RUN rm -rf /boot/initramfs-* || true
 
-RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 

--- a/images/Dockerfile.kairos-alpine
+++ b/images/Dockerfile.kairos-alpine
@@ -236,6 +236,12 @@ RUN luet database get-all-installed --output /etc/kairos/versions.yaml
 
 # TODO what about caches?
 RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
+
+# Set empty machine-id
+# This prevents systemd from thinking that the machine is on first boot
+# and recreating /etc/ dependencies in services and such
+# do this before initramfs so its in the initramfs
+RUN echo "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \
@@ -256,7 +262,6 @@ RUN kernel=$(ls /boot/Image* 2>/dev/null | head -n1) && if [ -e "$kernel" ]; the
 # this is generally present on rhel based systems, but it doesn't hurt to remove in any case
 RUN rm -rf /boot/initramfs-* || true
 
-RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 

--- a/images/Dockerfile.kairos-debian
+++ b/images/Dockerfile.kairos-debian
@@ -249,6 +249,12 @@ RUN luet database get-all-installed --output /etc/kairos/versions.yaml
 
 # TODO what about caches?
 RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
+
+# Set empty machine-id
+# This prevents systemd from thinking that the machine is on first boot
+# and recreating /etc/ dependencies in services and such
+# do this before initramfs so its in the initramfs
+RUN echo "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \
@@ -269,7 +275,6 @@ RUN kernel=$(ls /boot/Image* 2>/dev/null | head -n1) && if [ -e "$kernel" ]; the
 # this is generally present on rhel based systems, but it doesn't hurt to remove in any case
 RUN rm -rf /boot/initramfs-* || true
 
-RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 

--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -245,6 +245,12 @@ RUN luet database get-all-installed --output /etc/kairos/versions.yaml
 
 # TODO what about caches?
 RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
+
+# Set empty machine-id
+# This prevents systemd from thinking that the machine is on first boot
+# and recreating /etc/ dependencies in services and such
+# do this before initramfs so its in the initramfs
+RUN echo "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \
@@ -265,7 +271,6 @@ RUN kernel=$(ls /boot/Image* 2>/dev/null | head -n1) && if [ -e "$kernel" ]; the
 # this is generally present on rhel based systems, but it doesn't hurt to remove in any case
 RUN rm -rf /boot/initramfs-* || true
 
-RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 

--- a/images/Dockerfile.kairos-rhel
+++ b/images/Dockerfile.kairos-rhel
@@ -184,6 +184,12 @@ RUN luet database get-all-installed --output /etc/kairos/versions.yaml
 
 # TODO what about caches?
 RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
+
+# Set empty machine-id
+# This prevents systemd from thinking that the machine is on first boot
+# and recreating /etc/ dependencies in services and such
+# do this before initramfs so its in the initramfs
+RUN echo "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \
@@ -204,7 +210,6 @@ RUN kernel=$(ls /boot/Image* 2>/dev/null | head -n1) && if [ -e "$kernel" ]; the
 # this is generally present on rhel based systems, but it doesn't hurt to remove in any case
 RUN rm -rf /boot/initramfs-* || true
 
-RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -450,6 +450,12 @@ RUN luet database get-all-installed --output /etc/kairos/versions.yaml
 
 # TODO what about caches?
 RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
+
+# Set empty machine-id
+# This prevents systemd from thinking that the machine is on first boot
+# and recreating /etc/ dependencies in services and such
+# do this before initramfs so its in the initramfs
+RUN echo "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \
@@ -470,7 +476,6 @@ RUN kernel=$(ls /boot/Image* 2>/dev/null | head -n1) && if [ -e "$kernel" ]; the
 # this is generally present on rhel based systems, but it doesn't hurt to remove in any case
 RUN rm -rf /boot/initramfs-* || true
 
-RUN rm /etc/machine-id || true
 RUN rm /var/lib/dbus/machine-id || true
 RUN rm /etc/hostname || true
 


### PR DESCRIPTION
We used to rely on a hidden feature of sysinfo that created a filled machine-id during initramfs so systemd did not trigger the first boot service.

Now on the newer agent versions, that hidden functionality has gone away so if we remove it teh file, systemd will think that this is a new system and will do some work behind our back initializing and break things around.

So we need to create en empty machine-id file so systemd knows that we dont want to run the first boot services/target

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kairos-io/kairos/issues/2773
