### PR TITLE
Add grype ignore file

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -8,6 +8,7 @@
 # Its recommended to check the cve database of the distribution to see if the kernel is affected or not
 # as grype is not always correct
 ignore:
+  # Affected standard images
   - vulnerability: CVE-2025-22871 
     package:
       name: stdlib
@@ -16,6 +17,39 @@ ignore:
     package:
       name: stdlib
       location: /usr/bin/k3s
+  # Affected ubuntu 24.04
+  - vulnerability: CVE-2024-47685
+    package:
+      name: linux-kernel
+      version: 6.8.0-31-generic
+  - vulnerability: CVE-2024-39462
+    package:
+      name: linux-kernel
+      version: 6.8.0-31-generic
+  - vulnerability: CVE-2024-38623
+    package:
+      name: linux-kernel
+      version: 6.8.0-31-generic
+  - vulnerability: CVE-2024-38612
+    package:
+      name: linux-kernel
+      version: 6.8.0-31-generic
+  - vulnerability: CVE-2024-38541
+    package:
+      name: linux-kernel
+      version: 6.8.0-31-generic
+  - vulnerability: CVE-2024-36896
+    package:
+      name: linux-kernel
+      version: 6.8.0-31-generic
+  - vulnerability: CVE-2024-36031
+    package:
+      name: linux-kernel
+      version: 6.8.0-31-generic
+  - vulnerability: CVE-2024-35960
+    package:
+      name: linux-kernel
+      version: 6.8.0-31-generic
   # Affected ubuntu 22.04
   - vulnerability: CVE-2024-47685 
     package:

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,271 @@
+# All the kernel vulnerabilities are ignored because the real cve score is lower than critical
+# grype is very aggressive and marks all of them as critical which makes no sense as there are
+# vulnerabilities from 2021 not fixed yet.
+# Or in some other places it just mixes the version of the kernel
+# A good example is CVE-2023-38427 in Debian 12. It wrongly identifies the kernel version as 6.1.0-33-amd64
+# but you can see in the debian cve database that its not affected because its has a different version
+# https://security-tracker.debian.org/tracker/CVE-2023-38427
+# Its recommended to check the cve database of the distribution to see if the kernel is affected or not
+# as grype is not always correct
+ignore:
+  - vulnerability: CVE-2025-22871 
+    package:
+      name: stdlib
+      location: /usr/bin/kube-vip
+  - vulnerability: CVE-2025-22871 
+    package:
+      name: stdlib
+      location: /usr/bin/k3s
+  # Affected ubuntu 22.04
+  - vulnerability: CVE-2024-47685 
+    package:
+      name: linux-kernel
+      version: 6.8.0-57-generic
+  - vulnerability: CVE-2024-47685 
+    package:
+      name: linux-kernel
+      version: 6.8.0-57-generic
+  - vulnerability: CVE-2024-39462 
+    package:
+      name: linux-kernel
+      version: 6.8.0-57-generic
+  - vulnerability: CVE-2024-38623 
+    package:
+      name: linux-kernel
+      version: 6.8.0-57-generic
+  - vulnerability: CVE-2024-38612 
+    package:
+      name: linux-kernel
+      version: 6.8.0-57-generic
+  - vulnerability: CVE-2024-38541 
+    package:
+      name: linux-kernel
+      version: 6.8.0-57-generic
+  - vulnerability: CVE-2024-36896 
+    package:
+      name: linux-kernel
+      version: 6.8.0-57-generic
+  - vulnerability: CVE-2024-36896 
+    package:
+      name: linux-kernel
+      version: 6.8.0-57-generic
+  - vulnerability: CVE-2024-36031 
+    package:
+      name: linux-kernel
+      version: 6.8.0-57-generic
+  - vulnerability: CVE-2024-35960 
+    package:
+      name: linux-kernel
+      version: 6.8.0-57-generic
+  # Affected ubuntu 20.04
+  - vulnerability: CVE-2024-47685 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2024-38612 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2024-38612 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2024-38541 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2024-35960 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2024-35845 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2024-27053 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2023-52832 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2023-52735 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2022-48716 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2021-47548 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  - vulnerability: CVE-2023-52735 
+    package:
+      name: linux-kernel
+      version: 5.15.0-138-generic
+  # Affected opensuse leap 15.6
+  - vulnerability: CVE-2023-52801 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  - vulnerability: CVE-2023-52832 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  - vulnerability: CVE-2024-27053 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  - vulnerability: CVE-2023-52801 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  - vulnerability: CVE-2024-35845 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  - vulnerability: CVE-2024-35960 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  - vulnerability: CVE-2024-36896 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  - vulnerability: CVE-2024-38541 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  - vulnerability: CVE-2024-38612 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  - vulnerability: CVE-2024-38623 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  - vulnerability: CVE-2024-47685 
+    package:
+      name: linux-kernel
+      version: 6.4.0-150600.23.47-default
+  # Affected debian 12
+  - vulnerability: CVE-2024-47685
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2024-38623
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2024-38612
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2024-38541
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2024-36896
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2024-35960
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2024-35845
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2024-27053
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2023-52832
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2023-52735
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2023-38432
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2023-38431
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2023-38430
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2023-38429
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2023-38428
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2023-38427
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  - vulnerability: CVE-2023-38426
+    package:
+      name: linux-kernel
+      version: 6.1.0-33-amd64
+  # Affected Rockylinux 9
+  - vulnerability: CVE-2024-47685
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2024-38612
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2024-38541
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2024-35960
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2024-35845
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2024-27053
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2023-52832
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2023-52735
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2022-48716
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2021-47548
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2021-47378
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64
+  - vulnerability: CVE-2021-43267
+    package:
+      name: linux-kernel
+      version: 5.14.0-503.38.1.el9_5.x86_64

--- a/grype.yaml
+++ b/grype.yaml
@@ -1,6 +1,0 @@
-ignore:
-- vulnerability: CVE-2025-22871
-  package:
-    name: stdlib
-    vex-status: not_affected
-    vex-justification: vulnerable_code_not_present


### PR DESCRIPTION
grype is not that good on kernel info and uses a database that does not match the real score of the distributions. In some cases, grype reports a 9.1 score while the distribution gave it a 5.4 and didnt consider fixing it because its not that high priority or almost impossible to exploit.

so we are stuck with grype stopping the release while there are no plans on fixing those.

There is some other times that its totally out of our control and probably not even affecting them, like the k3s http golang vuln which is probably not possible on k3s but its being reported as critical.

This is only a workaround but we should probably think about dropping grype if it requires this much handholding and we have to keep adding entries to the ignore becuase its just not good enough.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
