### PR TITLE
Remove upgrade alpine exclude test

### DIFF
--- a/.github/workflows/image-master.yaml
+++ b/.github/workflows/image-master.yaml
@@ -104,9 +104,6 @@ jobs:
           - "reset"
           - "upgrade-with-cli"
           - "upgrade-latest-with-cli"
-        exclude:
-          - test: "upgrade-latest-with-cli"
-            base_image: "alpine:3.21"
         include:
           - test: "install"
             secureboot: true
@@ -132,9 +129,6 @@ jobs:
             base_image: "opensuse/leap:15.6"
           - test: "acceptance"
             base_image: "debian:12"
-          - test: "upgrade-latest-with-cli"
-            base_image: "alpine:3.21"
-            release-matcher: "kairos-alpine-3.19-core-amd64-generic-*.iso"
   netboot-tests:
     name: ${{ matrix.base_image }}
     uses: ./.github/workflows/reusable-qemu-netboot-test.yaml

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -69,9 +69,6 @@ jobs:
           - "reset"
           - "upgrade-with-cli"
           - "upgrade-latest-with-cli"
-        exclude:
-          - test: "upgrade-latest-with-cli"
-            base_image: "alpine:3.21"
         include:
           - test: "install"
             secureboot: true
@@ -80,9 +77,6 @@ jobs:
             base_image: "ubuntu:24.04"
           - test: "bundles"
             base_image: "ubuntu:24.04"
-          - test: "upgrade-latest-with-cli"
-            base_image: "alpine:3.21"
-            release-matcher: "kairos-alpine-3.19-core-amd64-generic-*.iso"
   netboot-tests:
     name: ${{ matrix.base_image }}
     uses: ./.github/workflows/reusable-qemu-netboot-test.yaml


### PR DESCRIPTION
Now that there is an alpine 3.21 release, we no longer need the upgrade job to use a release matcher to match the previous release as it will match with 3.21 so we can remove the exclude and just run the job as the others

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
