### PR TITLE
Allow building of k0s images via earthly

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -8,7 +8,7 @@ ARG TRIVY_VERSION=0.57.1
 # renovate: datasource=docker depName=anchore/grype versioning=semver
 ARG GRYPE_VERSION=v0.85.0
 # renovate: datasource=docker depName=quay.io/kairos/framework versioning=semver
-ARG KAIROS_FRAMEWORK_VERSION=v2.15.4
+ARG KAIROS_FRAMEWORK_VERSION=v2.15.10
 # renovate: datasource=docker depName=quay.io/kairos/auroraboot versioning=semver
 ARG AURORABOOT_VERSION=v0.4.3
 # renovate: datasource=docker depName=golang versioning=semver
@@ -253,6 +253,7 @@ base-image:
     ARG K3S_VERSION # As it comes from luet package
     ARG SOFTWARE_VERSION_PREFIX="k3s"
     ARG _SOFTWARE_LUET_VERSION=$K3S_VERSION
+    ARG SOFTWARE_VERSION_BUILD="k3s1"
     # Takes 1.28.2+1 and converts that to v1.18.2+k3s1
     # Hack because we use a different version in the luet package and in the
     # artifact names.
@@ -261,7 +262,7 @@ base-image:
     # luet, in the artifact names. E.g. v1.28.2+k3s2+3 (including our build number)
     IF [ "$K3S_VERSION" != "" ]
       ARG _FIXED_VERSION=$(echo $K3S_VERSION | sed 's/+[[:digit:]]*//')
-      ARG SOFTWARE_VERSION="v${_FIXED_VERSION}+k3s1"
+      ARG SOFTWARE_VERSION="v${_FIXED_VERSION}+${SOFTWARE_VERSION_PREFIX}${SOFTWARE_VERSION_BUILD}"
     END
 
     COPY +git-version/GIT_VERSION GIT_VERSION

--- a/images/Dockerfile.kairos
+++ b/images/Dockerfile.kairos
@@ -42,7 +42,7 @@ FROM base-kairos AS kairos-standard
 ARG SOFTWARE_VERSION
 LABEL io.kairos.k3s_version="${SOFTWARE_VERSION}"
 RUN luet install -y system/provider-kairos
-RUN luet install -y "k8s/k3s-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
+RUN luet install -y "k8s/${SOFTWARE_VERSION_PREFIX}-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
 
 FROM kairos-${VARIANT} AS kairos-final
 ARG BASE_IMAGE

--- a/images/Dockerfile.kairos-alpine
+++ b/images/Dockerfile.kairos-alpine
@@ -192,7 +192,7 @@ FROM base-kairos AS kairos-standard
 ARG SOFTWARE_VERSION
 LABEL io.kairos.k3s_version="${SOFTWARE_VERSION}"
 RUN luet install -y system/provider-kairos
-RUN luet install -y "k8s/k3s-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
+RUN luet install -y "k8s/${SOFTWARE_VERSION_PREFIX}-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
 
 FROM kairos-${VARIANT} AS kairos-final
 ARG BASE_IMAGE

--- a/images/Dockerfile.kairos-debian
+++ b/images/Dockerfile.kairos-debian
@@ -101,7 +101,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     squashfs-tools \
     sudo \
     systemd \
-    systemd-cryptsetup \
     systemd-resolved \
     systemd-sysv \
     systemd-timesyncd \
@@ -115,9 +114,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ###############################################################
+####          bookworm vs testing differences              ####
+###############################################################
+FROM common AS common-bookworm
+FROM common AS common-testing
+RUN apt-get update && apt-get install -y systemd-cryptsetup && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+###############################################################
 ####                    Common to a Model                  ####
 ###############################################################
-FROM common AS amd64-generic
+FROM common-${FLAVOR_RELEASE} AS amd64-generic
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     grub2 \
@@ -129,7 +135,7 @@ RUN apt-get update \
     zfsutils-linux \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-FROM common AS arm64-common
+FROM common-${FLAVOR_RELEASE} AS arm64-common
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     grub-efi-arm64-bin \
@@ -207,7 +213,7 @@ FROM base-kairos AS kairos-standard
 ARG SOFTWARE_VERSION
 LABEL io.kairos.k3s_version="${SOFTWARE_VERSION}"
 RUN luet install -y system/provider-kairos
-RUN luet install -y "k8s/k3s-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
+RUN luet install -y "k8s/${SOFTWARE_VERSION_PREFIX}-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
 
 FROM kairos-${VARIANT} AS kairos-final
 ARG BASE_IMAGE

--- a/images/Dockerfile.kairos-opensuse
+++ b/images/Dockerfile.kairos-opensuse
@@ -202,7 +202,7 @@ FROM base-kairos AS kairos-standard
 ARG SOFTWARE_VERSION
 LABEL io.kairos.k3s_version="${SOFTWARE_VERSION}"
 RUN luet install -y system/provider-kairos
-RUN luet install -y "k8s/k3s-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
+RUN luet install -y "k8s/${SOFTWARE_VERSION_PREFIX}-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
 
 FROM kairos-${VARIANT} AS kairos-final
 ARG BASE_IMAGE

--- a/images/Dockerfile.kairos-rhel
+++ b/images/Dockerfile.kairos-rhel
@@ -153,7 +153,7 @@ FROM base-kairos AS kairos-standard
 ARG SOFTWARE_VERSION
 LABEL io.kairos.k3s_version="${SOFTWARE_VERSION}"
 RUN luet install -y system/provider-kairos
-RUN luet install -y "k8s/k3s-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
+RUN luet install -y "k8s/${SOFTWARE_VERSION_PREFIX}-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
 
 FROM kairos-${VARIANT} AS kairos-final
 ARG BASE_IMAGE

--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -419,7 +419,7 @@ FROM base-kairos AS kairos-standard
 ARG SOFTWARE_VERSION
 LABEL io.kairos.k3s_version="${SOFTWARE_VERSION}"
 RUN luet install -y system/provider-kairos
-RUN luet install -y "k8s/k3s-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
+RUN luet install -y "k8s/${SOFTWARE_VERSION_PREFIX}-$(which-init.sh)@${SOFTWARE_LUET_VERSION:-$SOFTWARE_VERSION}" utils/edgevpn utils/k9s utils/nerdctl container/kubectl utils/kube-vip
 
 FROM kairos-${VARIANT} AS kairos-final
 ARG BASE_IMAGE


### PR DESCRIPTION
Bumps the version to one that handles k0s through the provider and allows passing of the software prefix and build version to create k0s images. By default it keeps the k3s functionality