### PR TITLE
chore: remove opensuse tumbleweed from base images

### DIFF
--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         base_image:
           - "opensuse/leap:15.6"
-          - "opensuse/tumbleweed:latest"
           - "ubuntu:20.04"
           - "ubuntu:22.04"
           - "ubuntu:24.04"
@@ -118,7 +117,6 @@ jobs:
         kubernetes_version: ${{ fromJson(needs.get-k3s-versions.outputs.kubernetes_versions) }}
         base_image:
           - "opensuse/leap:15.6"
-          - "opensuse/tumbleweed:latest"
           - "ubuntu:20.04"
           - "ubuntu:22.04"
           - "ubuntu:24.04"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         base_image:
           - "opensuse/leap:15.6"
-          - "opensuse/tumbleweed:latest"
           - "ubuntu:20.04"
           - "ubuntu:22.04"
           - "ubuntu:24.04"
@@ -147,7 +146,6 @@ jobs:
         kubernetes_version: ${{ fromJson(needs.get-k3s-versions.outputs.kubernetes_versions) }}
         base_image:
           - "opensuse/leap:15.6"
-          - "opensuse/tumbleweed:latest"
           - "ubuntu:20.04"
           - "ubuntu:22.04"
           - "ubuntu:24.04"


### PR DESCRIPTION
- Removed "opensuse/tumbleweed:latest" from base image configurations in release.yaml and release-arm.yaml
- This change is made to streamline the build process and avoid potential issues with the tumbleweed image.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kairos-io/kairos/issues/3722
