### PR TITLE
Fix the nvidia orin build on master

### DIFF
--- a/.github/workflows/reusable-build-flavor.yaml
+++ b/.github/workflows/reusable-build-flavor.yaml
@@ -57,6 +57,14 @@ jobs:
             # Use the base image as the distro
             distro="$base_image"
           fi
+          
+          # Special case for nvidia as we build 2 different images and the base_image is our cached image
+          # For release this makes no sense as we always build the base image anyway
+          # TODO: Add support for nvidia-jetson-agx-orin in kairos-init so we can build it properly
+          if [[ "${{ inputs.model }}" == "nvidia-jetson-agx-orin" ]]; then
+            distro="ubuntu"
+            tag="22.04"
+          fi
 
           echo "flavor=$distro" >> $GITHUB_OUTPUT
           echo "flavor_release=$tag" >> $GITHUB_OUTPUT
@@ -104,7 +112,7 @@ jobs:
             KUBERNETES_VERSION=${{ inputs.kubernetes_version }}
             VERSION=${{ env.VERSION }}
       - name: Build raw image
-        if: ${{ inputs.model != 'rpi3' && inputs.model != 'generic' }}
+        if: ${{ inputs.model != 'rpi3' && inputs.model != 'generic' && inputs.model != 'nvidia-jetson-agx-orin' }}
         run: |
           docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock \
           -v $PWD/build/:/output \

--- a/.github/workflows/reusable-build-flavor.yaml
+++ b/.github/workflows/reusable-build-flavor.yaml
@@ -57,7 +57,7 @@ jobs:
             # Use the base image as the distro
             distro="$base_image"
           fi
-          
+
           # Special case for nvidia as we build 2 different images and the base_image is our cached image
           # For release this makes no sense as we always build the base image anyway
           # TODO: Add support for nvidia-jetson-agx-orin in kairos-init so we can build it properly


### PR DESCRIPTION
Fixed the nvidia orin.

As init doesnt have the full set of packages for orin, we still need to build the base image as a separate thing, then use that as base for init to built the kairos image, which means that the base image does not confoft to what we are expecting as input, which breaks our distro/version separation.

We fix this by fixing the distro and tag manually in the nvidia build  case