### PR TITLE
feat(nvidia): bump base image to 22.04

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -188,7 +188,7 @@ jobs:
     secrets: inherit
     with:
       flavor: ubuntu
-      flavor_release: "20.04"
+      flavor_release: "22.04"
       family: ubuntu
       base_image: quay.io/kairos/cache:nvidia-base
       model: nvidia-jetson-agx-orin

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -123,7 +123,7 @@ jobs:
     secrets: inherit
     with:
       flavor: ubuntu
-      flavor_release: "20.04"
+      flavor_release: "22.04"
       family: ubuntu
       base_image: quay.io/kairos/cache:nvidia-base
       model: nvidia-jetson-agx-orin

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -319,7 +319,7 @@ FROM ubuntu-22.04-rpi AS arm64-ubuntu-22.04-rpi3
 FROM ubuntu-22.04-rpi AS arm64-ubuntu-22.04-rpi4
 FROM ubuntu-20.04-rpi AS arm64-ubuntu-20.04-rpi3
 FROM ubuntu-20.04-rpi AS arm64-ubuntu-20.04-rpi4
-FROM ubuntu-20.04-upstream AS arm64-ubuntu-20.04-nvidia-jetson-agx-orin
+FROM ubuntu-22.04-upstream AS arm64-ubuntu-22.04-nvidia-jetson-agx-orin
 
 ###############################################################
 ####                Common to a Single Flavor              ####

--- a/images/Dockerfile.nvidia
+++ b/images/Dockerfile.nvidia
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as base
+FROM ubuntu:22.04 as base
 
 RUN apt-get update
 RUN apt-get install -y ca-certificates

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -320,7 +320,7 @@ FROM ubuntu-22.04-rpi AS arm64-ubuntu-22.04-rpi3
 FROM ubuntu-22.04-rpi AS arm64-ubuntu-22.04-rpi4
 FROM ubuntu-20.04-rpi AS arm64-ubuntu-20.04-rpi3
 FROM ubuntu-20.04-rpi AS arm64-ubuntu-20.04-rpi4
-FROM ubuntu-20.04-upstream AS arm64-ubuntu-20.04-nvidia-jetson-agx-orin
+FROM ubuntu-22.04-upstream AS arm64-ubuntu-22.04-nvidia-jetson-agx-orin
 
 ###############################################################
 ####                Common to a Single Flavor              ####


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**: This PR bumps the agx orin and nvidia image base to 22.04

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
