### PR TITLE
Change treshold for new maintainer vote to 100%

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -3,7 +3,7 @@
 profiles:
   default:
     duration: 4w
-    pass_threshold: 10
+    pass_threshold: 100
     allowed_voters:
       teams:
         - maintainers
@@ -12,7 +12,7 @@ profiles:
     close_on_passing_min_wait: null
   maintainer-application:
     duration: 4w
-    pass_threshold: 10
+    pass_threshold: 100
     allowed_voters:
       teams:
         - maintainers


### PR DESCRIPTION
Checked with @mudler for the rules on this and we'll have 100% treshold from everyone in @kairos-io/maintainers 