### PR TITLE
:wrench: Allow testing overlya files branches

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -281,6 +281,7 @@ base-image:
     COPY +git-version/GIT_VERSION VERSION
     ARG KAIROS_AGENT_DEV_BRANCH
     ARG IMMUCORE_DEV_BRANCH
+    ARG OVERLAY_FILES_DEV_BRANCH
 
     IF [ "$KAIROS_AGENT_DEV_BRANCH" != "" ]
         RUN rm -rf /usr/bin/kairos-agent
@@ -298,11 +299,24 @@ base-image:
         fi
     END
 
+    IF [ "$OVERLAY_FILES_DEV_BRANCH" != "" ]
+        COPY +overlay-files/files /
+    END
+
     ARG _CIMG=$(cat /IMAGE)
     SAVE IMAGE $_CIMG
     SAVE ARTIFACT /IMAGE AS LOCAL build/IMAGE
     SAVE ARTIFACT VERSION AS LOCAL build/VERSION
     SAVE ARTIFACT /etc/kairos/versions.yaml versions.yaml AS LOCAL build/versions.yaml
+
+# Dev target to extract overlay files from specific commit or branch for testing
+overlay-files:
+    ARG OVERLAY_FILES_DEV_BRANCH
+    WORKDIR /build
+    RUN apk --no-cache add git
+    RUN --no-cache git clone --branch $OVERLAY_FILES_DEV_BRANCH https://github.com/kairos-io/packages.git /build/
+    SAVE ARTIFACT /build/packages/static/kairos-overlay-files/files/ files
+
 
 image-rootfs:
     BUILD +base-image # Make sure the image is also saved locally


### PR DESCRIPTION
Instead of waiting for them to trickled down, we can easily test them and integrate them intot he rootfs.

This provides a OVERLAY_FILES_DEV_BRANCH argument that can be set to a branch or commit of the packages repo in order to test ongoing branches or single commits directly.

Currently does not remove the existing files so anything that removes files cannot be tested by this as we cant now in advance which files to delete, so it only works by overwriting the files or adding new ones.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
