### PR TITLE
Install systemd-cryptsetup only in debian testing

### DIFF
--- a/images/Dockerfile.debian
+++ b/images/Dockerfile.debian
@@ -102,7 +102,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     squashfs-tools \
     sudo \
     systemd \
-    systemd-cryptsetup \
     systemd-resolved \
     systemd-sysv \
     systemd-timesyncd \
@@ -116,9 +115,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ###############################################################
+####          bookworm vs testing differences              ####
+###############################################################
+FROM common AS common-bookworm
+FROM common AS common-testing
+RUN apt-get update && apt-get install -y systemd-cryptsetup && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+###############################################################
 ####                    Common to a Model                  ####
 ###############################################################
-FROM common AS amd64-generic
+FROM common-${FLAVOR_RELEASE} AS amd64-generic
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     grub2 \
@@ -130,7 +136,7 @@ RUN apt-get update \
     zfsutils-linux \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM common AS arm64-common
+FROM common-${FLAVOR_RELEASE} AS arm64-common
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     grub-efi-arm64-bin \


### PR DESCRIPTION
because it doesn't exist as a package in bookworm

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
