### PR TITLE
Use the generic core matrix for the generic images

### DIFF
--- a/.github/workflows/image-arm.yaml
+++ b/.github/workflows/image-arm.yaml
@@ -262,7 +262,7 @@ jobs:
       statuses: read
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.get-core-matrix.outputs.matrix)}}
+      matrix: ${{fromJson(needs.get-core-matrix-generic.outputs.matrix)}}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
They were not running, not sure why it shows the error, but it should be pointing to the generic matrix anyways

<img width="1863" alt="Screenshot 2025-01-09 at 10 07 13" src="https://github.com/user-attachments/assets/46ccf136-027e-4fc6-86b5-2cdef057ba79" />
