### PR TITLE
fix(modules): do not compress modules

### DIFF
--- a/images/Dockerfile.kairos-ubuntu
+++ b/images/Dockerfile.kairos-ubuntu
@@ -332,9 +332,6 @@ RUN apt-get update \
     systemd-hwe-hwdb \
     systemd-resolved \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-# compress firmware (from 23.10, fw files come compressed)
-# for some reason \+ is breaking. Using \; instead despite being slower
-RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \;
 
 FROM ubuntu-latest AS ubuntu-latest-selinux
 RUN apt-get update \
@@ -350,7 +347,6 @@ FROM ubuntu-latest-selinux AS ubuntu-24.10
 FROM ubuntu-latest-selinux AS ubuntu-24.04
 
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-legacy
-RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \+
 
 FROM ubuntu-legacy AS ubuntu-22.04
 RUN apt-get update
@@ -366,9 +362,6 @@ FROM ubuntu-legacy AS ubuntu-20.04
 ####               Post-Process Common to All              ####
 ###############################################################
 FROM ${FLAVOR}-${FLAVOR_RELEASE} AS all
-
-# compress modules
-RUN find /usr/lib/modules -type f -name "*.ko" -execdir zstd --rm -9 {} \+
 
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -333,9 +333,6 @@ RUN apt-get update \
     systemd-hwe-hwdb \
     systemd-resolved \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-# compress firmware (from 23.10, fw files come compressed)
-# for some reason \+ is breaking. Using \; instead despite being slower
-RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \;
 
 FROM ubuntu-latest AS ubuntu-latest-selinux
 RUN apt-get update \
@@ -351,7 +348,6 @@ FROM ubuntu-latest-selinux AS ubuntu-24.10
 FROM ubuntu-latest-selinux AS ubuntu-24.04
 
 FROM ${TARGETARCH}-${FLAVOR}-${FLAVOR_RELEASE}-${MODEL} AS ubuntu-legacy
-RUN find /usr/lib/firmware -type f ! -name "*.zst" -execdir zstd --rm -9 {} \+
 
 FROM ubuntu-legacy AS ubuntu-22.04
 RUN apt-get update
@@ -367,9 +363,6 @@ FROM ubuntu-legacy AS ubuntu-20.04
 ####               Post-Process Common to All              ####
 ###############################################################
 FROM ${FLAVOR}-${FLAVOR_RELEASE} AS all
-
-# compress modules
-RUN find /usr/lib/modules -type f -name "*.ko" -execdir zstd --rm -9 {} \+
 
 RUN systemctl enable systemd-networkd
 RUN systemctl enable ssh


### PR DESCRIPTION
This is potentially dangerous for many reason, first of all it might compress firmwares that is not going to be picked up automatically by drivers which does not support compression. Some drivers, for example, may go looking directly for ucode or bin files without caring about compression.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
