### PR TITLE
:bug: Do not bindly install all tpm2 tools

### DIFF
--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -95,7 +95,7 @@ RUN  apt-get update \
     ubuntu-advantage-tools \
     xz-utils \
     zstd \
-    tpm2-* \
+    tpm2-tools \
     && apt-get remove -y unattended-upgrades && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install nohang

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -96,7 +96,7 @@ RUN  apt-get update \
     ubuntu-advantage-tools \
     xz-utils \
     zstd \
-    tpm2-* \
+    tpm2-tools \
     && apt-get remove -y unattended-upgrades && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install nohang


### PR DESCRIPTION
We were going a bit wide and installing everything under tpm2-* This brougth a userspace daemon for tpm2 which was failing to start in non-tpm enabled nodes, thus failing the systemd status and blocking boot

We added a workaround to time out the service but we should directly not have that daemon in there. All our tpm2 stuff uses the in kernel tpm calls as it needs to be really early so the daemon is useless in our workflows.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
