### PR TITLE
docs: fix non-HWE example path in README

### DIFF
--- a/examples/builds/ubuntu-non-hwe/README.md
+++ b/examples/builds/ubuntu-non-hwe/README.md
@@ -7,7 +7,7 @@ We are going to assume that you start the process at the root of the Kairos repo
 Let's start by building the base image.
 
 ```
-$ cd examples/byoi/ubuntu-non-hwe
+$ cd examples/builds/ubuntu-non-hwe
 $ docker build -t ubuntu-non-hwe:22.04 .
 [+] Building 58.7s (13/13) FINISHED                                                      docker:default
  => [internal] load build definition from Dockerfile                                               0.0s


### PR DESCRIPTION
The ubuntu-non-hwe example moved from examples/byoi/ to examples/builds/, but the README still instructed readers to cd into the old examples/byoi/ubuntu-non-hwe path, which no longer exists.

Point it at the current examples/builds/ubuntu-non-hwe directory.

Completes: https://github.com/kairos-io/kairos/issues/2036

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
