### PR TITLE
Improve Alpine WiFi example

### DIFF
--- a/examples/cloud-configs/wifi-alpine.yaml
+++ b/examples/cloud-configs/wifi-alpine.yaml
@@ -13,13 +13,15 @@ stages:
   initramfs:
     - name: Setup wireless
       files:
-        # Generate manually by following https://wiki.archlinux.org/title/ConnMan and add contents below
-        - path: /var/lib/connman/wifi_xxxxxxxxxxxx_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz_managed_psk/settings
+        # See https://man.archlinux.org/man/connman-service.config.5
+        - path: /var/lib/connman/home_wifi.config
           permissions: 0600
           content: |
-            [wifi_xxxxxxxxxxxx_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz_managed_psk]
-            Name=Your_SSID
-            ...etc...
+            [service_home_wifi]
+            Type = wifi
+            Name = your_ssid
+            Passphrase = your_wifi_password
+            IPv4 = dhcp
   boot:
     - name: Enable wireless
       commands:


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

Remove need for manually generating WiFI config on a working system and then copying into cloud-config. Now you can just add your WiFi network details and it will connect on first boot
