### PR TITLE
:bug: Move kairos vars to their own file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,6 +9,7 @@ labels: bug, unconfirmed, triage
 
 **Kairos version:**
 <!-- Provide the output from "cat /etc/os-release" -->
+<!-- Provide the output from "cat /etc/kairos-release" -->
 
 **CPU architecture, OS, and Version:**
 <!-- Provide the output from "uname -a"  -->

--- a/.github/workflows/reusable-uki-test.yaml
+++ b/.github/workflows/reusable-uki-test.yaml
@@ -87,6 +87,7 @@ jobs:
           sudo luet util unpack "${TEMP_IMAGE}" ./unpacked
           new_version="mynewversion"
           sudo sed -i 's/^KAIROS_VERSION=.*/KAIROS_VERSION="'$new_version'"/' ./unpacked/etc/os-release
+          sudo sed -i 's/^KAIROS_VERSION=.*/KAIROS_VERSION="'$new_version'"/' ./unpacked/etc/kairos-release
           echo "$new_version" > "${PWD}/build/expected_new_version"
 
           docker run --rm \

--- a/Earthfile
+++ b/Earthfile
@@ -8,9 +8,9 @@ ARG TRIVY_VERSION=0.55.2
 # renovate: datasource=docker depName=anchore/grype versioning=semver
 ARG GRYPE_VERSION=v0.80.1
 # renovate: datasource=docker depName=quay.io/kairos/framework versioning=semver
-ARG KAIROS_FRAMEWORK_VERSION=v2.12.4
+ARG KAIROS_FRAMEWORK_VERSION=v2.13.0
 # renovate: datasource=docker depName=quay.io/kairos/osbuilder-tools versioning=semver
-ARG OSBUILDER_VERSION=v0.300.3
+ARG OSBUILDER_VERSION=v0.400.0
 # renovate: datasource=docker depName=golang versioning=semver
 ARG GO_VERSION=1.22
 # renovate: datasource=docker depName=hadolint/hadolint

--- a/Earthfile
+++ b/Earthfile
@@ -178,7 +178,7 @@ syft:
 image-sbom:
     FROM +base-image
     WORKDIR /build
-    ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+    ARG ISO_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
     COPY +syft/syft /usr/bin/syft
     RUN syft / -o json=sbom.syft.json -o spdx-json=sbom.spdx.json
@@ -502,7 +502,7 @@ uki-dev-iso:
     # We just use it here to take a shortcut to the artifact name
     FROM +base-image
     WORKDIR /build
-    ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+    ARG ISO_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
     COPY +git-version/GIT_VERSION ./
     ARG KAIROS_VERSION=$(cat GIT_VERSION)
@@ -556,7 +556,7 @@ uki-dev-iso:
 
 iso:
     FROM +base-image
-    ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+    ARG ISO_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
     ARG OSBUILDER_IMAGE
     FROM $OSBUILDER_IMAGE
@@ -581,7 +581,7 @@ iso:
 iso-remote:
     ARG --required REMOTE_IMG
     FROM $REMOTE_IMG
-    ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+    ARG ISO_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
     ARG OSBUILDER_IMAGE
     FROM $OSBUILDER_IMAGE
@@ -595,7 +595,7 @@ iso-remote:
 netboot:
     FROM +base-image
 
-    ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+    ARG ISO_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
     # Variables used here:
     # https://github.com/kairos-io/osbuilder/blob/66e9e7a9403a413e310f462136b70d715605ab09/tools-image/ipxe.tmpl#L5
@@ -625,7 +625,7 @@ arm-image:
   ARG IMG_COMPRESSION=xz
 
   FROM --platform=linux/arm64 +base-image
-  ARG IMAGE_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//').img
+  ARG IMAGE_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//').img
 
   FROM $OSBUILDER_IMAGE
   ARG --required MODEL
@@ -694,7 +694,7 @@ ipxe-iso:
     ARG ENABLE_HTTPS
 
     FROM +base-image
-    ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+    ARG ISO_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
     # Variables used here:
     # https://github.com/kairos-io/osbuilder/blob/66e9e7a9403a413e310f462136b70d715605ab09/tools-image/ipxe.tmpl#L5
@@ -738,7 +738,7 @@ raw-image:
     # We just use it here to take a shortcut to the artifact name
     FROM +base-image
     WORKDIR /build
-    ARG IMG_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//').raw
+    ARG IMG_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//').raw
 
     ARG OSBUILDER_IMAGE
     FROM $OSBUILDER_IMAGE
@@ -777,7 +777,7 @@ trivy-scan:
     # Use base-image so it can read original os-release file
     FROM +base-image
 
-    ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+    ARG ISO_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
     COPY +trivy/trivy /trivy
     COPY +trivy/contrib /contrib
@@ -805,7 +805,7 @@ grype-scan:
 
     COPY +grype/grype grype
 
-    ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+    ARG ISO_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
     RUN mkdir build
     RUN ./grype dir:. --output sarif --add-cpes-if-none --file /build/report.sarif
@@ -855,7 +855,7 @@ run-qemu-datasource-tests:
 
 run-qemu-netboot-test:
     FROM +base-image
-    ARG ISO_NAME=$(cat /etc/os-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+    ARG ISO_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
 
     COPY +git-version/GIT_VERSION GIT_VERSION
     ARG VERSION=$(cat ./GIT_VERSION)

--- a/images/Dockerfile.kairos
+++ b/images/Dockerfile.kairos
@@ -14,7 +14,6 @@ RUN rm -rf /etc/ssh/ssh_host_*
 
 COPY which-init.sh /usr/local/bin/which-init.sh
 
-RUN sed -i -n '/KAIROS_/!p' /etc/os-release
 RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
@@ -74,7 +73,6 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-RUN kairos-agent versioneer os-release-variables >> /etc/os-release
 RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 

--- a/images/Dockerfile.kairos
+++ b/images/Dockerfile.kairos
@@ -15,7 +15,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
-RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
+RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"

--- a/images/Dockerfile.kairos
+++ b/images/Dockerfile.kairos
@@ -15,6 +15,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
+RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"
@@ -73,11 +74,8 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-# not duplicated but used to see the error
-RUN kairos-agent versioneer os-release-variables
 RUN kairos-agent versioneer os-release-variables >> /etc/os-release
-# not duplicated but used to see the error
-RUN kairos-agent versioneer container-artifact-name
+RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/images/Dockerfile.kairos-alpine
+++ b/images/Dockerfile.kairos-alpine
@@ -165,6 +165,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
+RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"
@@ -223,11 +224,8 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-# not duplicated but used to see the error
-RUN kairos-agent versioneer os-release-variables
 RUN kairos-agent versioneer os-release-variables >> /etc/os-release
-# not duplicated but used to see the error
-RUN kairos-agent versioneer container-artifact-name
+RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/images/Dockerfile.kairos-alpine
+++ b/images/Dockerfile.kairos-alpine
@@ -164,7 +164,6 @@ RUN rm -rf /etc/ssh/ssh_host_*
 
 COPY which-init.sh /usr/local/bin/which-init.sh
 
-RUN sed -i -n '/KAIROS_/!p' /etc/os-release
 RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
@@ -224,7 +223,6 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-RUN kairos-agent versioneer os-release-variables >> /etc/os-release
 RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 

--- a/images/Dockerfile.kairos-alpine
+++ b/images/Dockerfile.kairos-alpine
@@ -165,7 +165,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
-RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
+RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"

--- a/images/Dockerfile.kairos-debian
+++ b/images/Dockerfile.kairos-debian
@@ -178,7 +178,6 @@ RUN rm -rf /etc/ssh/ssh_host_*
 
 COPY which-init.sh /usr/local/bin/which-init.sh
 
-RUN sed -i -n '/KAIROS_/!p' /etc/os-release
 RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
@@ -238,7 +237,6 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-RUN kairos-agent versioneer os-release-variables >> /etc/os-release
 RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 

--- a/images/Dockerfile.kairos-debian
+++ b/images/Dockerfile.kairos-debian
@@ -179,7 +179,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
-RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
+RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"

--- a/images/Dockerfile.kairos-debian
+++ b/images/Dockerfile.kairos-debian
@@ -179,6 +179,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
+RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"
@@ -237,11 +238,8 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-# not duplicated but used to see the error
-RUN kairos-agent versioneer os-release-variables
 RUN kairos-agent versioneer os-release-variables >> /etc/os-release
-# not duplicated but used to see the error
-RUN kairos-agent versioneer container-artifact-name
+RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -175,7 +175,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
-RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
+RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"

--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -174,7 +174,6 @@ RUN rm -rf /etc/ssh/ssh_host_*
 
 COPY which-init.sh /usr/local/bin/which-init.sh
 
-RUN sed -i -n '/KAIROS_/!p' /etc/os-release
 RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
@@ -234,7 +233,6 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-RUN kairos-agent versioneer os-release-variables >> /etc/os-release
 RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 

--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -175,6 +175,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
+RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"
@@ -233,11 +234,8 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-# not duplicated but used to see the error
-RUN kairos-agent versioneer os-release-variables
 RUN kairos-agent versioneer os-release-variables >> /etc/os-release
-# not duplicated but used to see the error
-RUN kairos-agent versioneer container-artifact-name
+RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/images/Dockerfile.kairos-rhel
+++ b/images/Dockerfile.kairos-rhel
@@ -114,7 +114,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
-RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
+RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"

--- a/images/Dockerfile.kairos-rhel
+++ b/images/Dockerfile.kairos-rhel
@@ -113,7 +113,6 @@ RUN rm -rf /etc/ssh/ssh_host_*
 
 COPY which-init.sh /usr/local/bin/which-init.sh
 
-RUN sed -i -n '/KAIROS_/!p' /etc/os-release
 RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
@@ -173,7 +172,6 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-RUN kairos-agent versioneer os-release-variables >> /etc/os-release
 RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 

--- a/images/Dockerfile.kairos-rhel
+++ b/images/Dockerfile.kairos-rhel
@@ -114,6 +114,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
+RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"
@@ -172,11 +173,8 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-# not duplicated but used to see the error
-RUN kairos-agent versioneer os-release-variables
 RUN kairos-agent versioneer os-release-variables >> /etc/os-release
-# not duplicated but used to see the error
-RUN kairos-agent versioneer container-artifact-name
+RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -380,7 +380,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
-RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
+RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -379,7 +379,6 @@ RUN rm -rf /etc/ssh/ssh_host_*
 
 COPY which-init.sh /usr/local/bin/which-init.sh
 
-RUN sed -i -n '/KAIROS_/!p' /etc/os-release
 RUN if [ -f "/etc/kairos-release" ]; then sed -i -n '/KAIROS_/!p' /etc/kairos-release; fi
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
@@ -439,7 +438,6 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-RUN kairos-agent versioneer os-release-variables >> /etc/os-release
 RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -380,6 +380,7 @@ RUN rm -rf /etc/ssh/ssh_host_*
 COPY which-init.sh /usr/local/bin/which-init.sh
 
 RUN sed -i -n '/KAIROS_/!p' /etc/os-release
+RUN sed -i -n '/KAIROS_/!p' /etc/kairos-release
 
 # need to be defined after FROM for them to be replaced in the RUN bellow
 ARG HOME_URL="https://github.com/kairos-io/kairos"
@@ -438,11 +439,8 @@ LABEL io.kairos.software-version="${SOFTWARE_VERSION}"
 LABEL io.kairos.software-version-prefix="${SOFTWARE_VERSION_PREFIX}"
 LABEL io.kairos.targetarch="${TARGETARCH}"
 
-# not duplicated but used to see the error
-RUN kairos-agent versioneer os-release-variables
 RUN kairos-agent versioneer os-release-variables >> /etc/os-release
-# not duplicated but used to see the error
-RUN kairos-agent versioneer container-artifact-name
+RUN kairos-agent versioneer os-release-variables > /etc/kairos-release
 RUN kairos-agent versioneer container-artifact-name > /IMAGE
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -64,8 +64,8 @@ var _ = Describe("kairos bundles test", Label("bundles-test"), func() {
 				}, 3*time.Minute, 10*time.Second).Should(ContainSubstring("kubo"), func() string {
 					// Debug output in case of an error
 					result := ""
-					out, _ := vm.Sudo("cat /etc/os-release")
-					result = result + fmt.Sprintf("os-release:\n%s\n", out)
+					out, _ := vm.Sudo("cat /etc/kairos-release")
+					result = result + fmt.Sprintf("kairos-release:\n%s\n", out)
 
 					out, _ = vm.Sudo("cat /oem/90_custom.yaml")
 					result = result + fmt.Sprintf("90_custom.yaml:\n%s\n", out)

--- a/tests/provider_decentralized_test.go
+++ b/tests/provider_decentralized_test.go
@@ -204,7 +204,7 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 		})
 
 		vmForEach("checking if it upgrades to a specific version", vms, func(vm VM) {
-			version, err := vm.Sudo("source /etc/os-release; echo $VERSION")
+			version, err := vm.Sudo(getVersionCmd)
 			Expect(err).ToNot(HaveOccurred(), version)
 
 			out, err := vm.Sudo("kairos-agent upgrade --image quay.io/kairos/kairos-opensuse:v1.0.0-rc2-k3sv1.21.14-k3s1")

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -29,7 +29,7 @@ func TestSuite(t *testing.T) {
 	RunSpecs(t, "kairos Test Suite")
 }
 
-var getVersionCmd = ". /etc/kairos-release; [ ! -z \"$KAIROS_VERSION\" ] && echo $KAIROS_VERSION || echo $VERSION"
+var getVersionCmd = ". /etc/kairos-release; [ ! -z \"$KAIROS_VERSION\" ] && echo $KAIROS_VERSION"
 
 // https://gist.github.com/sevkin/96bdae9274465b2d09191384f86ef39d
 // GetFreePort asks the kernel for a free open port that is ready to use.

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -29,7 +29,7 @@ func TestSuite(t *testing.T) {
 	RunSpecs(t, "kairos Test Suite")
 }
 
-var getVersionCmd = ". /etc/os-release; [ ! -z \"$KAIROS_VERSION\" ] && echo $KAIROS_VERSION || echo $VERSION"
+var getVersionCmd = ". /etc/kairos-release; [ ! -z \"$KAIROS_VERSION\" ] && echo $KAIROS_VERSION || echo $VERSION"
 
 // https://gist.github.com/sevkin/96bdae9274465b2d09191384f86ef39d
 // GetFreePort asks the kernel for a free open port that is ready to use.

--- a/tests/uki_test.go
+++ b/tests/uki_test.go
@@ -280,7 +280,7 @@ var _ = Describe("kairos UKI test", Label("uki"), Ordered, func() {
 		vm.EventuallyConnects(1200)
 
 		By("checking if upgrade worked")
-		out, err = vm.Sudo("cat /etc/os-release")
+		out, err = vm.Sudo("cat /etc/kairos-release")
 		Expect(err).ToNot(HaveOccurred(), out)
 		Expect(out).To(MatchRegexp(fmt.Sprintf("KAIROS_VERSION=\"?%s\"?", os.Getenv("EXPECTED_NEW_VERSION"))))
 

--- a/tests/upgrade_latest_cli_test.go
+++ b/tests/upgrade_latest_cli_test.go
@@ -53,8 +53,15 @@ var _ = Describe("k3s upgrade manual test", Label("upgrade-latest-with-cli"), fu
 		})
 
 		It("can upgrade to current image", func() {
+			var currentVersion string
 			currentVersion, err := vm.Sudo(getVersionCmd)
-			Expect(err).ToNot(HaveOccurred())
+			// Upgrade test uses old version the upgrades to newer so test needs to get the version from os-release for now as
+			// fallback
+			if err != nil {
+				currentVersion, err = vm.Sudo(". /etc/os-release; [ ! -z \"$KAIROS_VERSION\" ] && echo $KAIROS_VERSION || echo $VERSION")
+				Expect(err).ToNot(HaveOccurred())
+			}
+
 			By(fmt.Sprintf("Checking current version: %s", currentVersion))
 			Expect(currentVersion).To(ContainSubstring("v"))
 

--- a/tests/upgrade_latest_cli_test.go
+++ b/tests/upgrade_latest_cli_test.go
@@ -57,8 +57,8 @@ var _ = Describe("k3s upgrade manual test", Label("upgrade-latest-with-cli"), fu
 			currentVersion, err := vm.Sudo(getVersionCmd)
 			// Upgrade test uses old version the upgrades to newer so test needs to get the version from os-release for now as
 			// fallback
-			if err != nil {
-				currentVersion, err = vm.Sudo(". /etc/os-release; [ ! -z \"$KAIROS_VERSION\" ] && echo $KAIROS_VERSION || echo $VERSION")
+			if err != nil || currentVersion == "" {
+				currentVersion, err = vm.Sudo(". /etc/os-release; [ ! -z \"$KAIROS_VERSION\" ] && echo $KAIROS_VERSION")
 				Expect(err).ToNot(HaveOccurred())
 			}
 


### PR DESCRIPTION
Otherwise when creating derivatives, the upgrades can overwrite the existing kairos release info adn break the whole thing.

This patch adds the variables into a new /]etc/kairos-release file, as well as keeping them in the usual /etc/os-release file for backwards compatibility

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


Part of: https://github.com/kairos-io/kairos/issues/2907
