### PR TITLE
Fix arm64 artifact naming missing k3s version

### DIFF
--- a/.github/workflows/reusable-docker-arm-build.yaml
+++ b/.github/workflows/reusable-docker-arm-build.yaml
@@ -64,12 +64,12 @@ jobs:
       - name: Set Image name (master)
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
-          IMAGE_REF=$(FLAVOR=${{ inputs.flavor }} FLAVOR_RELEASE="${{ inputs.flavor_release }}" MODEL=${{ inputs.model }} TARGETARCH=arm64 VARIANT=${{ inputs.variant }} REGISTRY_AND_ORG="${{ env.REGISTRY }}" RELEASE=master kairos-agent versioneer container-artifact-name)
+          SOFTWARE_VERSION=${{ inputs.k3s_version }} SOFTWARE_VERSION_PREFIX=k3s IMAGE_REF=$(FLAVOR=${{ inputs.flavor }} FLAVOR_RELEASE="${{ inputs.flavor_release }}" MODEL=${{ inputs.model }} TARGETARCH=arm64 VARIANT=${{ inputs.variant }} REGISTRY_AND_ORG="${{ env.REGISTRY }}" RELEASE=master kairos-agent versioneer container-artifact-name)
           echo "IMAGE_REF=${IMAGE_REF}" >> $GITHUB_ENV
       - name: Set Image name (release/PR)
         if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'pull_request' }}
         run: |
-          IMAGE_REF=$(FLAVOR=${{ inputs.flavor }} FLAVOR_RELEASE="${{ inputs.flavor_release }}" MODEL=${{ inputs.model }} TARGETARCH=arm64 VARIANT=${{ inputs.variant }} REGISTRY_AND_ORG="${{ env.REGISTRY }}" RELEASE=${{ env.GIT_VERSION }} kairos-agent versioneer container-artifact-name)
+          SOFTWARE_VERSION=${{ inputs.k3s_version }} SOFTWARE_VERSION_PREFIX=k3s IMAGE_REF=$(FLAVOR=${{ inputs.flavor }} FLAVOR_RELEASE="${{ inputs.flavor_release }}" MODEL=${{ inputs.model }} TARGETARCH=arm64 VARIANT=${{ inputs.variant }} REGISTRY_AND_ORG="${{ env.REGISTRY }}" RELEASE=${{ env.GIT_VERSION }} kairos-agent versioneer container-artifact-name)
           echo "IMAGE_REF=${IMAGE_REF}" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         if: ${{ inputs.worker != 'ARM64' }}


### PR DESCRIPTION
Because standard/arm64 artifacts for v3.3.0 release are missing the k3s version.

e.g.

quay.io/kairos/alpine:3.19-standard-arm64-rpi4-v3.3.0

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
