### PR TITLE
Fixed RPi WiFi example

### DIFF
--- a/examples/cloud-configs/wifi.yaml
+++ b/examples/cloud-configs/wifi.yaml
@@ -13,7 +13,7 @@ stages:
   initramfs:
     - name: "Setup wireless"
       files:
-      - path: /etc/wpa_supplicant/wpa_supplicant-wlan0.conf
+      - path: /etc/wpa_supplicant/wpa_supplicant.conf
         content: |
           # This file should be generated using wpa_passphrase
           ctrl_interface=/var/run/wpa_supplicant
@@ -25,7 +25,18 @@ stages:
         permissions: 0600
         owner: 0
         group: 0
-
+      - path: /etc/systemd/network/20-dhcp-wlan0.network
+        content: |
+          [Match]
+          Name=wlan0
+          [Network]
+          DHCP=yes
+          [DHCP]
+          ClientIdentifier=mac
+        permissions: 0644
+        owner: 0
+        group: 0
+  
   boot:
     - name: "Enabling wireless"
       commands:


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

Without this patch, WPA supplicant errored due to the default config using the `wheel` user, and DHCP wasn't run to get an IPv4 address. I can confirm this works as expected on a Raspberry Pi 4 B+


