### PR TITLE
feat: bump hadron base image to v0.2.0

### DIFF
--- a/.github/workflows/image-master-arm.yaml
+++ b/.github/workflows/image-master-arm.yaml
@@ -45,19 +45,19 @@ jobs:
         include:
           - image_name: "hadron"
             model: "generic"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             cleanup: false
             grype: true
             custom_job_name_format: "core-arm64-generic"
           - image_name: "hadron"
             model: "rpi4"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             cleanup: false
             grype: true
             custom_job_name_format: "core-arm64-rpi4"
           - image_name: "hadron"
             model: "rpi3"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             cleanup: false
             grype: true
             custom_job_name_format: "core-arm64-rpi3"

--- a/.github/workflows/image-master.yaml
+++ b/.github/workflows/image-master.yaml
@@ -44,10 +44,10 @@ jobs:
       matrix:
         include:
           - image_name: "hadron"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             kubernetes_distro: ""
             custom_job_name_format: "core-amd64-generic"
           - image_name: "hadron"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             kubernetes_distro: "k3s"
             custom_job_name_format: "standard-amd64-generic-k3s"

--- a/.github/workflows/image-pr-arm.yaml
+++ b/.github/workflows/image-pr-arm.yaml
@@ -24,19 +24,19 @@ jobs:
         include:
           - image_name: "hadron"
             model: "rpi4"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             cleanup: false
             grype: true
             custom_job_name_format: "core-arm64-rpi4"
           - image_name: "hadron"
             model: "rpi3"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             cleanup: false
             grype: true
             custom_job_name_format: "core-arm64-rpi3"
           - image_name: "hadron"
             model: "generic"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             cleanup: false
             grype: true
             custom_job_name_format: "core-arm64-generic"

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -75,7 +75,7 @@ jobs:
           - test: "upgrade-with-cli"
           - test: "bundles"
           - test: "upgrade-latest-with-cli"
-            release-matcher: "kairos-hadron-0.0.1-core-amd64-generic-v4.0.0.iso"
+            release-matcher: "kairos-hadron-*-core-amd64-generic-v*.iso"
   standard-tests:
     name: ${{ format('standard-tests (hadron, amd64, generic) {0}', matrix.test) }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
@@ -121,4 +121,4 @@ jobs:
           - test: "encryption-remote-https-pinned"
           - test: "encryption-remote-https-bad-cert"
           - test: "provider-upgrade-latest-k8s-with-kubernetes"
-            release-matcher: "kairos-hadron-0.0.1-standard-amd64-generic-*k3sv*.iso"
+            release-matcher: "kairos-hadron-*-standard-amd64-generic-*k3sv*.iso"

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         include:
           - image_name: "hadron"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             kubernetes_distro: ""
             custom_job_name_format: "core-amd64-generic"
           - image_name: "hadron"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             kubernetes_distro: "k3s"
             custom_job_name_format: "standard-amd64-generic-k3s"
     with:
@@ -54,7 +54,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
-      base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+      base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
       test: ${{ matrix.test }}
       secureboot: false
       release-matcher: ${{ matrix.release-matcher || '' }}
@@ -96,7 +96,7 @@ jobs:
       repository-projects: read
       statuses: read
     with:
-      base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+      base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
       test: ${{ matrix.test }}
       variant: "standard"
       arch: "amd64"

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - "ghcr.io/kairos-io/hadron:v0.0.4"
+          - "ghcr.io/kairos-io/hadron:v0.2.0"
         model:
           - "generic"
           - "rpi4"
@@ -30,13 +30,13 @@ jobs:
         grype: [true]
         include:
           - image_name: "hadron"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             model: "generic"
             cleanup: true
             grype: true
             custom_job_name_format: "core-arm64-generic"
           - image_name: "hadron"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             model: "rpi4"
             cleanup: true
             grype: true
@@ -120,7 +120,7 @@ jobs:
       matrix:
         kubernetes_version: ${{ fromJson(needs.get-k3s-versions.outputs.kubernetes_versions) }}
         base_image:
-          - "ghcr.io/kairos-io/hadron:v0.0.4"
+          - "ghcr.io/kairos-io/hadron:v0.2.0"
         model:
           - "generic"
           - "rpi4"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,11 +19,11 @@ jobs:
       matrix:
         include:
           - image_name: "hadron"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             trusted_boot: false
             custom_job_name_format: "core-amd64-generic"
           - image_name: "hadron"
-            base_image: "ghcr.io/kairos-io/hadron:v0.0.4"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             trusted_boot: true
             custom_job_name_format: "core-amd64-generic-uki"
     secrets:
@@ -122,7 +122,7 @@ jobs:
         image_name:
           - "hadron"
         base_image:
-          - "ghcr.io/kairos-io/hadron:v0.0.4"
+          - "ghcr.io/kairos-io/hadron:v0.2.0"
         kubernetes_version: ${{ fromJson(needs.get-k3s-versions.outputs.kubernetes_versions) }}
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
@@ -165,7 +165,7 @@ jobs:
         image_name:
           - "hadron"
         base_image:
-          - "ghcr.io/kairos-io/hadron:v0.0.4"
+          - "ghcr.io/kairos-io/hadron:v0.2.0"
         kubernetes_version: ${{ fromJson(needs.get-k0s-versions.outputs.kubernetes_versions) }}
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/upload-cloud-images.yaml
+++ b/.github/workflows/upload-cloud-images.yaml
@@ -71,7 +71,7 @@ jobs:
             exit 0
           fi
 
-          containerImage="quay.io/kairos/hadron:v0.0.4-core-amd64-generic-${latestTag}"
+          containerImage="quay.io/kairos/hadron:v0.2.0-core-amd64-generic-${latestTag}"
           docker run -v /var/run/docker.sock:/var/run/docker.sock --net host \
             --privileged \
             -v $PWD:/aurora --rm quay.io/kairos/auroraboot:v0.19.4 \
@@ -146,7 +146,7 @@ jobs:
             exit 0
           fi
 
-          containerImage="quay.io/kairos/hadron:v0.0.4-core-amd64-generic-${latestTag}"
+          containerImage="quay.io/kairos/hadron:v0.2.0-core-amd64-generic-${latestTag}"
           docker run -v /var/run/docker.sock:/var/run/docker.sock --net host \
             --privileged \
             -v $PWD:/aurora --rm quay.io/kairos/auroraboot:v0.19.4 \
@@ -220,7 +220,7 @@ jobs:
         if: ${{ steps.checkPushed.outputs.shouldBuild == 'true' }}
         run: |
             latestTag=$(cat LATEST_TAG)
-            containerImage="quay.io/kairos/hadron:v0.0.4-core-amd64-generic-${latestTag}"
+            containerImage="quay.io/kairos/hadron:v0.2.0-core-amd64-generic-${latestTag}"
             docker run -v /var/run/docker.sock:/var/run/docker.sock --net host \
               --privileged \
               -v $PWD:/aurora --rm quay.io/kairos/auroraboot:v0.19.4 \

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ubuntu:20.04
-ARG KAIROS_INIT=v0.10.1
+ARG KAIROS_INIT=v0.12.1
 
 FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
 


### PR DESCRIPTION
## Summary
- Bump hadron base image from v0.0.4 to v0.2.0 across all workflow files

## Test plan
- [ ] CI workflows pass with the new hadron version
- [ ] Image builds complete successfully

Made with [Cursor](https://cursor.com)