### PR TITLE
:Robot: Cache triby DB before running the build

### DIFF
--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -244,6 +244,12 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Cache trivy DB
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: earthly +trivy
       - name: Build  🔧
         run: |
           earthly -P +all-arm \
@@ -356,6 +362,12 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Cache trivy DB
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: earthly +trivy
       - name: Build  🔧
         run: |
           earthly -P +all-arm \
@@ -470,6 +482,12 @@ jobs:
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      - name: Cache trivy DB
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: earthly +trivy
       - name: Build iso  🔧
         run: |
           INIT=$([[ "${{ matrix.flavor }}" == "alpine" ]] && echo "openrc" || echo "systemd")

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -159,6 +159,12 @@ jobs:
         with:
           repository: quay.io/kairos/packages
           packages: utils/earthly
+      - name: Cache trivy DB
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: earthly +trivy
       - name: Build  🔧
         run: |
           earthly +all  \
@@ -405,6 +411,12 @@ jobs:
           packages: utils/earthly
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      - name: Cache trivy DB
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: earthly +trivy
       - name: Build  🔧
         run: |
           earthly +all  \

--- a/.github/workflows/reusable-build-flavor.yaml
+++ b/.github/workflows/reusable-build-flavor.yaml
@@ -121,6 +121,13 @@ jobs:
         with:
           repository: quay.io/kairos/packages
           packages: system/kairos-agent
+      - name: Cache trivy DB
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: earthly +trivy
       - name: Build master 🔧
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |

--- a/.github/workflows/reusable-build-provider.yaml
+++ b/.github/workflows/reusable-build-provider.yaml
@@ -110,6 +110,13 @@ jobs:
         with:
           repository: quay.io/kairos/packages
           packages: system/kairos-agent
+      - name: Cache trivy DB
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          command: earthly +trivy
       - name: Build master 🔧
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |

--- a/Earthfile
+++ b/Earthfile
@@ -770,7 +770,7 @@ trivy:
     FROM aquasec/trivy:$TRIVY_VERSION
     RUN /usr/local/bin/trivy fs --download-db-only
     SAVE ARTIFACT /contrib contrib
-    SAVE ARTIFACT /root cache
+    SAVE ARTIFACT /root/.cache cache
     SAVE ARTIFACT /usr/local/bin/trivy /trivy
 
 trivy-scan:

--- a/Earthfile
+++ b/Earthfile
@@ -768,7 +768,9 @@ datasource-iso:
 trivy:
     ARG TRIVY_VERSION
     FROM aquasec/trivy:$TRIVY_VERSION
+    RUN /usr/local/bin/trivy fs --download-db-only
     SAVE ARTIFACT /contrib contrib
+    SAVE ARTIFACT /root cache
     SAVE ARTIFACT /usr/local/bin/trivy /trivy
 
 trivy-scan:
@@ -781,6 +783,7 @@ trivy-scan:
 
     COPY +trivy/trivy /trivy
     COPY +trivy/contrib /contrib
+    COPY +trivy/cache /root/.cache
 
     WORKDIR /build
     RUN /trivy filesystem --skip-dirs /tmp --timeout 30m --format sarif -o report.sarif --no-progress /


### PR DESCRIPTION
If we hit a problem with the trivy download, we can make the step that downloads the database a retryable one so we dont stop the actual workflow

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
