### PR TITLE
Fix container image naming

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -262,7 +262,7 @@ base-image:
     # luet, in the artifact names. E.g. v1.28.2+k3s2+3 (including our build number)
     IF [ "$K3S_VERSION" != "" ]
       ARG _FIXED_VERSION=$(echo $K3S_VERSION | sed 's/+[[:digit:]]*//')
-      ARG SOFTWARE_VERSION="v${_FIXED_VERSION}+${SOFTWARE_VERSION_PREFIX}${SOFTWARE_VERSION_BUILD}"
+      ARG SOFTWARE_VERSION="v${_FIXED_VERSION}+${SOFTWARE_VERSION_BUILD}"
     END
 
     COPY +git-version/GIT_VERSION GIT_VERSION


### PR DESCRIPTION
From this:

```
quay.io/kairos/ubuntu:24.04-standard-amd64-generic-v3.3.1-rc2-2-g53b68481-k3sv1.32.1-rc2-k3sk3s1
```

to this:

```
quay.io/kairos/ubuntu:24.04-standard-amd64-generic-v3.3.1-rc2-2-g53b68481-k3sv1.32.1-rc2-k3s1
```

The bug was introduced here: https://github.com/kairos-io/kairos/commit/97872afeb

and it affects the names of the v3.3.1-rcX releases

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
