### PR TITLE
bug: Fix bundle tests

### DIFF
--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -72,7 +72,12 @@ var _ = Describe("kairos bundles test", Label("bundles"), func() {
 
 			By("checking if it has kubo extension", func() {
 				Eventually(func() string {
-					out, _ := vm.Sudo("systemd-sysext")
+					// This seems to not load the /etc/profile.d/systemd-sysext.sh sot it cant use the
+					// SYSTEMD_SYSEXT_HIERARCHIES that we set
+					// So we run the command with login so it loads the envs
+					// Without the SYSTEMD_SYSEXT_HIERARCHIES set to the proper paths it will not
+					// find any extensions
+					out, _ := vm.Sudo("bash -l -c \"systemd-sysext\"")
 					return out
 				}, 3*time.Minute, 10*time.Second).Should(ContainSubstring("kubo"), func() string {
 					// Debug output in case of an error


### PR DESCRIPTION
Now that we enable the same sysext paths for everything we rely in the profile.d setting an enviroment variable to set the sysext paths.

Runnig commands related to sysext service via ssh without a real login does not load any profile files so that env var is not set and it defaults to the normal one which makes it seem like there is no extensions in the system

This changes it so it runs the login for the command so it loads the proper env

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
