### PR TITLE
Add missing package that makes debian:testing unbootable

### DIFF
--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -102,6 +102,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     squashfs-tools \
     sudo \
     systemd \
+    systemd-cryptsetup \
     systemd-resolved \
     systemd-sysv \
     systemd-timesyncd \

--- a/images/Dockerfile.kairos-debian
+++ b/images/Dockerfile.kairos-debian
@@ -101,6 +101,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     squashfs-tools \
     sudo \
     systemd \
+    systemd-cryptsetup \
     systemd-resolved \
     systemd-sysv \
     systemd-timesyncd \


### PR DESCRIPTION
Producing this error at build time:

kairos-final | dracut[I]: 01systemd-cryptsetup: Could not find any command of '/usr/lib/systemd/systemd-cryptsetup'!
kairos-final | dracut[E]: Module 'dracut-systemd' depends on module 'systemd-cryptsetup', which can't be installed

E.g. here: https://github.com/kairos-io/kairos/actions/runs/12256409387/job/34191620277#step:15:4469

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
