### PR TITLE
Run everything in a liner

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -11,7 +11,4 @@ ARG KUBERNETES_VERSION
 ARG VERSION
 
 COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug -s install -m "${MODEL}" -t "${TRUSTED_BOOT}" -k "${KUBERNETES_DISTRO}" --k8sversion "${KUBERNETES_VERSION}" --version "${VERSION}"
-RUN /kairos-init -l debug -s init -m "${MODEL}" -t "${TRUSTED_BOOT}" -k "${KUBERNETES_DISTRO}" --k8sversion "${KUBERNETES_VERSION}" --version "${VERSION}"
-RUN /kairos-init validate -t "${TRUSTED_BOOT}"
-RUN rm /kairos-init
+RUN /kairos-init -l debug -m "${MODEL}" -t "${TRUSTED_BOOT}" -k "${KUBERNETES_DISTRO}" --k8sversion "${KUBERNETES_VERSION}" --version "${VERSION}" && /kairos-init validate -t "${TRUSTED_BOOT}" && rm /kairos-init


### PR DESCRIPTION
This saves a lot of space from the final image due to how docker works

Now that the build and init process its more stable we can put everything in a single line to save space from the final artifacts

On local tests with a single ubuntu image, this saved about 200Mb from the oci artifact, plus less layers to push and pull

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
