### PR TITLE
Use Kairos Factory GitHub Action

### DIFF
--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -29,7 +29,7 @@ jobs:
       registry_domain: "quay.io"
       registry_namespace: "kairos"
       registry_repository: "ci-temp-images"
-      custom_tag_format: "$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$SHA"
+      custom_tag_format: "$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$COMMIT_SHA"
       custom_artifact_format: "kairos-$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL"
       image_labels: "quay.expires-after=6h"
       summary_artifacts: true


### PR DESCRIPTION
This is consuming https://github.com/kairos-io/kairos-factory-action, if we agree that the use is the one we would like to have and expose to our users, then I'd start doing the same for image-pr-arm, master, master-arm and so on. Once all of them have been moved, we can get read of reusable-build-flavor workflow and such. I'll create tickets for all of it if this is the way we want to go.

Todo:

- [x] change requested tests names in the configuration of the repo
