### PR TITLE
:bug: Fix +base-image for Remote Execution

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -191,9 +191,13 @@ luet:
 ### Image Build targets
 ###
 
+kairos-dockerfile-context:
+    COPY --dir images/ .
+    SAVE ARTIFACT images
+
 kairos-dockerfile:
     ARG --required FAMILY
-    COPY ./images .
+    COPY +kairos-dockerfile-context/images .
     IF [ "$FAMILY" == "all" ]
         ARG FAMILY_LIST="alpine debian opensuse rhel ubuntu"
     ELSE
@@ -274,7 +278,7 @@ base-image:
       --build-arg FRAMEWORK_VERSION=$_FRAMEWORK_VERSION \
       --build-arg BOOTLOADER=$BOOTLOADER \
       -f +kairos-dockerfile/Dockerfile \
-      ./images
+      +kairos-dockerfile-context/images/*
 
     ARG _CIMG=$(cat ./IMAGE)
 


### PR DESCRIPTION
This does not work with remote execution today.  For example, if I made a new `Earthfile` in a different repository that contained this:
```yaml
kairos-image:
    BUILD github.com/kairos-io/kairos:3.1.1+base-image \
        --BASE_IMAGE=ubuntu:24.04 \
        --BOOTLOADER=grub \
        --FAMILY=ubuntu \
        --FLAVOR=ubuntu \
        --FLAVOR_RELEASE=24.04 \
        --MODEL=generic \
        --VARIANT=standard
```
It will fail to build with:
```
g/k/kairos:v3.1.1+base-image | resolve build context for dockerfile: read build file: open images/+kairos-dockerfile/Dockerfile: no such file or directory
Error: async earthfile2llb for github.com/kairos-io/kairos:v3.1.1+base-image: /tmp/earthly-git3649441421/Earthfile:263:4 from dockerfile: resolve build context for dockerfile: read build file: open images/+kairos-dockerfile/Dockerfile: no such file or directory
in              github.com/kairos-io/kairos:v3.1.1+base-image --BASE_IMAGE=ghcr.io/marinatedconcrete/ubuntu-24-lts:latest --BOOTLOADER=grub --FAMILY=ubuntu --FLAVOR=ubuntu --FLAVOR_RELEASE=24.04 --FRAMEWORK_VERSION= --K3S_VERSION= --MODEL=generic --RELEASE= --SOFTWARE_VERSION_PREFIX= --TARGETARCH= --VARIANT=standard --_FRAMEWORK_VERSION= --_SOFTWARE_LUET_VERSION=
```

This change fixes it by using a saved artifact instead of directly copying referencing the relative path.  This also aligns better with the Earthly docs: https://docs.earthly.dev/docs/earthfile#from-dockerfile