### PR TITLE
feat: Enable concurrent execution in vmForEach function

### DIFF
--- a/tests/provider_decentralized_test.go
+++ b/tests/provider_decentralized_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -217,10 +218,16 @@ func HaveMinMaxRole(name string, min, max int) types.GomegaMatcher {
 }
 
 func vmForEach(description string, vms []VM, action func(vm VM)) {
+	var wg sync.WaitGroup
 	for i, vm := range vms {
-		By(fmt.Sprintf("%s [%s]", description, strconv.Itoa(i+1)))
-		action(vm)
+		wg.Add(1)
+		go func(i int, vm VM) {
+			defer wg.Done()
+			By(fmt.Sprintf("%s [%s]", description, strconv.Itoa(i+1)))
+			action(vm)
+		}(i, vm)
 	}
+	wg.Wait()
 }
 
 func cloudConfig(token string) string {


### PR DESCRIPTION
- Added a WaitGroup to allow concurrent processing of VMs
- Each VM action is now executed in a separate goroutine
- This change improves performance by reducing execution time for multiple VMs

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
