### PR TITLE
:robot: Exit on CRITICAL vulnerabilities

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -777,9 +777,9 @@ trivy-scan:
     COPY +trivy/contrib /contrib
 
     WORKDIR /build
-    RUN /trivy filesystem --skip-dirs /tmp --timeout 30m --format sarif -o report.sarif --no-progress /
-    RUN /trivy filesystem --skip-dirs /tmp --timeout 30m --format template --template "@/contrib/html.tpl" -o report.html --no-progress /
-    RUN /trivy filesystem --skip-dirs /tmp --timeout 30m -f json -o results.json --no-progress /
+    RUN /trivy filesystem --skip-dirs /tmp --severity CRITICAL --exit-code 255 --timeout 30m --format sarif -o report.sarif --no-progress /
+    RUN /trivy filesystem --skip-dirs /tmp --severity CRITICAL --exit-code 255--timeout 30m --format template --template "@/contrib/html.tpl" -o report.html --no-progress /
+    RUN /trivy filesystem --skip-dirs /tmp --severity CRITICAL --exit-code 255 --timeout 30m -f json -o results.json --no-progress /
     SAVE ARTIFACT /build/report.sarif report.sarif AS LOCAL build/${ISO_NAME}-trivy.sarif
     SAVE ARTIFACT /build/report.html report.html AS LOCAL build/${ISO_NAME}-trivy.html
     SAVE ARTIFACT /build/results.json results.json AS LOCAL build/${ISO_NAME}-trivy.json
@@ -802,8 +802,8 @@ grype-scan:
     ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
     RUN mkdir build
-    RUN ./grype dir:. --output sarif --add-cpes-if-none --file /build/report.sarif
-    RUN ./grype dir:. --output json --add-cpes-if-none --file /build/report.json
+    RUN ./grype dir:. --fail-on CRITICAL --output sarif --add-cpes-if-none --file /build/report.sarif
+    RUN ./grype dir:. --fail-on CRITICAL --output json --add-cpes-if-none --file /build/report.json
     SAVE ARTIFACT /build/report.sarif report.sarif AS LOCAL build/${ISO_NAME}-grype.sarif
     SAVE ARTIFACT /build/report.json report.json AS LOCAL build/${ISO_NAME}-grype.json
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Fails the build process if we find critical vulnerabilities.
Not sure about this. Could block a release but do we want a release that has known critical vulns?

We could also add a switch the says that they can be ignored if there is not a fix yet but thats terrible IMHO because we would be releasing something that its indeed broken

This would fail builds on MASTER and RELEASE pipelines only, which makes sense to me. Between a PR and a master/release build there can be updates to packages and so on, so we dont have the control there and should not block a PR. But on release and master we can be informed about it and block a release or send and advisor or backport stuff/rebuild.