### PR TITLE
📖 Fix documentation URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Kairos can be used to:
 - Manage the cluster lifecycle with Kubernetes—from building to provisioning, and upgrading :rocket:
 - Create a multiple—node, a single cluster that spans up across regions :earth_africa:
 
-For comprehensive docs, tutorials, and examples see our [documentation](https://kairos.io/docs/getting-started/).
+For comprehensive docs, tutorials, and examples see our [documentation](https://kairos.io/getting-started/).
 
 ## Project status
 


### PR DESCRIPTION
Update getting started documentation link from /docs/getting-started/ to /getting-started/ to resolve broken URL reference.

**What this PR does / why we need it**:

Fixes a broken documentation URL in the README that was causing a 404 error. The getting started documentation link was pointing to `/docs/getting-started/` but the correct path is `/getting-started/`. This ensures users can properly access the getting started documentation when clicking the link from the README.
