### PR TITLE
🤖 Increase the UKI VM resources

### DIFF
--- a/.github/workflows/reusable-uki-test.yaml
+++ b/.github/workflows/reusable-uki-test.yaml
@@ -116,8 +116,8 @@ jobs:
         env:
           USE_QEMU: true
           KVM: true
-          MEMORY: 4000
-          CPUS: 2
+          MEMORY: 6000
+          CPUS: 4
           FIRMWARE: /usr/share/OVMF/OVMF_CODE.fd
           EMULATE_TPM: true
           UKI_TEST: true

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -56,3 +56,4 @@ jobs:
       flavor: ${{ matrix.flavor }}
       flavor_release: ${{ matrix.flavor_release }}
       variant: ${{ matrix.variant }}
+      k3s_version: ${{ matrix.k3s_version }}


### PR DESCRIPTION
It looks like during upgrade the resources for the VM can be exhausted
which kills the machine in the middle.

Now that we are running the UKI tests in our own workers we can increase
a bit the minimun resources for the test VMs.

This patch increases the memory to 6Gb from 4gb and the CPU from 2 to 4

Signed-off-by: Itxaka <itxaka@kairos.io>