### PR TITLE
:robot: Build Ubuntu 24.04 Standard Image UKI on Github

### DIFF
--- a/.github/workflows/reusable-uki-test.yaml
+++ b/.github/workflows/reusable-uki-test.yaml
@@ -64,7 +64,7 @@ jobs:
             --FLAVOR_RELEASE=${{ inputs.flavor_release }} \
             --FAMILY=${{ inputs.family }} \
             --MODEL=generic \
-            --VARIANT=core \
+            --VARIANT=${{ inputs.variant }} \
             --BASE_IMAGE=${{ inputs.base_image }} \
             --BOOTLOADER=systemd-boot
       - name: Push image to ttl.sh
@@ -140,7 +140,7 @@ jobs:
           COSIGN_YES: true
         run: |
           SUFFIX="-uki"
-          IMAGE=$(FLAVOR=${{ inputs.flavor }} FLAVOR_RELEASE="${{ inputs.flavor_release }}" MODEL=generic TARGETARCH=amd64 VARIANT=core REGISTRY_AND_ORG="quay.io/kairos" RELEASE=master kairos-agent versioneer container-artifact-name)
+          IMAGE=$(FLAVOR=${{ inputs.flavor }} FLAVOR_RELEASE="${{ inputs.flavor_release }}" MODEL=generic TARGETARCH=amd64 VARIANT=${{ inputs.variant }} REGISTRY_AND_ORG="quay.io/kairos" RELEASE=master kairos-agent versioneer container-artifact-name)
           docker tag $(cat build/IMAGE) "$IMAGE$SUFFIX"
           docker push "$IMAGE$SUFFIX"
           image_ref=$(docker image inspect --format='{{index .RepoDigests 0}}' "$IMAGE$SUFFIX")
@@ -148,6 +148,6 @@ jobs:
       - uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9 # v4
         if: failure()
         with:
-          name: ${{ env.FLAVOR }}-${{ env.FLAVOR_RELEASE }}.logs.zip
+          name: ${{ env.FLAVOR }}-${{ env.FLAVOR_RELEASE }}-${{ env.VARIANT }}.logs.zip
           path: tests/**/logs/*
           if-no-files-found: warn

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -21,10 +21,17 @@ jobs:
             flavor_release: 24.04
             family: ubuntu
             base_image: ubuntu:24.04
+            variant: core
+          - flavor: ubuntu
+            flavor_release: 24.04
+            family: ubuntu
+            base_image: ubuntu:24.04
+            variant: standard
           - flavor: fedora
             family: rhel
             flavor_release: 40
             base_image: fedora:40
+            variant: core
     uses: ./.github/workflows/reusable-uki-test.yaml
     permissions:
       id-token: write  # OIDC support

--- a/.github/workflows/uki_branches.yaml
+++ b/.github/workflows/uki_branches.yaml
@@ -20,7 +20,7 @@ concurrency:
 env:
   FORCE_COLOR: 1
 jobs:
-  test-uki-ubuntu-lts:
+  test-uki-ubuntu-lts-core:
     uses: ./.github/workflows/reusable-uki-test.yaml
     permissions:
       id-token: write  # OIDC support
@@ -42,6 +42,30 @@ jobs:
       family: ubuntu
       flavor: ubuntu
       flavor_release: 24.04
+      variant: core
+  test-uki-ubuntu-lts-standard:
+    uses: ./.github/workflows/reusable-uki-test.yaml
+    permissions:
+      id-token: write  # OIDC support
+      contents: write
+      security-events: write
+      actions: read
+      attestations: read
+      checks: read
+      deployments: read
+      discussions: read
+      issues: read
+      packages: read
+      pages: read
+      pull-requests: read
+      repository-projects: read
+      statuses: read
+    with:
+      base_image: ubuntu:24.04
+      family: ubuntu
+      flavor: ubuntu
+      flavor_release: 24.04
+      variant: standard
   test-uki-fedora:
     uses: ./.github/workflows/reusable-uki-test.yaml
     permissions:
@@ -64,3 +88,4 @@ jobs:
       family: rhel
       flavor: fedora
       flavor_release: 40
+      variant: core


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: 
Until the standard packages can be auto installed as sysext I think this gives a way to work with standard UKI images.  I can open a ticket on this for the future.  This will help me to build with the released file sets and test changes more quickly.

**Which issue(s) this PR fixes** 
Discussed at https://cloud-native.slack.com/archives/C0707M8UEU8/p1727801588480279?thread_ts=1727801588.480279&cid=C0707M8UEU8

I don't have a great way to set all of this without the full CI/CD access, so if someone has a few minutes to review before accepting that would be great.

I changed the logging filename to include the variant, so they do not overwrite.  I could not find anything this affects, but I might not have full visibility.