### PR TITLE
Install arm64 earthly

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -57,6 +57,7 @@ jobs:
     uses: ./.github/workflows/reusable-build-flavor.yaml
     needs:
       - trivy-cache
+      - get-core-matrix
     permissions:
       id-token: write  # OIDC support
       contents: write
@@ -81,8 +82,6 @@ jobs:
       model: ${{ matrix.model }}
       variant: ${{ matrix.variant }}
       arch: ${{ matrix.arch }}
-    needs:
-      - get-core-matrix
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.get-core-matrix.outputs.matrix)}}

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -107,48 +107,8 @@ jobs:
       - name: Install kairos-agent (for versioneer)
         uses: Luet-lab/luet-install-action@cec77490c3f2416d7d07a47cfab04d448641d7ce # v1.1
         with:
-          repository: quay.io/kairos/packages
+          repository: quay.io/kairos/packages-arm64
           packages: system/kairos-agent
-      - name: Release space from worker
-        run: |
-          echo "Listing top largest packages"
-          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
-          head -n 30 <<< "${pkgs}"
-          echo
-          df -h
-          echo
-          sudo apt-get remove -y '^llvm-.*|^libllvm.*' || true
-          sudo apt-get remove --auto-remove android-sdk-platform-tools || true
-          sudo apt-get purge --auto-remove android-sdk-platform-tools || true
-          sudo rm -rf /usr/local/lib/android
-          sudo apt-get remove -y '^dotnet-.*|^aspnetcore-.*' || true
-          sudo rm -rf /usr/share/dotnet
-          sudo apt-get remove -y '^mono-.*' || true
-          sudo apt-get remove -y '^ghc-.*' || true
-          sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
-          sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm || true
-          sudo apt-get remove -y powershell || true
-          sudo apt-get remove -y firefox || true
-          sudo apt-get remove -y monodoc-manual || true
-          sudo apt-get remove -y msbuild || true
-          sudo apt-get remove -y microsoft-edge-stable || true
-          sudo apt-get remove -y '^google-.*' || true
-          sudo apt-get remove -y azure-cli || true
-          sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
-          sudo apt-get remove -y '^gfortran-.*' || true
-          sudo apt-get remove -y '^gcc-*' || true
-          sudo apt-get remove -y '^g++-*' || true
-          sudo apt-get remove -y '^cpp-*' || true
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-          echo
-          echo "Listing top largest packages"
-          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
-          head -n 30 <<< "${pkgs}"
-          echo
-          sudo rm -rfv build || true
-          df -h
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
@@ -163,7 +123,6 @@ jobs:
           export IMAGE=quay.io/kairos/cache:nvidia-base
           docker build --platform=linux/arm64 -t $IMAGE -f ./images/Dockerfile.nvidia ./images
           docker push $IMAGE
-
   nvidia-arm-core:
     uses: ./.github/workflows/reusable-docker-arm-build.yaml
     permissions:
@@ -190,7 +149,6 @@ jobs:
       base_image: quay.io/kairos/cache:nvidia-base
       model: nvidia-jetson-agx-orin
       worker: ARM64
-
   build-arm-core:
     runs-on: ${{ matrix.worker }}
     needs:
@@ -205,47 +163,6 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.get-core-matrix.outputs.matrix)}}
     steps:
-      - name: Release space from worker
-        if: ${{ matrix.worker != 'kvm' }}
-        run: |
-          echo "Listing top largest packages"
-          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
-          head -n 30 <<< "${pkgs}"
-          echo
-          df -h
-          echo
-          sudo apt-get remove -y '^llvm-.*|^libllvm.*' || true
-          sudo apt-get remove --auto-remove android-sdk-platform-tools || true
-          sudo apt-get purge --auto-remove android-sdk-platform-tools || true
-          sudo rm -rf /usr/local/lib/android
-          sudo apt-get remove -y '^dotnet-.*|^aspnetcore-.*' || true
-          sudo rm -rf /usr/share/dotnet
-          sudo apt-get remove -y '^mono-.*' || true
-          sudo apt-get remove -y '^ghc-.*' || true
-          sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
-          sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm || true
-          sudo apt-get remove -y powershell || true
-          sudo apt-get remove -y firefox || true
-          sudo apt-get remove -y monodoc-manual || true
-          sudo apt-get remove -y msbuild || true
-          sudo apt-get remove -y microsoft-edge-stable || true
-          sudo apt-get remove -y '^google-.*' || true
-          sudo apt-get remove -y azure-cli || true
-          sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
-          sudo apt-get remove -y '^gfortran-.*' || true
-          sudo apt-get remove -y '^gcc-*' || true
-          sudo apt-get remove -y '^g++-*' || true
-          sudo apt-get remove -y '^cpp-*' || true
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-          echo
-          echo "Listing top largest packages"
-          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
-          head -n 30 <<< "${pkgs}"
-          echo
-          sudo rm -rfv build || true
-          df -h
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 0
@@ -258,7 +175,7 @@ jobs:
       - name: Install earthly
         uses: Luet-lab/luet-install-action@cec77490c3f2416d7d07a47cfab04d448641d7ce # v1.1
         with:
-          repository: quay.io/kairos/packages
+          repository: quay.io/kairos/packages-arm64
           packages: utils/earthly
       - name: Set up Docker Buildx
         id: buildx
@@ -365,16 +282,12 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
       - name: Install earthly
         uses: Luet-lab/luet-install-action@cec77490c3f2416d7d07a47cfab04d448641d7ce # v1.1
         with:
-          repository: quay.io/kairos/packages
+          repository: quay.io/kairos/packages-arm64
           packages: utils/earthly
       - name: Set up Docker Buildx
         id: buildx
@@ -382,9 +295,6 @@ jobs:
       - name: size of docker images
         run: |
           docker images --format "{{.Size}} - {{.Repository}}:{{.Tag}}"
-      - name: Available space
-        run: |
-          df -h
       - name: Login to DockerHub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:
@@ -503,12 +413,8 @@ jobs:
       - name: Install earthly
         uses: Luet-lab/luet-install-action@cec77490c3f2416d7d07a47cfab04d448641d7ce # v1.1
         with:
-          repository: quay.io/kairos/packages
+          repository: quay.io/kairos/packages-arm64
           packages: utils/earthly
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3

--- a/.github/workflows/reusable-docker-arm-build.yaml
+++ b/.github/workflows/reusable-docker-arm-build.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Install earthly
         uses: Luet-lab/luet-install-action@cec77490c3f2416d7d07a47cfab04d448641d7ce # v1.1
         with:
-          repository: quay.io/kairos/packages
+          repository: quay.io/kairos/packages-arm64 # change to quay.io/kairos/packages if running this on non-native amd64 workers
           packages: utils/earthly
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/reusable-docker-arm-build.yaml
+++ b/.github/workflows/reusable-docker-arm-build.yaml
@@ -36,47 +36,6 @@ jobs:
       actions: read
       security-events: write
     steps:
-      - name: Release space from worker
-        if: ${{ inputs.worker != 'fast' }}
-        run: |
-          echo "Listing top largest packages"
-          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
-          head -n 30 <<< "${pkgs}"
-          echo
-          df -h
-          echo
-          sudo apt-get remove -y '^llvm-.*|^libllvm.*' || true
-          sudo apt-get remove --auto-remove android-sdk-platform-tools || true
-          sudo apt-get purge --auto-remove android-sdk-platform-tools || true
-          sudo rm -rf /usr/local/lib/android
-          sudo apt-get remove -y '^dotnet-.*|^aspnetcore-.*' || true
-          sudo rm -rf /usr/share/dotnet
-          sudo apt-get remove -y '^mono-.*' || true
-          sudo apt-get remove -y '^ghc-.*' || true
-          sudo apt-get remove -y '.*jdk.*|.*jre.*' || true
-          sudo apt-get remove -y 'php.*' || true
-          sudo apt-get remove -y hhvm || true
-          sudo apt-get remove -y powershell || true
-          sudo apt-get remove -y firefox || true
-          sudo apt-get remove -y monodoc-manual || true
-          sudo apt-get remove -y msbuild || true
-          sudo apt-get remove -y microsoft-edge-stable || true
-          sudo apt-get remove -y '^google-.*' || true
-          sudo apt-get remove -y azure-cli || true
-          sudo apt-get remove -y '^mongo.*-.*|^postgresql-.*|^mysql-.*|^mssql-.*' || true
-          sudo apt-get remove -y '^gfortran-.*' || true
-          sudo apt-get remove -y '^gcc-*' || true
-          sudo apt-get remove -y '^g++-*' || true
-          sudo apt-get remove -y '^cpp-*' || true
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-          echo
-          echo "Listing top largest packages"
-          pkgs=$(dpkg-query -Wf '${Installed-Size}\t${Package}\t${Status}\n' | awk '$NF == "installed"{print $1 "\t" $2}' | sort -nr)
-          head -n 30 <<< "${pkgs}"
-          echo
-          sudo rm -rfv build || true
-          df -h
       - name: Block all traffic to metadata ip  # For cloud runners, the metadata ip can interact with our test machines
         run: |
           sudo iptables -I INPUT -s 169.254.169.254 -j DROP
@@ -84,10 +43,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
       - name: Install earthly
@@ -152,8 +107,8 @@ jobs:
               --IMG_COMPRESSION=${{env.IMG_COMPRESSION}}
       - name: Show img sizes
         run: |
-          ls -ltra build
           ls -ltrh build
+          uname -a
       - name: Convert all json files into a reports.tar.gz file
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -163,7 +118,7 @@ jobs:
       - name: Install kairos-agent (for versioneer)
         uses: Luet-lab/luet-install-action@cec77490c3f2416d7d07a47cfab04d448641d7ce # v1.1
         with:
-          repository: quay.io/kairos/packages
+          repository: quay.io/kairos/packages-arm64
           packages: system/kairos-agent
       - name: Set Image name (master)
         if: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
Install arm64 earthly build in arm64 jobs (run under arm64 arch) and removes the uneeded space free step and the qemu install as we dont need any in our workers.

Cancelled all jobs but the arm ones as those are the ones affected by this