### PR TITLE
:bug: Fix wifi cloud-config example

### DIFF
--- a/examples/cloud-configs/wifi.yaml
+++ b/examples/cloud-configs/wifi.yaml
@@ -11,18 +11,20 @@ users:
 
 stages:
   initramfs:
-    - path: /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
-      content: |
-        # This file should be generated using wpa_passphrase
-        ctrl_interface=/var/run/wpa_supplicant
-        ctrl_interface_group=admin
-        network={
-                ssid="$SSID_GOES_HERE"
-                psk=$PSK_GOES_HERE
-        }
-      permissions: 0600
-      owner: 0
-      group: 0
+    - name: "Setup wireless"
+      files:
+      - path: /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
+        content: |
+          # This file should be generated using wpa_passphrase
+          ctrl_interface=/var/run/wpa_supplicant
+          ctrl_interface_group=admin
+          network={
+                  ssid="$SSID_GOES_HERE"
+                  psk="$PSK_GOES_HERE"
+          }
+        permissions: 0600
+        owner: 0
+        group: 0
 
   boot:
     - name: "Enabling wireless"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

YAML structure was missing "files" so wasn't created. PSK must be quoted.

NB: I've not tested this as I don't have a Raspberry Pi to hand, but I have verified the PSK needs to be quoted and the file adding from my other PR to configure WiFi on alpine 
