### PR TITLE
:book: Add alpine wifi cloud-config

### DIFF
--- a/examples/cloud-configs/wifi-alpine.yaml
+++ b/examples/cloud-configs/wifi-alpine.yaml
@@ -1,0 +1,26 @@
+#cloud-config
+
+hostname: metal-{{ trunc 4 .MachineID }}
+users:
+  - name: kairos
+    # Change to your pass here
+    passwd: kairos
+    ssh_authorized_keys:
+    # Replace with your github user and un-comment the line below:
+    # - github:mudler
+
+stages:
+  initramfs:
+    - name: Setup wireless
+      files:
+        # Generate manually by following https://wiki.archlinux.org/title/ConnMan and add contents below
+        - path: /var/lib/connman/wifi_xxxxxxxxxxxx_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz_managed_psk/settings
+          permissions: 0600
+          content: |
+            [wifi_xxxxxxxxxxxx_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz_managed_psk]
+            Name=Your_SSID
+            ...etc...
+  boot:
+    - name: Enable wireless
+      commands:
+        - connmanctl enable wifi


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

Adds a sample config for WiFi on alpine. Have noticed only Alpine & RPi openSUSE has wpa_supplicant - will update docs later in a separate PR and reference this config

I've never used connman before, so there could be a better way of doing this!
