### PR TITLE
Add ubuntu 24.10 flavor

### DIFF
--- a/.github/flavors.json
+++ b/.github/flavors.json
@@ -250,6 +250,46 @@
         "worker": "ARM64"
     },
     {
+        "family": "ubuntu",
+        "flavor": "ubuntu",
+        "flavorRelease": "24.10",
+        "variant": "core",
+        "model": "generic",
+        "baseImage": "ubuntu:24.10",
+        "arch": "arm64",
+        "worker": "ARM64"
+    },
+    {
+        "family": "ubuntu",
+        "flavor": "ubuntu",
+        "flavorRelease": "24.10",
+        "variant": "standard",
+        "model": "generic",
+        "baseImage": "ubuntu:24.04",
+        "arch": "amd64",
+        "worker": "self-hosted"
+    },
+    {
+        "family": "ubuntu",
+        "flavor": "ubuntu",
+        "flavorRelease": "24.10",
+        "variant": "core",
+        "model": "generic",
+        "baseImage": "ubuntu:24.10",
+        "arch": "amd64",
+        "worker": "self-hosted"
+    },
+    {
+        "family": "ubuntu",
+        "flavor": "ubuntu",
+        "flavorRelease": "24.04",
+        "variant": "core",
+        "model": "generic",
+        "baseImage": "ubuntu:24.10",
+        "arch": "arm64",
+        "worker": "ARM64"
+    },
+    {
         "family": "alpine",
         "flavor": "alpine",
         "flavorRelease": "3.19",

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -90,6 +90,35 @@ jobs:
       variant: core
       arch: amd64
 
+  core-ubuntu-24-10:
+    uses: ./.github/workflows/reusable-build-flavor.yaml
+    secrets: inherit
+    needs:
+      - trivy-cache
+    permissions:
+      contents: write
+      security-events: write
+      id-token: write
+      actions: read
+      attestations: read
+      checks: read
+      deployments: read
+      discussions: read
+      issues: read
+      packages: read
+      pages: read
+      pull-requests: read
+      repository-projects: read
+      statuses: read
+    with:
+      flavor: ubuntu
+      flavor_release: "24.10"
+      family: ubuntu
+      base_image: ubuntu:24.10
+      model: generic
+      variant: core
+      arch: amd64
+
   core-alpine:
     uses: ./.github/workflows/reusable-build-flavor.yaml
     secrets: inherit

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -21,6 +21,10 @@ jobs:
             flavor_release: 24.04
             family: ubuntu
             base_image: ubuntu:24.04
+          - flavor: ubuntu
+            flavor_release: 24.10
+            family: ubuntu
+            base_image: ubuntu:24.10
           - flavor: fedora
             family: rhel
             flavor_release: 40

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -7,9 +7,10 @@ ARG FAMILY=ubuntu
 # Currently supported flavors are:
 #   - ubuntu
 ARG FLAVOR
-#   - 20.04
-#   - 22.04
+#   - 24.10
 #   - 24.04
+#   - 22.04
+#   - 20.04
 ARG FLAVOR_RELEASE
 # Currently supported models are:
 #   - generic
@@ -25,11 +26,10 @@ ARG BOOTLOADER=grub
 ###############################################################
 ####                     Upstream Images                   ####
 ###############################################################
-FROM ${BASE_IMAGE} AS ubuntu-20.04-upstream
-
-FROM ${BASE_IMAGE} AS ubuntu-22.04-upstream
-
+FROM ${BASE_IMAGE} AS ubuntu-24.10-upstream
 FROM ${BASE_IMAGE} AS ubuntu-24.04-upstream
+FROM ${BASE_IMAGE} AS ubuntu-22.04-upstream
+FROM ${BASE_IMAGE} AS ubuntu-20.04-upstream
 
 ###############################################################
 ####                build nohang from source               ####
@@ -155,7 +155,9 @@ RUN [ -z "$(ls -A /lib/firmware/intel-ucode/)" ] && apt-get update && apt-get in
 
 FROM systemd-boot AS systemd-boot-arm64
 
+FROM systemd-boot-amd64 AS systemd-boot-amd64-24.10
 FROM systemd-boot-amd64 AS systemd-boot-amd64-24.04
+FROM systemd-boot-arm64 AS systemd-boot-arm64-24.10
 FROM systemd-boot-arm64 AS systemd-boot-arm64-24.04
 
 FROM grub AS grub-amd64
@@ -188,9 +190,11 @@ FROM grub-current AS grub-arm64-current
 FROM grub-legacy AS grub-amd64-legacy
 FROM grub-legacy AS grub-arm64-legacy
 
+FROM grub-current AS grub-amd64-24.10
 FROM grub-current AS grub-amd64-24.04
 FROM grub-current AS grub-amd64-22.04
 FROM grub-legacy AS grub-amd64-20.04
+FROM grub-current AS grub-arm64-24.10
 FROM grub-current AS grub-arm64-24.04
 FROM grub-current AS grub-arm64-22.04
 FROM grub-legacy AS grub-arm64-20.04
@@ -241,13 +245,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     polkitd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM base-ubuntu-current AS kernel-ubuntu-24.04
+FROM base-ubuntu-current AS kernel-ubuntu-current
 RUN apt-get update
 # If a kernel is already installed, don't try to install it again, this way the base image can
 # be non-hwe for older releases
 RUN [ -z "$(ls -A /boot/vmlinuz*)" ] && apt-get install -y --no-install-recommends \
     linux-image-generic-hwe-24.04 || true
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+FROM kernel-ubuntu-current AS kernel-ubuntu-24.10
+FROM kernel-ubuntu-current AS kernel-ubuntu-24.04
 
 FROM base-ubuntu-current AS kernel-ubuntu-22.04
 RUN apt-get update
@@ -265,13 +272,15 @@ RUN [ -z "$(ls -A /boot/vmlinuz*)" ] && apt-get install -y --no-install-recommen
     linux-image-generic-hwe-20.04 || true
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM kernel-ubuntu-20.04 AS amd64-ubuntu-20.04
-FROM kernel-ubuntu-22.04 AS amd64-ubuntu-22.04
+FROM kernel-ubuntu-24.10 AS amd64-ubuntu-24.10
 FROM kernel-ubuntu-24.04 AS amd64-ubuntu-24.04
+FROM kernel-ubuntu-22.04 AS amd64-ubuntu-22.04
+FROM kernel-ubuntu-20.04 AS amd64-ubuntu-20.04
 
-FROM kernel-ubuntu-20.04 AS arm64-ubuntu-20.04
-FROM kernel-ubuntu-22.04 AS arm64-ubuntu-22.04
+FROM kernel-ubuntu-24.10 AS arm64-ubuntu-24.10
 FROM kernel-ubuntu-24.04 AS arm64-ubuntu-24.04
+FROM kernel-ubuntu-22.04 AS arm64-ubuntu-22.04
+FROM kernel-ubuntu-20.04 AS arm64-ubuntu-20.04
 
 ###############################################################
 ####               Common to a Single Model                ####
@@ -299,10 +308,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-modules-extra-raspi \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+FROM generic AS amd64-ubuntu-24.10-generic
 FROM generic AS amd64-ubuntu-24.04-generic
 FROM generic AS amd64-ubuntu-22.04-generic
 FROM generic AS amd64-ubuntu-20.04-generic
 
+FROM generic AS arm64-ubuntu-24.10-generic
 FROM generic AS arm64-ubuntu-24.04-generic
 FROM ubuntu-22.04-rpi AS arm64-ubuntu-24.04-rpi4
 FROM ubuntu-22.04-rpi AS arm64-ubuntu-22.04-rpi3
@@ -314,7 +325,6 @@ FROM ubuntu-20.04-upstream AS arm64-ubuntu-20.04-nvidia-jetson-agx-orin
 ###############################################################
 ####                Common to a Single Flavor              ####
 ###############################################################
-# As soon as 24.04 is released, this can be renamed to ubuntu-24.04 directly and remove all 23.10 references
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-latest
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -327,7 +337,7 @@ RUN apt-get update \
 # for some reason \+ is breaking. Using \; instead despite being slower
 RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \;
 
-FROM ubuntu-latest AS ubuntu-24.04
+FROM ubuntu-latest AS ubuntu-latest-selinux
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     isc-dhcp-common \
@@ -336,6 +346,9 @@ RUN apt-get update \
     selinux-basics \
     selinux-policy-default \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+FROM ubuntu-latest-selinux AS ubuntu-24.10
+FROM ubuntu-latest-selinux AS ubuntu-24.04
 
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-legacy
 RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \+

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -8,10 +8,10 @@ ARG FAMILY=ubuntu
 # Currently supported flavors are:
 #   - ubuntu
 ARG FLAVOR
-#   - 20.04
-#   - 22.04
-#   - 24.04
 #   - 24.10
+#   - 24.04
+#   - 22.04
+#   - 20.04
 ARG FLAVOR_RELEASE
 # Currently supported models are:
 #   - generic
@@ -27,13 +27,10 @@ ARG BOOTLOADER=grub
 ###############################################################
 ####                     Upstream Images                   ####
 ###############################################################
-FROM ${BASE_IMAGE} AS ubuntu-20.04-upstream
-
-FROM ${BASE_IMAGE} AS ubuntu-22.04-upstream
-
-FROM ${BASE_IMAGE} AS ubuntu-24.04-upstream
-
 FROM ${BASE_IMAGE} AS ubuntu-24.10-upstream
+FROM ${BASE_IMAGE} AS ubuntu-24.04-upstream
+FROM ${BASE_IMAGE} AS ubuntu-22.04-upstream
+FROM ${BASE_IMAGE} AS ubuntu-20.04-upstream
 
 ###############################################################
 ####                build nohang from source               ####
@@ -159,10 +156,10 @@ RUN [ -z "$(ls -A /lib/firmware/intel-ucode/)" ] && apt-get update && apt-get in
 
 FROM systemd-boot AS systemd-boot-arm64
 
-FROM systemd-boot-amd64 AS systemd-boot-amd64-24.04
 FROM systemd-boot-amd64 AS systemd-boot-amd64-24.10
-FROM systemd-boot-arm64 AS systemd-boot-arm64-24.04
+FROM systemd-boot-amd64 AS systemd-boot-amd64-24.04
 FROM systemd-boot-arm64 AS systemd-boot-arm64-24.10
+FROM systemd-boot-arm64 AS systemd-boot-arm64-24.04
 
 FROM grub AS grub-amd64
 RUN apt-get update \
@@ -194,12 +191,12 @@ FROM grub-current AS grub-arm64-current
 FROM grub-legacy AS grub-amd64-legacy
 FROM grub-legacy AS grub-arm64-legacy
 
-FROM grub-current AS grub-amd64-24.04
 FROM grub-current AS grub-amd64-24.10
+FROM grub-current AS grub-amd64-24.04
 FROM grub-current AS grub-amd64-22.04
 FROM grub-legacy AS grub-amd64-20.04
-FROM grub-current AS grub-arm64-24.04
 FROM grub-current AS grub-arm64-24.10
+FROM grub-current AS grub-arm64-24.04
 FROM grub-current AS grub-arm64-22.04
 FROM grub-legacy AS grub-arm64-20.04
 
@@ -249,7 +246,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     polkitd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM base-ubuntu-current AS kernel-ubuntu-24.10
+FROM base-ubuntu-current AS kernel-ubuntu-current
 RUN apt-get update
 # If a kernel is already installed, don't try to install it again, this way the base image can
 # be non-hwe for older releases
@@ -257,13 +254,8 @@ RUN [ -z "$(ls -A /boot/vmlinuz*)" ] && apt-get install -y --no-install-recommen
     linux-image-generic-hwe-24.04 || true
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM base-ubuntu-current AS kernel-ubuntu-24.04
-RUN apt-get update
-# If a kernel is already installed, don't try to install it again, this way the base image can
-# be non-hwe for older releases
-RUN [ -z "$(ls -A /boot/vmlinuz*)" ] && apt-get install -y --no-install-recommends \
-    linux-image-generic-hwe-24.04 || true
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM kernel-ubuntu-current AS kernel-ubuntu-24.10
+FROM kernel-ubuntu-current AS kernel-ubuntu-24.04
 
 FROM base-ubuntu-current AS kernel-ubuntu-22.04
 RUN apt-get update
@@ -281,15 +273,15 @@ RUN [ -z "$(ls -A /boot/vmlinuz*)" ] && apt-get install -y --no-install-recommen
     linux-image-generic-hwe-20.04 || true
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM kernel-ubuntu-20.04 AS amd64-ubuntu-20.04
-FROM kernel-ubuntu-22.04 AS amd64-ubuntu-22.04
-FROM kernel-ubuntu-24.04 AS amd64-ubuntu-24.04
 FROM kernel-ubuntu-24.10 AS amd64-ubuntu-24.10
+FROM kernel-ubuntu-24.04 AS amd64-ubuntu-24.04
+FROM kernel-ubuntu-22.04 AS amd64-ubuntu-22.04
+FROM kernel-ubuntu-20.04 AS amd64-ubuntu-20.04
 
-FROM kernel-ubuntu-20.04 AS arm64-ubuntu-20.04
-FROM kernel-ubuntu-22.04 AS arm64-ubuntu-22.04
-FROM kernel-ubuntu-24.04 AS arm64-ubuntu-24.04
 FROM kernel-ubuntu-24.10 AS arm64-ubuntu-24.10
+FROM kernel-ubuntu-24.04 AS arm64-ubuntu-24.04
+FROM kernel-ubuntu-22.04 AS arm64-ubuntu-22.04
+FROM kernel-ubuntu-20.04 AS arm64-ubuntu-20.04
 
 ###############################################################
 ####               Common to a Single Model                ####
@@ -317,13 +309,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     linux-modules-extra-raspi \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM generic AS amd64-ubuntu-24.04-generic
 FROM generic AS amd64-ubuntu-24.10-generic
+FROM generic AS amd64-ubuntu-24.04-generic
 FROM generic AS amd64-ubuntu-22.04-generic
 FROM generic AS amd64-ubuntu-20.04-generic
 
-FROM generic AS arm64-ubuntu-24.04-generic
 FROM generic AS arm64-ubuntu-24.10-generic
+FROM generic AS arm64-ubuntu-24.04-generic
 FROM ubuntu-22.04-rpi AS arm64-ubuntu-24.04-rpi4
 FROM ubuntu-22.04-rpi AS arm64-ubuntu-22.04-rpi3
 FROM ubuntu-22.04-rpi AS arm64-ubuntu-22.04-rpi4
@@ -346,7 +338,7 @@ RUN apt-get update \
 # for some reason \+ is breaking. Using \; instead despite being slower
 RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \;
 
-FROM ubuntu-latest AS ubuntu-24.10
+FROM ubuntu-latest AS ubuntu-latest-selinux
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     isc-dhcp-common \
@@ -356,15 +348,8 @@ RUN apt-get update \
     selinux-policy-default \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM ubuntu-latest AS ubuntu-24.04
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    isc-dhcp-common \
-    isc-dhcp-client \
-    selinux-utils \
-    selinux-basics \
-    selinux-policy-default \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM ubuntu-latest-selinux AS ubuntu-24.10
+FROM ubuntu-latest-selinux AS ubuntu-24.04
 
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-legacy
 RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \+

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -11,6 +11,7 @@ ARG FLAVOR
 #   - 20.04
 #   - 22.04
 #   - 24.04
+#   - 24.10
 ARG FLAVOR_RELEASE
 # Currently supported models are:
 #   - generic
@@ -31,6 +32,8 @@ FROM ${BASE_IMAGE} AS ubuntu-20.04-upstream
 FROM ${BASE_IMAGE} AS ubuntu-22.04-upstream
 
 FROM ${BASE_IMAGE} AS ubuntu-24.04-upstream
+
+FROM ${BASE_IMAGE} AS ubuntu-24.10-upstream
 
 ###############################################################
 ####                build nohang from source               ####
@@ -157,7 +160,9 @@ RUN [ -z "$(ls -A /lib/firmware/intel-ucode/)" ] && apt-get update && apt-get in
 FROM systemd-boot AS systemd-boot-arm64
 
 FROM systemd-boot-amd64 AS systemd-boot-amd64-24.04
+FROM systemd-boot-amd64 AS systemd-boot-amd64-24.10
 FROM systemd-boot-arm64 AS systemd-boot-arm64-24.04
+FROM systemd-boot-arm64 AS systemd-boot-arm64-24.10
 
 FROM grub AS grub-amd64
 RUN apt-get update \
@@ -190,9 +195,11 @@ FROM grub-legacy AS grub-amd64-legacy
 FROM grub-legacy AS grub-arm64-legacy
 
 FROM grub-current AS grub-amd64-24.04
+FROM grub-current AS grub-amd64-24.10
 FROM grub-current AS grub-amd64-22.04
 FROM grub-legacy AS grub-amd64-20.04
 FROM grub-current AS grub-arm64-24.04
+FROM grub-current AS grub-arm64-24.10
 FROM grub-current AS grub-arm64-22.04
 FROM grub-legacy AS grub-arm64-20.04
 
@@ -242,6 +249,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     polkitd \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+FROM base-ubuntu-current AS kernel-ubuntu-24.10
+RUN apt-get update
+# If a kernel is already installed, don't try to install it again, this way the base image can
+# be non-hwe for older releases
+RUN [ -z "$(ls -A /boot/vmlinuz*)" ] && apt-get install -y --no-install-recommends \
+    linux-image-generic-hwe-24.04 || true
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
 FROM base-ubuntu-current AS kernel-ubuntu-24.04
 RUN apt-get update
 # If a kernel is already installed, don't try to install it again, this way the base image can
@@ -269,10 +284,12 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 FROM kernel-ubuntu-20.04 AS amd64-ubuntu-20.04
 FROM kernel-ubuntu-22.04 AS amd64-ubuntu-22.04
 FROM kernel-ubuntu-24.04 AS amd64-ubuntu-24.04
+FROM kernel-ubuntu-24.10 AS amd64-ubuntu-24.10
 
 FROM kernel-ubuntu-20.04 AS arm64-ubuntu-20.04
 FROM kernel-ubuntu-22.04 AS arm64-ubuntu-22.04
 FROM kernel-ubuntu-24.04 AS arm64-ubuntu-24.04
+FROM kernel-ubuntu-24.10 AS arm64-ubuntu-24.10
 
 ###############################################################
 ####               Common to a Single Model                ####
@@ -301,10 +318,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM generic AS amd64-ubuntu-24.04-generic
+FROM generic AS amd64-ubuntu-24.10-generic
 FROM generic AS amd64-ubuntu-22.04-generic
 FROM generic AS amd64-ubuntu-20.04-generic
 
 FROM generic AS arm64-ubuntu-24.04-generic
+FROM generic AS arm64-ubuntu-24.10-generic
 FROM ubuntu-22.04-rpi AS arm64-ubuntu-24.04-rpi4
 FROM ubuntu-22.04-rpi AS arm64-ubuntu-22.04-rpi3
 FROM ubuntu-22.04-rpi AS arm64-ubuntu-22.04-rpi4
@@ -315,7 +334,6 @@ FROM ubuntu-20.04-upstream AS arm64-ubuntu-20.04-nvidia-jetson-agx-orin
 ###############################################################
 ####                Common to a Single Flavor              ####
 ###############################################################
-# As soon as 24.04 is released, this can be renamed to ubuntu-24.04 directly and remove all 23.10 references
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-latest
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -327,6 +345,16 @@ RUN apt-get update \
 # compress firmware (from 23.10, fw files come compressed)
 # for some reason \+ is breaking. Using \; instead despite being slower
 RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \;
+
+FROM ubuntu-latest AS ubuntu-24.10
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    isc-dhcp-common \
+    isc-dhcp-client \
+    selinux-utils \
+    selinux-basics \
+    selinux-policy-default \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM ubuntu-latest AS ubuntu-24.04
 RUN apt-get update \


### PR DESCRIPTION
24.10 has already been available for a bit, and it would be nice to already include it in our pipeline

This PR also cleans up a bit the order of the flavors to always go from newest to oldest