### PR TITLE
📖 Add KubeStellar Console guided install to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For comprehensive docs, tutorials, and examples see our [documentation](https://
 
 | Integration | Description |
 |---|---|
-| [KubeStellar Console](https://console.kubestellar.io/missions/install-kairos) | Guided install mission with pre-flight checks, step-by-step commands, validation, troubleshooting, and rollback. The [mission definition](https://github.com/kubestellar/console-kb/blob/master/solutions/cncf-install/install-kairos.json) is open source — PRs welcome. |
+| [KubeStellar Console](https://console.kubestellar.io/missions/install-kairos) | Guided install mission with pre-flight checks, step-by-step commands, validation, troubleshooting, and rollback. The [mission definition](https://github.com/kubestellar/console-kb/blob/master/fixes/cncf-install/install-kairos.json) is open source — PRs welcome. |
 
 ## Project status
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Kairos can be used to:
 
 For comprehensive docs, tutorials, and examples see our [documentation](https://kairos.io/getting-started/).
 
+## Integrations
+
+| Integration | Description |
+|---|---|
+| [KubeStellar Console](https://console.kubestellar.io/missions/install-kairos) | Guided install mission with pre-flight checks, step-by-step commands, validation, troubleshooting, and rollback. The [mission definition](https://github.com/kubestellar/console-kb/blob/master/solutions/cncf-install/install-kairos.json) is open source — PRs welcome. |
+
 ## Project status
 
 Check the [Roadmap](https://github.com/orgs/kairos-io/projects/2) for a high-level view of what features are coming to Kairos.


### PR DESCRIPTION
## Summary

- Adds an **Integrations** section to the README with a reference to the [KubeStellar Console guided install mission for Kairos](https://console.kubestellar.io/missions/install-kairos)
- The mission provides step-by-step installation with pre-flight checks, validation, troubleshooting, and rollback
- The [mission definition](https://github.com/kubestellar/console-kb/blob/master/fixes/cncf-install/install-kairos.json) is open source — PRs welcome

## Context

Per @mudler's request in #4014:

> we are already in the process of updating our documentation to refer to integrations (#4004) — do you have any documentation page we can link to?

This PR seeds the Integrations section proposed in #4004 with the first entry. The table format makes it easy to add more integrations as they come in.

KubeStellar Console is a CNCF project dashboard with guided install missions for 185+ CNCF projects. The Kairos mission walks users through installation with pre-flight checks, copy-paste commands, post-step validation, troubleshooting, and rollback — all against a live cluster via kubeconfig, or as read-only documentation without a cluster connection.

Closes #4014
Ref #4004