### PR TITLE
Keep only high and critical severity results

### DIFF
--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -230,21 +230,36 @@ jobs:
           files: |
             build/*scan-reports.tar.gz
       - name: Prepare sarif files  🔧
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          mkdir trivy-sarif grype-sarif
-          sudo mv build/*trivy.sarif trivy-sarif/
-          sudo mv build/*grype.sarif grype-sarif/
+          mkdir trivy-results grype-results
+          trivy=$(ls build/*trivy.sarif 2>/dev/null | head -n 1)
+          grype=$(ls build/*grype.sarif 2>/dev/null | head -n 1)
+          sudo mv $trivy trivy-results/result.sarif
+          sudo mv $grype grype-results/result.sarif
+      - uses: itxaka/sarif-filter@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          input: trivy-results/result.sarif
+          output: trivy-results/result.sarif
+          severity: high
+      - uses: itxaka/sarif-filter@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          input: grype-results/result.sarif
+          output: grype-results/result.sarif
+          severity: high
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          sarif_file: 'trivy-sarif'
+          sarif_file: 'trivy-results'
           category: ${{ matrix.flavor }}-${{ matrix.flavor_release }}-${{ matrix.variant }}-${{ matrix.arch }}-${{ matrix.model }}-trivy
       - name: Upload Grype scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          sarif_file: 'grype-sarif'
+          sarif_file: 'grype-results'
           category: ${{ matrix.flavor }}-${{ matrix.flavor_release }}-${{ matrix.variant }}-${{ matrix.arch }}-${{ matrix.model }}-grype
   build-arm-standard:
     runs-on: ARM64
@@ -331,20 +346,34 @@ jobs:
             build/*scan-reports.tar.gz
       - name: Prepare sarif files  🔧
         run: |
-          mkdir trivy-sarif grype-sarif
-          sudo mv build/*trivy.sarif trivy-sarif/
-          sudo mv build/*grype.sarif grype-sarif/
+          mkdir trivy-results grype-results
+          trivy=$(ls build/*trivy.sarif 2>/dev/null | head -n 1)
+          grype=$(ls build/*grype.sarif 2>/dev/null | head -n 1)
+          sudo mv $trivy trivy-results/result.sarif
+          sudo mv $grype grype-results/result.sarif
+      - uses: itxaka/sarif-filter@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          input: trivy-results/result.sarif
+          output: trivy-results/result.sarif
+          severity: high
+      - uses: itxaka/sarif-filter@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          input: grype-results/result.sarif
+          output: grype-results/result.sarif
+          severity: high
       - name: Upload Trivy scan results to GitHub Security tab
         if: startsWith(github.ref, 'refs/tags/')
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3
         with:
-          sarif_file: 'trivy-sarif'
+          sarif_file: 'trivy-results'
           category: ${{ matrix.flavor }}-${{ matrix.flavor_release }}-${{ matrix.variant }}-${{ matrix.arch }}-${{ matrix.model }}-trivy
       - name: Upload Grype scan results to GitHub Security tab
         if: startsWith(github.ref, 'refs/tags/')
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3
         with:
-          sarif_file: 'grype-sarif'
+          sarif_file: 'grype-results'
           category: ${{ matrix.flavor }}-${{ matrix.flavor_release }}-${{ matrix.variant }}-${{ matrix.arch }}-${{ matrix.model }}-grype
       - name: Space stats
         if: always()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -194,9 +194,11 @@ jobs:
                           --output-signature="${filename}.sig" "${filename}"
       - name: Prepare files for release
         run: |
-          mkdir trivy-sarif grype-sarif
-          sudo mv release/*trivy.sarif trivy-sarif/
-          sudo mv release/*grype.sarif grype-sarif/
+          mkdir trivy-results grype-results
+          trivy=$(ls build/*trivy.sarif 2>/dev/null | head -n 1)
+          grype=$(ls build/*grype.sarif 2>/dev/null | head -n 1)
+          sudo mv $trivy trivy-results/result.sarif
+          sudo mv $grype grype-results/result.sarif
           mkdir reports
           mv release/*.json reports/
           cd reports
@@ -205,6 +207,18 @@ jobs:
           mv *.tar.gz ../release/
           cd ..
           rm release/IMAGE release/VERSION release/versions.yaml
+      - uses: itxaka/sarif-filter@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          input: trivy-results/result.sarif
+          output: trivy-results/result.sarif
+          severity: high
+      - uses: itxaka/sarif-filter@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          input: grype-results/result.sarif
+          output: grype-results/result.sarif
+          severity: high
       - name: Release
         uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         if: startsWith(github.ref, 'refs/tags/')
@@ -215,13 +229,13 @@ jobs:
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          sarif_file: 'trivy-sarif'
+          sarif_file: 'trivy-results'
           category: ${{ matrix.flavor }}-${{ matrix.flavor_release }}-${{ matrix.variant }}-${{ matrix.arch }}-${{ matrix.model }}-trivy
       - name: Upload Grype scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          sarif_file: 'grype-sarif'
+          sarif_file: 'grype-results'
           category: ${{ matrix.flavor }}-${{ matrix.flavor_release }}-${{ matrix.variant }}-${{ matrix.arch }}-${{ matrix.model }}-grype
   build-uki-container-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-build-flavor.yaml
+++ b/.github/workflows/reusable-build-flavor.yaml
@@ -139,8 +139,22 @@ jobs:
           sudo mv build/* .
           sudo rm -rf build
           mkdir trivy-results grype-results
-          sudo mv *trivy.sarif trivy-results/
-          sudo mv *grype.sarif grype-results/
+          trivy=$(ls *trivy.sarif 2>/dev/null | head -n 1)
+          grype=$(ls *grype.sarif 2>/dev/null | head -n 1)
+          sudo mv $trivy trivy-results/result.sarif
+          sudo mv $grype grype-results/result.sarif
+      - uses: itxaka/sarif-filter@v1
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        with:
+          input: trivy-results/result.sarif
+          output: trivy-results/result.sarif
+          severity: high
+      - uses: itxaka/sarif-filter@v1
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        with:
+          input: grype-results/result.sarif
+          output: grype-results/result.sarif
+          severity: high
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3

--- a/.github/workflows/reusable-docker-arm-build.yaml
+++ b/.github/workflows/reusable-docker-arm-build.yaml
@@ -151,20 +151,34 @@ jobs:
       - name: Prepare sarif files  🔧
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          mkdir trivy-sarif grype-sarif
-          sudo mv build/*trivy.sarif trivy-sarif/
-          sudo mv build/*grype.sarif grype-sarif/
+          mkdir trivy-results grype-results
+          trivy=$(ls *trivy.sarif 2>/dev/null | head -n 1)
+          grype=$(ls *grype.sarif 2>/dev/null | head -n 1)
+          sudo mv $trivy trivy-results/result.sarif
+          sudo mv $grype grype-results/result.sarif
+      - uses: itxaka/sarif-filter@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          input: trivy-results/result.sarif
+          output: trivy-results/result.sarif
+          severity: high
+      - uses: itxaka/sarif-filter@v1
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          input: grype-results/result.sarif
+          output: grype-results/result.sarif
+          severity: high
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3
         if: startsWith(github.ref, 'refs/tags/v')
         with:
-          sarif_file: 'trivy-sarif'
+          sarif_file: 'trivy-results'
           category: ${{ matrix.flavor }}-${{ matrix.flavor_release }}-${{ matrix.variant }}-${{ matrix.arch }}-${{ matrix.model }}-trivy
       - name: Upload Grype scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3
         if: startsWith(github.ref, 'refs/tags/v')
         with:
-          sarif_file: 'grype-sarif'
+          sarif_file: 'grype-results'
           category: ${{ matrix.flavor }}-${{ matrix.flavor_release }}-${{ matrix.variant }}-${{ matrix.arch }}-${{ matrix.model }}-grype
       - name: Upload results
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && inputs.model != 'nvidia-jetson-agx-orin' }}


### PR DESCRIPTION
because we exceed github limit of 5000 results and it breaks the results page

Consumes @Itxaka 's amazing work here: https://github.com/Itxaka/sarif-filter

Part of: https://github.com/kairos-io/kairos/issues/3119

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
