### PR TITLE
Pin setup-buildx-action to v3

### DIFF
--- a/.github/workflows/image-master-arm.yaml
+++ b/.github/workflows/image-master-arm.yaml
@@ -105,10 +105,10 @@ jobs:
           df -h
       - name: Set up Docker Buildx
         if: ${{ steps.cache.outputs.cache_available == 'false' || steps.changed-files.outputs.nvidia_any_changed == 'true' && runner.environment == 'github-hosted' }}
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3
       - name: Set up Docker Buildx for custom runners
         if: ${{ steps.cache.outputs.cache_available == 'false' || steps.changed-files.outputs.nvidia_any_changed == 'true' && runner.environment == 'self-hosted' }}
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3
         with:
           buildkitd-config-inline: |
             [registry."docker.io"]

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -200,10 +200,10 @@ jobs:
           fetch-depth: 0
       - name: Set up Docker Buildx for public runners
         if: runner.environment == 'github-hosted'
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3
       - name: Set up Docker Buildx for custom runners
         if: runner.environment == 'self-hosted'
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3
         with:
           buildkitd-config-inline: |
             [registry."docker.io"]

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -89,10 +89,10 @@ jobs:
           cache: ${{ runner.environment == 'self-hosted' && 'false' || 'true' }}
       - name: Set up Docker Buildx for public runners
         if: runner.environment == 'github-hosted'
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3
       - name: Set up Docker Buildx for custom runners
         if: runner.environment == 'self-hosted'
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3
         with:
           buildkitd-config-inline: |
             [registry."docker.io"]


### PR DESCRIPTION
because using `master` will eventually fail. Currently fails on master with:

```
Error: ERROR: failed to initialize builder builder-5c8f04e0-e3af-417d-b07d-2b1a81886763 (builder-5c8f04e0-e3af-417d-b07d-2b1a818867630): Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.43
```

see here: https://github.com/kairos-io/kairos/actions/runs/21238656935/job/61112121151