### PR TITLE
Fix test printing old value for debugging

### DIFF
--- a/tests/provider_decentralized_test.go
+++ b/tests/provider_decentralized_test.go
@@ -56,7 +56,7 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 			Expect(err).ToNot(HaveOccurred())
 
 			out, _ := vm.Sudo("kairos-agent manual-install --device auto /tmp/config.yaml")
-			Expect(out).Should(ContainSubstring("Running after-install hook"), out)
+			Expect(out).Should(ContainSubstring("Running after-install hook"))
 			vm.Reboot()
 
 			By("waiting until it reboots to installed system")
@@ -146,13 +146,13 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 			Eventually(func() string {
 				out, _ = vm.Sudo("kairos get-kubeconfig")
 				return out
-			}, 1500*time.Second, 10*time.Second).Should(ContainSubstring("https:"), out)
+			}, 1500*time.Second, 10*time.Second).Should(ContainSubstring("https:"))
 
 			Eventually(func() string {
 				vm.Sudo("kairos get-kubeconfig > kubeconfig")
 				out, _ = vm.Sudo("KUBECONFIG=kubeconfig kubectl get nodes -o wide")
 				return out
-			}, 900*time.Second, 10*time.Second).Should(ContainSubstring("Ready"), out)
+			}, 900*time.Second, 10*time.Second).Should(ContainSubstring("Ready"))
 		})
 
 		vmForEach("checking roles", vms, func(vm VM) {
@@ -195,11 +195,11 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 
 					out, _ = vm.Sudo("dig +short foo.bar")
 					return strings.TrimSpace(out)
-				}, 900*time.Second, 10*time.Second).Should(Equal("2.2.2.2"), out)
+				}, 900*time.Second, 10*time.Second).Should(Equal("2.2.2.2"))
 				Eventually(func() string {
 					out, _ = vm.Sudo("dig +short google.com")
 					return strings.TrimSpace(out)
-				}, 900*time.Second, 10*time.Second).ShouldNot(BeEmpty(), out)
+				}, 900*time.Second, 10*time.Second).ShouldNot(BeEmpty())
 			}
 		})
 

--- a/tests/provider_upgrade_k8s_test.go
+++ b/tests/provider_upgrade_k8s_test.go
@@ -145,13 +145,13 @@ var _ = Describe("k3s upgrade test", Label("provider", "provider-upgrade-k8s"), 
 		Eventually(func() string {
 			out, _ = kubectl(vm, "get pods -A")
 			return out
-		}, 900*time.Second, 10*time.Second).Should(ContainSubstring("apply-os-upgrade-on-"), out)
+		}, 900*time.Second, 10*time.Second).Should(ContainSubstring("apply-os-upgrade-on-"))
 
 		By("wait for plan to finish")
 		Eventually(func() string {
 			out, _ = kubectl(vm, "get pods -A")
 			return out
-		}, 30*time.Minute, 10*time.Second).ShouldNot(ContainSubstring("ContainerCreating"), out)
+		}, 30*time.Minute, 10*time.Second).ShouldNot(ContainSubstring("ContainerCreating"))
 
 		By("validate upgraded version")
 		expectedVersion := getExpectedVersion()
@@ -160,7 +160,9 @@ var _ = Describe("k3s upgrade test", Label("provider", "provider-upgrade-k8s"), 
 			version, _ := vm.Sudo(getVersionCmd)
 			fmt.Printf("version = %+v\n", version)
 			return version
-		}, 30*time.Minute, 10*time.Second).Should(ContainSubstring(expectedVersion), out)
+		}, 30*time.Minute, 10*time.Second).Should(ContainSubstring(expectedVersion), func() string {
+			return out
+		})
 	})
 })
 

--- a/tests/provider_upgrade_latest_k8s_test.go
+++ b/tests/provider_upgrade_latest_k8s_test.go
@@ -160,12 +160,12 @@ var _ = Describe("k3s upgrade test from k8s", Label("provider", "provider-upgrad
 		Eventually(func() string {
 			out, _ = kubectl(vm, "apply -f suc.yaml")
 			return out
-		}, 900*time.Second, 10*time.Second).Should(ContainSubstring("created"), out)
+		}, 900*time.Second, 10*time.Second).Should(ContainSubstring("created"))
 
 		Eventually(func() string {
 			out, _ = kubectl(vm, "get pods -A")
 			return out
-		}, 900*time.Second, 10*time.Second).Should(ContainSubstring("apply-os-upgrade-on-"), out)
+		}, 900*time.Second, 10*time.Second).Should(ContainSubstring("apply-os-upgrade-on-"))
 
 		By("checking upgraded version")
 		Eventually(func() string {

--- a/tests/provider_upgrade_latest_k8s_test.go
+++ b/tests/provider_upgrade_latest_k8s_test.go
@@ -176,6 +176,13 @@ var _ = Describe("k3s upgrade test from k8s", Label("provider", "provider-upgrad
 				return currentVersion
 			}
 			return version
-		}, 50*time.Minute, 10*time.Second).ShouldNot(Equal(currentVersion), out)
+		}, 50*time.Minute, 10*time.Second).ShouldNot(Equal(currentVersion), func() string {
+			out, _ := kubectl(vm, "get pods -A")
+			if err != nil {
+				return fmt.Sprintf("errored while trying to get debug output: %s", err.Error())
+			} else {
+				return out
+			}
+		})
 	})
 })


### PR DESCRIPTION
ShouldNot(Equal(currentVersion), out) is a method call and as such, it received the value of `out` at the time of the call. That was not the updated value after the `Eventually` timeout had passed but rather the value from the previous call that populated it.
This made the test output very confusing because, even though the upgrade Pod was erroring out, the output shows the cluster being only some seconds old and the pod still being created (ouch!)

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
