### PR TITLE
:robot: Also build k0s images for ubuntu:24.04 when releasing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,6 +197,7 @@ jobs:
         kubernetes_version: ${{ fromJson(needs.get-k0s-versions.outputs.kubernetes_versions) }}
         base_image:
           - "opensuse/leap:15.6"
+          - "ubuntu:24.04"
           - "ubuntu:25.10"
           - "rockylinux:9"
     secrets:


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:
Having trouble upgrading to Kairos v3.6.0 from v3.5.5 or v3.5.10 (to test kairos-io/kairos-agent#1018).

As v.3.6.0 only provides k0s with Ubuntu 25.10, I can't be sure if my issue is caused by Kairos or OS version upgrade. Having a released Kairos image with the same OS version as I'm currently using would help.

I also saw that *k3s* images are released with more OSs and versions than *k0s*. I only needed to test it with Ubuntu 24.04 but feel free to add others to align both supported Kubernetes distributions.