### PR TITLE
:robot: Allow testing provider dev versions

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -288,6 +288,7 @@ base-image:
     ARG KAIROS_AGENT_DEV_BRANCH
     ARG IMMUCORE_DEV_BRANCH
     ARG OVERLAY_FILES_DEV_BRANCH
+    ARG KAIROS_PROVIDER_DEV_BRANCH
 
     IF [ "$KAIROS_AGENT_DEV_BRANCH" != "" ]
         RUN rm -rf /usr/bin/kairos-agent
@@ -303,6 +304,11 @@ base-image:
           dracut -f "/boot/initrd-${kernel}" "${kernel}" && \
           ln -sf "initrd-${kernel}" /boot/initrd; \
         fi
+    END
+
+    IF [ "$KAIROS_PROVIDER_DEV_BRANCH" != "" ]
+        RUN rm -rf /system/providers/agent-provider-kairos
+        COPY github.com/kairos-io/provider-kairos:$KAIROS_PROVIDER_DEV_BRANCH+build-kairos-agent-provider/agent-provider-kairos /system/providers/agent-provider-kairos
     END
 
     IF [ "$OVERLAY_FILES_DEV_BRANCH" != "" ]


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Allows to set `KAIROS_PROVIDER_DEV_BRANCH` during earthly build to point at a provider branch or commit as part of the base image to test unreleased versions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
