### PR TITLE
Disable fips flag for ubnutu example

### DIFF
--- a/examples/builds/ubuntu-fips/Dockerfile
+++ b/examples/builds/ubuntu-fips/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:20.04
 ARG VERSION=v0.0.1
 
 COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug -s install --fips --version "${VERSION}"
+RUN /kairos-init -l debug -s install --version "${VERSION}"
 # Remove default kernel that Kairos-init installs
 RUN apt-get remove -y linux-base linux-image-generic-hwe-20.04 && apt-get autoremove -y
 ## THIS comes from the Ubuntu documentation: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/tutorials/create_a_fips_docker_image.html


### PR DESCRIPTION
We dont support automatic fips for ubuntu so we should not pass that flag and show in the example how to build a ubutu fips image

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
