### PR TITLE
:arrow_up: Update quay.io/kairos/kairos-init Docker tag to v0.14.2

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ubuntu:20.04
-ARG KAIROS_INIT=v0.14.0
+ARG KAIROS_INIT=v0.14.2
 
 FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
 


### PR DESCRIPTION
## Summary
- Bump `KAIROS_INIT` from v0.14.0 to [v0.14.2](https://github.com/kairos-io/kairos-init/releases/tag/v0.14.2)
- Picks up kairos-agent v2.29.4

## Test plan
- [ ] CI image build passes


Made with [Cursor](https://cursor.com)