### PR TITLE
Create a truly empy /etc/machine-id

### DIFF
--- a/images/Dockerfile.kairos
+++ b/images/Dockerfile.kairos
@@ -86,7 +86,7 @@ RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
 # This prevents systemd from thinking that the machine is on first boot
 # and recreating /etc/ dependencies in services and such
 # do this before initramfs so its in the initramfs
-RUN echo "" > /etc/machine-id || true
+RUN printf "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \

--- a/images/Dockerfile.kairos-alpine
+++ b/images/Dockerfile.kairos-alpine
@@ -236,7 +236,7 @@ RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
 # This prevents systemd from thinking that the machine is on first boot
 # and recreating /etc/ dependencies in services and such
 # do this before initramfs so its in the initramfs
-RUN echo "" > /etc/machine-id || true
+RUN printf "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \

--- a/images/Dockerfile.kairos-debian
+++ b/images/Dockerfile.kairos-debian
@@ -250,7 +250,7 @@ RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
 # This prevents systemd from thinking that the machine is on first boot
 # and recreating /etc/ dependencies in services and such
 # do this before initramfs so its in the initramfs
-RUN echo "" > /etc/machine-id || true
+RUN printf "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \

--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -246,7 +246,7 @@ RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
 # This prevents systemd from thinking that the machine is on first boot
 # and recreating /etc/ dependencies in services and such
 # do this before initramfs so its in the initramfs
-RUN echo "" > /etc/machine-id || true
+RUN printf "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \

--- a/images/Dockerfile.kairos-rhel
+++ b/images/Dockerfile.kairos-rhel
@@ -185,7 +185,7 @@ RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
 # This prevents systemd from thinking that the machine is on first boot
 # and recreating /etc/ dependencies in services and such
 # do this before initramfs so its in the initramfs
-RUN echo "" > /etc/machine-id || true
+RUN printf "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -463,7 +463,7 @@ RUN kernel=$(ls /lib/modules | head -n1) && depmod -a "${kernel}"
 # This prevents systemd from thinking that the machine is on first boot
 # and recreating /etc/ dependencies in services and such
 # do this before initramfs so its in the initramfs
-RUN echo "" > /etc/machine-id || true
+RUN printf "" > /etc/machine-id || true
 # Regenerate initrd if necessary, proper config files with immucore and custom initrd should already be in there installed by framework
 # for systemd distros
 RUN if [ -f "/usr/bin/dracut" ]; then \


### PR DESCRIPTION
because `echo` adds a LF (line feed) character and that breaks on Alpine

Fixes https://github.com/kairos-io/kairos/issues/3059

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
