### PR TITLE
Add systemd boot standard image to the build matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
         sudo apt update && sudo apt install -y jq
     - id: set-matrix
       run: |
-          content=`cat ./.github/flavors.json | jq -r 'map(select(.arch == "amd64" and .variant == "core" and (.flavor == "fedora" or (.flavor == "ubuntu" and (.flavorRelease == "24.04")))))'`
+          content=`cat ./.github/flavors.json | jq -r 'map(select(.arch == "amd64" and (.flavor == "fedora" or (.flavor == "ubuntu" and (.flavorRelease == "24.04")))))'`
           # the following lines are only required for multi line json
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"
@@ -253,7 +253,7 @@ jobs:
         with:
           sarif_file: 'grype-sarif'
           category: ${{ matrix.flavor }}-grype
-  build-core-uki:
+  build-uki-container-image:
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # OIDC support


### PR DESCRIPTION
to make it easier to build UKI artifacts from it

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
