### PR TITLE
Keep the v in the kubernetes version

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -73,8 +73,8 @@ jobs:
           echo "flavor_release=$tag" >> $GITHUB_OUTPUT
       - name: Set Image Tag
         run: |
-          # Replace + with - in kubernetes version as we use it in the image tag. Remove v as well
-          sanitized_kubernetes_version=$(echo "${{ inputs.kubernetes_version }}" | sed 's/^v//; s/+/-/g')
+          # Replace + with - in kubernetes version as we use it in the image tag.
+          sanitized_kubernetes_version=$(echo "${{ inputs.kubernetes_version }}" | sed 's/+/-/g')
           if [ -n "${sanitized_kubernetes_version}" ]; then
             echo "IMAGE_TAG=quay.io/kairos/${{ steps.split.outputs.flavor }}:${{ steps.split.outputs.flavor_release }}-${{ inputs.variant }}-${{ inputs.arch }}-${{ inputs.model }}-${{ github.ref_name }}-${{ inputs.kubernetes_distro }}${sanitized_kubernetes_version}${{ inputs.trusted_boot != 'false' && '-uki' || '' }}" >> $GITHUB_ENV
             echo "ISO_NAME=kairos-${{ steps.split.outputs.flavor }}-${{ steps.split.outputs.flavor_release }}-${{ inputs.variant }}-${{ inputs.arch }}-${{ inputs.model }}-${{ github.ref_name }}${{ inputs.kubernetes_distro }}${sanitized_kubernetes_version}${{ inputs.trusted_boot != 'false' && '-uki' || '' }}" >> $GITHUB_ENV


### PR DESCRIPTION
By mistake the v was clean off but our artifacts all have the v in front of the k8s provider version

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
