### PR TITLE
Bump auroraboot to v0.4.0 to fix root permission to 755

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -10,7 +10,7 @@ ARG GRYPE_VERSION=v0.85.0
 # renovate: datasource=docker depName=quay.io/kairos/framework versioning=semver
 ARG KAIROS_FRAMEWORK_VERSION=v2.14.4
 # renovate: datasource=docker depName=quay.io/kairos/auroraboot versioning=semver
-ARG AURORABOOT_VERSION=v0.3.3
+ARG AURORABOOT_VERSION=v0.4.0
 # renovate: datasource=docker depName=golang versioning=semver
 ARG GO_VERSION=1.22
 # renovate: datasource=docker depName=hadolint/hadolint


### PR DESCRIPTION
https://github.com/kairos-io/AuroraBoot/pull/129

without this, the isos we generate will not allow any non-root user to login after installation

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
