### PR TITLE
Fix ubuntu fips build for SB

### DIFF
--- a/examples/builds/ubuntu-20.04-fips/Dockerfile
+++ b/examples/builds/ubuntu-20.04-fips/Dockerfile
@@ -9,12 +9,14 @@ RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
 RUN apt-get remove -y linux-base linux-image-generic-hwe-20.04 && apt-get autoremove -y
 ## THIS comes from the Ubuntu documentation: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/tutorials/create_a_fips_docker_image.html
 ## I've just added "linux-image-fips" in the package list
+## If you want to use secureboot with fips, you need to install the shim-signed package
+## from the Ubuntu PRO repos as its signed with adifferent key
 RUN --mount=type=secret,id=pro-attach-config \
     apt-get update \
     && apt-get install --no-install-recommends -y ubuntu-advantage-tools ca-certificates \
     && pro attach --attach-config /run/secrets/pro-attach-config \
     && apt-get upgrade -y \
-    && apt-get install -y openssl libssl1.1 libssl1.1-hmac libgcrypt20 libgcrypt20-hmac strongswan strongswan-hmac openssh-client openssh-server linux-image-fips \
+    && apt-get install -y openssl libssl1.1 libssl1.1-hmac libgcrypt20 libgcrypt20-hmac strongswan strongswan-hmac openssh-client openssh-server linux-image-fips shim-signed \
     && pro detach --assume-yes
 
 # Copy the custom dracut config file which enables fipsn

--- a/examples/builds/ubuntu-22.04-fips/Dockerfile
+++ b/examples/builds/ubuntu-22.04-fips/Dockerfile
@@ -9,12 +9,14 @@ RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
 RUN apt-get remove -y linux-base linux-image-generic-hwe-22.04 && apt-get autoremove -y
 ## THIS comes from the Ubuntu documentation: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/tutorials/create_a_fips_docker_image.html
 ## I've just added "linux-image-fips" in the package list
+## If you want to use secureboot with fips, you need to install the shim-signed package
+## from the Ubuntu PRO repos as its signed with adifferent key
 RUN --mount=type=secret,id=pro-attach-config \
     apt-get update \
     && apt-get install --no-install-recommends -y ubuntu-advantage-tools ca-certificates \
     && pro attach --attach-config /run/secrets/pro-attach-config \
     && apt-get upgrade -y \
-    && apt-get install -y strongswan strongswan-hmac openssh-client openssh-server linux-image-fips \
+    && apt-get install -y strongswan strongswan-hmac openssh-client openssh-server linux-image-fips shim-signed \
     && pro detach --assume-yes
 
 # Copy the custom dracut modules.fips that includes 2 missing modules


### PR DESCRIPTION
We need to install shim-signed from the Pro FIPS repos as it has a different signature and needs to match with the grub and kernel signatures

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kairos-io/kairos/issues/3542
