### PR TITLE
:ROBOT: Prevent secureboot keys from being added to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /kairos
 /dist
 /build
+/keys
 /trivy-cache
 coverage.out
 .DS_Store


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
For people building with custom keys adding the `/keys` this prevents accidental leakage of the keys to git.
