### PR TITLE
Log files no longer have hardcoded names, use a glob for the test

### DIFF
--- a/tests/provider_decentralized_test.go
+++ b/tests/provider_decentralized_test.go
@@ -131,7 +131,7 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 				*/
 			} else {
 				Eventually(func() string {
-					out, _ = vm.Sudo("cat /var/log/kairos/agent-provider.log")
+					out, _ = vm.Sudo("cat /var/log/kairos/*.log")
 					return out
 				}, 45*time.Minute, 1*time.Second).Should(
 					Or(


### PR DESCRIPTION
This test is still run manually and fails later when it tries to upgrade to:

quay.io/kairos/kairos-opensuse:v1.0.0-rc2-k3sv1.21.14-k3s1

but I don't even know why it should be able to "upgrade" (actually downgrade) to such an old version successfully. Manually upgrading works.

This fix is meant to make it easier to run the test locally until we can run it again on CI (https://github.com/kairos-io/kairos/issues/2709).

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
