### PR TITLE
fix: Update voting commands in YAML and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/contributor_nomination.md
+++ b/.github/ISSUE_TEMPLATE/contributor_nomination.md
@@ -46,7 +46,7 @@ See: https://github.com/kairos-io/community/blob/main/GOVERNANCE.md
 ## Process
 
 1. **Review**: Maintainers/approvers review the nomination and may ask questions.
-2. **Voting**: A maintainer comments `/vote-contributor-application` to start a vote.
+2. **Voting**: A maintainer comments `/vote-contributor` to start a vote.
    - Requires 2 positive votes from maintainers or admins.
    - Voting period is up to 4 weeks.
 3. **Onboarding**: Once approved, an onboarding issue is automatically created.

--- a/.github/ISSUE_TEMPLATE/maintainer_application.md
+++ b/.github/ISSUE_TEMPLATE/maintainer_application.md
@@ -93,7 +93,7 @@ These are the traits we’ll look for during the review (from the governance “
 
 **What happens**
 - Kairos maintainers vote to accept (or reject) the application.
-- To start the voting process, a maintainer should comment: `/vote`
+- To start the voting process, a maintainer should comment: `/vote-maintainer`
 - This will initiate a 4-week voting period where maintainers can cast their votes.
 
 **Timing**

--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -10,7 +10,8 @@ profiles:
       exclude_team_maintainers: false
     close_on_passing: true
     close_on_passing_min_wait: null
-  maintainer-application:
+  # Use with: /vote-maintainer
+  maintainer:
     duration: 4w
     pass_threshold: 100
     allowed_voters:
@@ -21,8 +22,8 @@ profiles:
     close_on_passing_min_wait: null
   # Profile for adding new contributors
   # Requires at least 2 positive votes from maintainers or admins (33% of 6 voters)
-  # Use with: /vote-contributor-application
-  contributor-application:
+  # Use with: /vote-contributor
+  contributor:
     duration: 4w
     pass_threshold: 33
     allowed_voters:


### PR DESCRIPTION
- Changed maintainer and contributor application commands in .gitvote.yml and related issue templates to simplify the voting process. Becuase otherwise they cannot be initiatied with a hyphen in-between
- Updated comments to reflect the new command usage for starting votes.

