### PR TITLE
Fix backtick escaping in workflow summary

### DIFF
--- a/.github/workflows/release-notes-diff.yaml
+++ b/.github/workflows/release-notes-diff.yaml
@@ -204,11 +204,11 @@ jobs:
           {
             echo "## Release diff generated"
             echo
-            echo "- Current release: \\`${CURRENT_TAG}\\`"
-            echo "- Previous final release: \\`${{ steps.prev.outputs.tag }}\\`"
+            echo "- Current release: \`${CURRENT_TAG}\`"
+            echo "- Previous final release: \`${{ steps.prev.outputs.tag }}\`"
             if [ "${{ steps.append.outputs.appended }}" = "true" ]; then
-              echo "- Release description updated: \\`yes\\`"
+              echo "- Release description updated: \`yes\`"
             else
-              echo "- Release description updated: \\`no (already contained section header)\\`"
+              echo "- Release description updated: \`no (already contained section header)\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The summary lines used \` inside a double-quoted string, which bash read as a literal backslash followed by a command substitution. It tried to run the tag (e.g. v4.1.1) as a command, logging 'command not found' and emitting mangled summary lines. A single backslash escapes the backtick so the markdown code spans render correctly.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
