### PR TITLE
Set registry_domain so that we push the produced images

### DIFF
--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -67,6 +67,8 @@ jobs:
       arch: "arm64"
       model: "rpi4"
       version: "auto"
+      registry_domain: "quay.io"
+      registry_namespace: "kairos"
       grype: true
       grype_sarif: true
       trivy: true
@@ -132,6 +134,8 @@ jobs:
       kubernetes_version: ${{ matrix.kubernetes_version }}
       kubernetes_distro: "k3s"
       version: "auto"
+      registry_domain: "quay.io"
+      registry_namespace: "kairos"
       iso: true
       grype: true
       grype_sarif: true
@@ -168,6 +172,8 @@ jobs:
       kubernetes_version: ${{ matrix.kubernetes_version }}
       kubernetes_distro: "k3s"
       version: "auto"
+      registry_domain: "quay.io"
+      registry_namespace: "kairos"
       grype: true
       grype_sarif: true
       trivy: true
@@ -228,6 +234,8 @@ jobs:
       arch: "arm64"
       model: "nvidia-jetson-agx-orin"
       version: "auto"
+      registry_domain: "quay.io"
+      registry_namespace: "kairos"
       grype: true
       grype_sarif: true
       trivy: true


### PR DESCRIPTION
That's the condition used here:

https://github.com/kairos-io/kairos-factory-action/blob/a9439a91ef3c968c99a6d50209fa8e2db22afb85/.github/workflows/reusable-factory.yaml#L609C1-L609C41

Fixes https://github.com/kairos-io/kairos/issues/3756
