### PR TITLE
Run trivy-cache job on ARM64 worker

### DIFF
--- a/.github/workflows/image-arm-pr.yaml
+++ b/.github/workflows/image-arm-pr.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   # Populate the trivy cache once for all later jobs to use
   trivy-cache:
-    runs-on: ubuntu-latest
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:

--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -83,7 +83,7 @@ jobs:
 
   # Populate the trivy cache once for all later jobs to use
   trivy-cache:
-    runs-on: ubuntu-latest
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -79,7 +79,7 @@ jobs:
 
   # Populate the trivy cache once for all later jobs to use
   trivy-cache:
-    runs-on: ubuntu-latest
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:


### PR DESCRIPTION
because we suspect this is the reason why later jobs that run on those workers don't find the cache.

Might be related to:
https://github.com/actions/cache/blob/main/tips-and-workarounds.md#cross-os-cache

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
