### PR TITLE
feat: update IPFS version and Dockerfile configuration

### DIFF
--- a/examples/bundle/Dockerfile
+++ b/examples/bundle/Dockerfile
@@ -1,14 +1,17 @@
-FROM alpine AS build
+FROM golang AS build
 
 # Install a binary
-RUN wget https://github.com/ipfs/kubo/releases/download/v0.15.0/kubo_v0.15.0_linux-amd64.tar.gz -O kubo.tar.gz
-RUN tar xvf kubo.tar.gz
-RUN mv kubo/ipfs /usr/bin/ipfs
-RUN mkdir -p /usr/lib/extension-release.d/
+RUN git clone -b v0.38.0 https://github.com/ipfs/kubo.git /kubo
+WORKDIR /kubo
+RUN CGO_ENABLED=0 go build -o ipfs ./cmd/ipfs
+WORKDIR /bundle
+RUN mkdir -p /bundle/usr/bin
+RUN mv /kubo/ipfs /bundle/usr/bin/ipfs
+RUN mkdir -p /bundle/usr/lib/extension-release.d/
 # systemd version 252+ is necessary in order to use the special key _any here
-RUN echo ID=_any > /usr/lib/extension-release.d/extension-release.kubo
+RUN echo ID=_any > /bundle/usr/lib/extension-release.d/extension-release.kubo
 
 FROM scratch
 
-COPY --from=build /usr/bin/ipfs /usr/bin/ipfs
-COPY --from=build /usr/lib/extension-release.d /usr/lib/extension-release.d
+COPY --from=build /bundle/usr/bin/ipfs /usr/bin/ipfs
+COPY --from=build /bundle/usr/lib/extension-release.d /usr/lib/extension-release.d

--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -99,7 +99,7 @@ var _ = Describe("kairos bundles test", Label("bundles"), func() {
 
 				ipfsV, err := vm.Sudo("ipfs version")
 				Expect(err).ToNot(HaveOccurred(), ipfsV)
-				Expect(ipfsV).To(ContainSubstring("0.15.0"))
+				Expect(ipfsV).To(ContainSubstring("0.38.0"))
 			})
 
 			By("checking that there are no duplicate entries in the config (issue#2019)", func() {


### PR DESCRIPTION
- Updated IPFS version from 0.15.0 to 0.38.0 in tests
- Changed Dockerfile to build IPFS from source using version 0.38.0
- Adjusted paths for binary and extension-release configuration

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
