### PR TITLE
docs: fix stale governance links and ubuntu 24.04 fips readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ How to contribute
 -  **Send a pull request** - if you want to contribute code. Please be
    sure to file an issue first.
 -  **Check good first-issue** - check out [good first issues](https://github.com/kairos-io/kairos/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) if you want to contribute to a specific problem
--  **Read about our code of conduct and governance**: Kairos is an Open source, community-driven project with a [governance](https://github.com/kairos-io/kairos/blob/master/GOVERNANCE.md) and adopts CNCF [Code of conduct](https://github.com/kairos-io/kairos/blob/master/CODE_OF_CONDUCT.md)
+-  **Read about our code of conduct and governance**: Kairos is an Open source, community-driven project with a [governance](https://github.com/kairos-io/community/blob/main/GOVERNANCE.md) and adopts CNCF [Code of conduct](https://github.com/kairos-io/kairos/blob/master/CODE_OF_CONDUCT.md)
 
 Guiding user stories
 --------------------

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,7 +32,7 @@ Contribute
 </td>
 <td>
   
-🙌[ CONTRIBUTING.md ]( https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md ) <br> :raising_hand: [ GOVERNANCE ]( https://github.com/kairos-io/kairos/blob/master/GOVERNANCE.md ) <br>:construction_worker:[Code of conduct](https://github.com/kairos-io/kairos/blob/master/CODE_OF_CONDUCT.md) 
+🙌[ CONTRIBUTING.md ]( https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md ) <br> :raising_hand: [ GOVERNANCE ]( https://github.com/kairos-io/community/blob/main/GOVERNANCE.md ) <br>:construction_worker:[Code of conduct](https://github.com/kairos-io/kairos/blob/master/CODE_OF_CONDUCT.md)
   
 </td>
 </tr>

--- a/examples/builds/ubuntu-24.04-fips/README.md
+++ b/examples/builds/ubuntu-24.04-fips/README.md
@@ -1,4 +1,4 @@
-# Kairos Ubuntu jammy fips
+# Kairos Ubuntu noble fips
 
 - Edit `pro-attach-config.yaml` with your token
 - run `bash build.sh`
@@ -31,5 +31,5 @@ After install, you can verify that fips is enabled by running:
 kairos@localhost:~$ cat /proc/sys/crypto/fips_enabled
 1
 kairos@localhost:~$ uname -r
-5.15.0-140-fips
+6.8.0-xx-fips
 ```


### PR DESCRIPTION
Minor documentation cleanup - no functional changes.

Changes:
- Fixed 2 broken governance links that returned 404 errors
- Updated the Ubuntu 24.04 FIPS README to reference Noble instead of Jammy

How to reproduce the original issues:
1. Open `CONTRIBUTING.md` or `examples/README.md` and click the governance link - it returns a 404.
2. Open `examples/builds/ubuntu-24.04-fips/README.md` - it was copied from the Jammy version, so the label and kernel example were incorrect.

Risk: Low - docs-only fix.