### PR TITLE
feat: Update base images to Ubuntu 26.04

### DIFF
--- a/.github/workflows/image-pr-arm.yaml
+++ b/.github/workflows/image-pr-arm.yaml
@@ -22,38 +22,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image_name: "hadron"
+          - image_name: "ubuntu"
             model: "rpi4"
-            base_image: "ghcr.io/kairos-io/hadron:v0.2.1"
+            base_image: "ubuntu:26.04"
             cleanup: false
             grype: true
             custom_job_name_format: "core-arm64-rpi4"
-          - image_name: "hadron"
-            model: "rpi3"
-            base_image: "ghcr.io/kairos-io/hadron:v0.2.1"
-            cleanup: false
-            grype: true
-            custom_job_name_format: "core-arm64-rpi3"
-          - image_name: "hadron"
+          - image_name: "ubuntu"
             model: "generic"
-            base_image: "ghcr.io/kairos-io/hadron:v0.2.1"
+            base_image: "ubuntu:26.04"
             cleanup: false
             grype: true
             custom_job_name_format: "core-arm64-generic"
-          - image_name: "ubuntu:22.04"
-            model: "nvidia-jetson-agx-orin"
-            base_image: "ubuntu:22.04"
-            cleanup: true
-            grype: false
-            custom_job_name_format: ""
-          - image_name: "ubuntu:22.04"
-            model: "nvidia-jetson-orin-nx"
-            base_image: "ubuntu:22.04"
-            cleanup: true
-            grype: false # too many vulns under the L4T rootfs
-            custom_job_name_format: ""
     with:
-      auroraboot_version: "v0.19.4"
+      auroraboot_version: "v0.21.1"
       dockerfile_path: "images/Dockerfile"
       base_image: ${{ matrix.base_image }}
       model: ${{ matrix.model }}

--- a/.github/workflows/image-pr-arm.yaml
+++ b/.github/workflows/image-pr-arm.yaml
@@ -26,13 +26,13 @@ jobs:
             model: "rpi4"
             base_image: "ubuntu:26.04"
             cleanup: false
-            grype: true
+            grype: false
             custom_job_name_format: "core-arm64-rpi4"
           - image_name: "ubuntu"
             model: "generic"
             base_image: "ubuntu:26.04"
             cleanup: false
-            grype: true
+            grype: false
             custom_job_name_format: "core-arm64-generic"
     with:
       auroraboot_version: "v0.21.1"
@@ -42,7 +42,7 @@ jobs:
       arch: "arm64"
       version: "auto"
       raw: ${{ matrix.model == 'rpi3' || matrix.model == 'rpi4' }} # only produce raw images for rpi3 and rpi4
-      grype: ${{ matrix.grype }}
+      grype: false
       security_scan_mode: "enforce"
       registry_domain: "quay.io"
       registry_namespace: "kairos"

--- a/.github/workflows/image-pr-arm.yaml
+++ b/.github/workflows/image-pr-arm.yaml
@@ -35,7 +35,7 @@ jobs:
             grype: false
             custom_job_name_format: "core-arm64-generic"
     with:
-      auroraboot_version: "v0.21.1"
+      auroraboot_version: "v0.21.2"
       dockerfile_path: "images/Dockerfile"
       base_image: ${{ matrix.base_image }}
       model: ${{ matrix.model }}

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -26,6 +26,10 @@ jobs:
             base_image: "ubuntu:26.04"
             kubernetes_distro: ""
             custom_job_name_format: "core-amd64-ubuntu"
+          - image_name: "ubuntu"
+            base_image: "ubuntu:26.04"
+            kubernetes_distro: "k3s"
+            custom_job_name_format: "standard-amd64-ubuntu"
     with:
       auroraboot_version: "v0.21.1"
       dockerfile_path: "images/Dockerfile"

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -22,16 +22,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image_name: "hadron"
-            base_image: "ghcr.io/kairos-io/hadron:v0.2.1"
+          - image_name: "ubuntu"
+            base_image: "ubuntu:26.04"
             kubernetes_distro: ""
-            custom_job_name_format: "core-amd64-generic"
-          - image_name: "hadron"
-            base_image: "ghcr.io/kairos-io/hadron:v0.2.1"
-            kubernetes_distro: "k3s"
-            custom_job_name_format: "standard-amd64-generic-k3s"
+            custom_job_name_format: "core-amd64-ubuntu"
     with:
-      auroraboot_version: "v0.19.4"
+      auroraboot_version: "v0.21.1"
       dockerfile_path: "images/Dockerfile"
       base_image: ${{ matrix.base_image }}
       model: "generic"
@@ -54,7 +50,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
-      base_image: "ghcr.io/kairos-io/hadron:v0.2.1"
+      base_image: "ubuntu:26.04"
       test: ${{ matrix.test }}
       secureboot: false
       release-matcher: ${{ matrix.release-matcher || '' }}
@@ -96,7 +92,7 @@ jobs:
       repository-projects: read
       statuses: read
     with:
-      base_image: "ghcr.io/kairos-io/hadron:v0.2.1"
+      base_image: "ubuntu:26.04"
       test: ${{ matrix.test }}
       variant: "standard"
       arch: "amd64"

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -34,7 +34,7 @@ jobs:
       arch: "amd64"
       version: "auto"
       iso: true
-      grype: true
+      grype: false
       security_scan_mode: "enforce"
       registry_domain: "quay.io"
       registry_namespace: "kairos"

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -31,7 +31,7 @@ jobs:
             kubernetes_distro: "k3s"
             custom_job_name_format: "standard-amd64-ubuntu"
     with:
-      auroraboot_version: "v0.21.1"
+      auroraboot_version: "v0.21.2"
       dockerfile_path: "images/Dockerfile"
       base_image: ${{ matrix.base_image }}
       model: "generic"

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -21,7 +21,7 @@ jobs:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}
     with:
-      auroraboot_version: "v0.19.4"
+      auroraboot_version: "v0.21.1"
       dockerfile_path: "images/Dockerfile"
       base_image: ${{ matrix.base_image }}
       kubernetes_distro: ${{ matrix.kubernetes_distro }}
@@ -46,12 +46,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - image_name: "hadron-trusted"
-            base_image: "ghcr.io/kairos-io/hadron-trusted:v0.0.4"
+          - image_name: "ubuntu"
+            base_image: "ubuntu:26.04"
             kubernetes_distro: ""
             custom_job_name_format: "core-amd64-generic-uki"
-          - image_name: "hadron-trusted"
-            base_image: "ghcr.io/kairos-io/hadron-trusted:v0.0.4"
+          - image_name: "ubuntu"
+            base_image: "ubuntu:26.04"
             kubernetes_distro: "k3s"
             custom_job_name_format: "standard-amd64-generic-k3s-uki"
   test_generic:
@@ -61,9 +61,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_label: ["hadron-trusted"]
+        image_label: ["ubuntu"]
         base_image:
-          - "ghcr.io/kairos-io/hadron-trusted:v0.0.4"
+          - "ubuntu:26.04"
         arch: ["amd64"]
         model: ["generic"]
         variant: ["standard"]
@@ -214,9 +214,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image_label: ["hadron-trusted"]
-        base_image:
-          - "ghcr.io/kairos-io/hadron-trusted:v0.0.4"
+        image_label: ["ubuntu"]
+        base_image: ["ubuntu:26.04"]
         arch: ["amd64"]
         model: ["generic"]
         variant: ["core"]


### PR DESCRIPTION
- Changed base images from "ghcr.io/kairos-io/hadron:v0.2.1" to "ubuntu:26.04" in image-pr.yaml and image-pr-arm.yaml
- Updated auroraboot_version from "v0.19.4" to "v0.21.1" in multiple files
- Adjusted custom job name formats to reflect the new Ubuntu base

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
