### PR TITLE
:robot: Fix master builds of arm64 artifacts

### DIFF
--- a/.github/workflows/reusable-docker-arm-build.yaml
+++ b/.github/workflows/reusable-docker-arm-build.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Build the docker image
         uses: docker/build-push-action@v6
         with:
-          context: images/
+          context: .
           file: images/Dockerfile
           platforms: linux/arm64
           load: true
@@ -106,10 +106,7 @@ jobs:
             VARIANT=${{ inputs.variant }}
             MODEL=${{ inputs.model }}
             BASE_IMAGE=${{ inputs.base_image }}
-            SOFTWARE_VERSION: ${{ inputs.k3s_version && 'v' || '' }}${{ inputs.k3s_version }}
-            SOFTWARE_VERSION_PREFIX=k3s
-            # renovate: datasource=docker depName=quay.io/kairos/framework versioning=semver
-            FRAMEWORK_VERSION=v2.15.12
+            KUBERNETES_VERSION=${{ inputs.k3s_version && 'v' || '' }}${{ inputs.k3s_version }}
       - name: Grype table
         if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
         uses: anchore/scan-action@v6.0.0
@@ -142,8 +139,8 @@ jobs:
         if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
         uses: docker/build-push-action@v6
         with:
-          context: images/
-          file: images/Dockerfile.kairos-${{ inputs.family }}
+          context: .
+          file: images/Dockerfile
           platforms: linux/arm64
           push: "true"
           tags: ${{ env.IMAGE_REF }}
@@ -151,11 +148,7 @@ jobs:
             VARIANT=${{ inputs.variant }}
             MODEL=${{ inputs.model }}
             BASE_IMAGE=${{ inputs.base_image }}
-            RELEASE=${{ env.RELEASE }}
-            SOFTWARE_VERSION: ${{ inputs.k3s_version && 'v' || '' }}${{ inputs.k3s_version }}
-            SOFTWARE_VERSION_PREFIX=k3s
-            # renovate: datasource=docker depName=quay.io/kairos/framework versioning=semver
-            FRAMEWORK_VERSION=v2.15.12
+            KUBERNETES_VERSION=${{ inputs.k3s_version && 'v' || '' }}${{ inputs.k3s_version }}
       - name: Sign image
         if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
         env:

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ubuntu:20.04
 
-FROM quay.io/kairos/kairos-init:v0.2.2 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.2.3 AS kairos-init
 
 FROM ${BASE_IMAGE} AS base
 ARG VARIANT=core

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ubuntu:20.04
 
-FROM quay.io/kairos/kairos-init:v0.2.0 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.2.1 AS kairos-init
 
 FROM ${BASE_IMAGE} AS base
 ARG VARIANT=core

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ubuntu:20.04
 
-FROM quay.io/kairos/kairos-init:v0.2.1 AS kairos-init
+FROM quay.io/kairos/kairos-init:v0.2.2 AS kairos-init
 
 FROM ${BASE_IMAGE} AS base
 ARG VARIANT=core


### PR DESCRIPTION
Bump kairos-init to fix the nvidia build
On artifact push, use the same as the normal docker build but with push Use the proper Dockerfile
Pass the correct build args for the Kubernetes version Use the main dir as context

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
