### PR TITLE
Scan images not dir

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -788,21 +788,25 @@ trivy-scan:
 
     # Use base-image so it can read original os-release file
     FROM +base-image
-
-    ARG ISO_NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
-
+    RUN mkdir build
+    WORKDIR /
     COPY +trivy/trivy /trivy
     COPY +trivy/contrib /contrib
     # This repo seems to have no request limit
     ENV TRIVY_DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-db:2
 
-    WORKDIR /build
-    RUN /trivy filesystem --skip-dirs /tmp --timeout 30m --format sarif -o report.sarif --no-progress /
-    RUN /trivy filesystem --skip-dirs /tmp --timeout 30m --format template --template "@/contrib/html.tpl" -o report.html --no-progress /
-    RUN /trivy filesystem --skip-dirs /tmp --timeout 30m -f json -o results.json --no-progress /
-    SAVE ARTIFACT /build/report.sarif report.sarif AS LOCAL build/${ISO_NAME}-trivy.sarif
-    SAVE ARTIFACT /build/report.html report.html AS LOCAL build/${ISO_NAME}-trivy.html
-    SAVE ARTIFACT /build/results.json results.json AS LOCAL build/${ISO_NAME}-trivy.json
+    ARG NAME=$(cat /etc/kairos-release | grep 'KAIROS_ARTIFACT' | sed 's/KAIROS_ARTIFACT=\"//' | sed 's/\"//')
+
+    # We could scan the "/" directory but earthly injects binaries like earth_debugger which are not in the image
+    WITH DOCKER --load image=+base-image
+      RUN /trivy image --skip-dirs /tmp --timeout 30m --format sarif -o /build/report.sarif --no-progress image && \
+          /trivy image --skip-dirs /tmp --timeout 30m --format template --template "@/contrib/html.tpl" -o /build/report.html --no-progress image && \
+          /trivy image --skip-dirs /tmp --timeout 30m -f json -o /build/results.json --no-progress image
+    END
+
+    SAVE ARTIFACT /build/report.sarif report.sarif AS LOCAL build/${NAME}-trivy.sarif
+    SAVE ARTIFACT /build/report.html report.html AS LOCAL build/${NAME}-trivy.html
+    SAVE ARTIFACT /build/results.json results.json AS LOCAL build/${NAME}-trivy.json
 
 grype:
     ARG GRYPE_VERSION


### PR DESCRIPTION
Because earthly injects binaries like earth_debugger which might container security vulnerabilities but are completely irrelevant to our image (and not included in it).

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
