### PR TITLE
Don't run both rngd and haveged

### DIFF
--- a/images/Dockerfile.alpine
+++ b/images/Dockerfile.alpine
@@ -86,7 +86,6 @@ RUN apk --no-cache add  \
       parted \
       qemu-guest-agent \
       rbd-nbd \
-      rng-tools \
       rsync \
       sgdisk \
       smartmontools \

--- a/images/Dockerfile.kairos-alpine
+++ b/images/Dockerfile.kairos-alpine
@@ -85,7 +85,6 @@ RUN apk --no-cache add  \
       parted \
       qemu-guest-agent \
       rbd-nbd \
-      rng-tools \
       rsync \
       sgdisk \
       smartmontools \

--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -1,4 +1,5 @@
 # This file is auto-generated with the command: earthly +kairos-dockerfile --FAMILY=opensuse
+
 ###############################################################
 ####                           ARGS                        ####
 ###############################################################
@@ -71,7 +72,6 @@ RUN zypper in --force-resolution -y \
     policycoreutils \
     polkit \
     procps \
-    rng-tools \
     rsync \
     shim \
     squashfs \

--- a/images/Dockerfile.opensuse
+++ b/images/Dockerfile.opensuse
@@ -1,4 +1,5 @@
 # WARNING: This is a base image used internally for Kairos, it is not meant to be built directly, use the images/Dockerfile.kairos-* files instead
+
 ###############################################################
 ####                           ARGS                        ####
 ###############################################################
@@ -72,7 +73,6 @@ RUN zypper in --force-resolution -y \
     policycoreutils \
     polkit \
     procps \
-    rng-tools \
     rsync \
     shim \
     squashfs \


### PR DESCRIPTION
because they clash. We keedp haveged only because we can't know if there is special rng hardware or not.

Fixes https://github.com/kairos-io/kairos/issues/2716


