### PR TITLE
Push cloud images when a new tag is created

### DIFF
--- a/.github/workflows/upload-cloud-images.yaml
+++ b/.github/workflows/upload-cloud-images.yaml
@@ -1,5 +1,8 @@
 name: Upload cloud images
 on:
+  push:
+    tags:
+      - 'v*'  # Triggers on any tag that starts with 'v'
   schedule:
     # Everyday at 2am
     - cron: '0 2 * * *'


### PR DESCRIPTION
because if we have released 3.4.0-beta1 and we then push 3.3.3 that release will never be pushed because the scheduled job only picks the latest tag from master.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
