### PR TITLE
Mount kairos-init instead of copying during image build

### DIFF
--- a/examples/builds/fedora-fips/Dockerfile
+++ b/examples/builds/fedora-fips/Dockerfile
@@ -3,14 +3,14 @@ FROM quay.io/kairos/kairos-init:v0.5.1 AS kairos-init
 FROM fedora:40
 ARG VERSION=v0.0.1
 
-COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug -s install --fips --version "${VERSION}"
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -s install --fips --version "${VERSION}"
 
 # Copy the custom dracut config file which enables fips
 COPY dracut.conf /etc/dracut.conf.d/kairos-fips.conf
 
-RUN /kairos-init -l debug -s init --version "${VERSION}"
-RUN rm /kairos-init
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -s init --version "${VERSION}"
 
 # Symlink kernel HMAC
 RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && ln -sf ."${kernel#/boot/}".hmac /boot/.vmlinuz.hmac

--- a/examples/builds/rockylinux-fips/Dockerfile
+++ b/examples/builds/rockylinux-fips/Dockerfile
@@ -3,13 +3,13 @@ FROM quay.io/kairos/kairos-init:v0.5.1 AS kairos-init
 FROM rockylinux:9
 ARG VERSION=v0.0.1
 
-COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug -s install --fips --version "${VERSION}"
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -s install --fips --version "${VERSION}"
 # Copy the custom dracut config file
 COPY dracut.conf /etc/dracut.conf.d/kairos-fips.conf
 
-RUN /kairos-init -l debug -s init --version "${VERSION}"
-RUN rm /kairos-init
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -s init --version "${VERSION}"
 
 # Symlink kernel HMAC
 RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && ln -sf ."${kernel#/boot/}".hmac /boot/.vmlinuz.hmac

--- a/examples/builds/ubuntu-20.04-fips/Dockerfile
+++ b/examples/builds/ubuntu-20.04-fips/Dockerfile
@@ -3,8 +3,8 @@ FROM quay.io/kairos/kairos-init:v0.5.1 AS kairos-init
 FROM ubuntu:20.04
 ARG VERSION=v0.0.1
 
-COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug -s install --version "${VERSION}"
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -s install --version "${VERSION}"
 # Remove default kernel that Kairos-init installs
 RUN apt-get remove -y linux-base linux-image-generic-hwe-20.04 && apt-get autoremove -y
 ## THIS comes from the Ubuntu documentation: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/tutorials/create_a_fips_docker_image.html
@@ -20,8 +20,8 @@ RUN --mount=type=secret,id=pro-attach-config \
 # Copy the custom dracut config file which enables fipsn
 COPY dracut.conf /etc/dracut.conf.d/kairos-fips.conf
 
-RUN /kairos-init -l debug -s init --version "${VERSION}"
-RUN rm /kairos-init
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -s init --version "${VERSION}"
 
 # Symlink kernel HMAC
 RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && ln -sf ."${kernel#/boot/}".hmac /boot/.vmlinuz.hmac

--- a/examples/builds/ubuntu-22.04-fips/Dockerfile
+++ b/examples/builds/ubuntu-22.04-fips/Dockerfile
@@ -3,8 +3,8 @@ FROM quay.io/kairos/kairos-init:v0.5.1 AS kairos-init
 FROM ubuntu:22.04
 ARG VERSION=v0.0.1
 
-COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug -s install --version "${VERSION}"
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -s install --version "${VERSION}"
 # Remove default kernel that Kairos-init installs
 RUN apt-get remove -y linux-base linux-image-generic-hwe-22.04 && apt-get autoremove -y
 ## THIS comes from the Ubuntu documentation: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/tutorials/create_a_fips_docker_image.html
@@ -21,8 +21,8 @@ RUN --mount=type=secret,id=pro-attach-config \
 COPY modules.fips /tmp/modules.fips
 RUN kernel=$(ls /lib/modules | head -n1) && mv /tmp/modules.fips /lib/modules/${kernel}/modules.fips
 
-RUN /kairos-init -l debug -s init --version "${VERSION}"
-RUN rm /kairos-init
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -s init --version "${VERSION}"
 
 # Symlink kernel HMAC
 RUN kernel=$(ls /boot/vmlinuz-* | head -n1) && ln -sf ."${kernel#/boot/}".hmac /boot/.vmlinuz.hmac

--- a/examples/builds/ubuntu-non-hwe/Dockerfile
+++ b/examples/builds/ubuntu-non-hwe/Dockerfile
@@ -3,11 +3,11 @@ FROM quay.io/kairos/kairos-init:v0.5.1 AS kairos-init
 FROM ubuntu:22.04 AS base-kairos
 ARG VERSION=v0.0.1
 
-COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug -s install --version "${VERSION}"
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -s install --version "${VERSION}"
 # Remove default kernel that Kairos-init installs
 RUN apt-get remove -y linux-base linux-image-generic-hwe-22.04 && apt-get autoremove -y
 # Install generic linux image instead
 RUN apt-get install -y --no-install-recommends linux-image-generic
-RUN /kairos-init -l debug -s init --version "${VERSION}"
-RUN rm /kairos-init
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init -l debug -s init --version "${VERSION}"

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -11,4 +11,4 @@ ARG KUBERNETES_VERSION
 ARG VERSION
 
 RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
-    kairos-init -l debug -m "${MODEL}" -t "${TRUSTED_BOOT}" -k "${KUBERNETES_DISTRO}" --k8sversion "${KUBERNETES_VERSION}" --version "${VERSION}" && /kairos-init validate -t "${TRUSTED_BOOT}"
+    /kairos-init -l debug -m "${MODEL}" -t "${TRUSTED_BOOT}" -k "${KUBERNETES_DISTRO}" --k8sversion "${KUBERNETES_VERSION}" --version "${VERSION}" && /kairos-init validate -t "${TRUSTED_BOOT}"

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -10,5 +10,5 @@ ARG KUBERNETES_DISTRO
 ARG KUBERNETES_VERSION
 ARG VERSION
 
-COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug -m "${MODEL}" -t "${TRUSTED_BOOT}" -k "${KUBERNETES_DISTRO}" --k8sversion "${KUBERNETES_VERSION}" --version "${VERSION}" && /kairos-init validate -t "${TRUSTED_BOOT}" && rm /kairos-init
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    kairos-init -l debug -m "${MODEL}" -t "${TRUSTED_BOOT}" -k "${KUBERNETES_DISTRO}" --k8sversion "${KUBERNETES_VERSION}" --version "${VERSION}" && /kairos-init validate -t "${TRUSTED_BOOT}"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes how the kairos-init is made available during the build, instead copying it and bloat the image size it just mounts it during the RUN command, saving up ~100MB on each image build.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
