### PR TITLE
Use cached image again (now that we pushed 1.23)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -115,7 +115,7 @@ build-and-push-golang-testing:
 
 go-deps-test:
     ARG GO_VERSION
-    FROM +build-and-push-golang-testing
+    FROM $IMAGE_REPOSITORY_ORG/golang-testing:$GO_VERSION
     WORKDIR /build
     COPY tests/go.mod tests/go.sum ./
     RUN go mod download


### PR DESCRIPTION
the push happens manually from a local build

It was removed here: https://github.com/kairos-io/kairos/pull/3055/files#diff-2705f6016a64189abd14041e2f3e8dbb829553295d9088e4eb42eccb5e61bf47R118

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
