### PR TITLE
Ignore grype cve until k0s/k3s have a fix

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -22,3 +22,15 @@ ignore:
     package:
       name: stdlib
       location: /usr/bin/edgevpn
+
+  # CVE-2026-27143 is a stdlib vulnerability fixed in go1.25.9/1.26.2.
+  # k3s and k0s have not yet cut releases built with a fixed Go toolchain.
+  # Remove these ignores once k3s and k0s ship binaries built with go1.25.9+ or go1.26.2+.
+  - vulnerability: CVE-2026-27143
+    package:
+      name: stdlib
+      location: /usr/bin/k3s
+  - vulnerability: CVE-2026-27143
+    package:
+      name: stdlib
+      location: /usr/bin/k0s

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ubuntu:20.04
-ARG KAIROS_INIT=v0.8.4
+ARG KAIROS_INIT=v0.8.6
 
 FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
 


### PR DESCRIPTION
also bump kairos-init to bump versions

Should fix: https://github.com/kairos-io/kairos/issues/4048

if we release but if we don't release for a while, the fix might make it in k0s/k3s and we can skip this.
