### PR TITLE
Add permissions to generic arm release pipeline

### DIFF
--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -414,6 +414,21 @@ jobs:
 
   build-arm-generic:
     runs-on: ARM64
+    permissions:
+      id-token: write  # OIDC support
+      contents: write
+      security-events: write
+      actions: read
+      attestations: read
+      checks: read
+      deployments: read
+      discussions: read
+      issues: read
+      packages: read
+      pages: read
+      pull-requests: read
+      repository-projects: read
+      statuses: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
so we can release generic artifacts again
