### PR TITLE
test(uki): run UKI bench against immucore fix/uki-sysroot-perms-0755

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,7 +1,21 @@
 ARG BASE_IMAGE=ubuntu:20.04
 ARG KAIROS_INIT=v0.14.6
 
+# TEST OVERRIDE: build immucore from a branch instead of the kairos-init pinned release.
+# Remove this stage + the override RUN below to go back to the released immucore.
+ARG IMMUCORE_REPO=https://github.com/kairos-io/immucore
+ARG IMMUCORE_BRANCH=fix/uki-sysroot-perms-0755
+
 FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
+
+FROM golang:1.26 AS immucore-build
+ARG IMMUCORE_REPO
+ARG IMMUCORE_BRANCH
+RUN git clone --depth 1 --branch "${IMMUCORE_BRANCH}" "${IMMUCORE_REPO}" /src
+WORKDIR /src
+RUN CGO_ENABLED=0 go build -tags "nogit nounpack" \
+    -ldflags "-w -s -X github.com/kairos-io/immucore/internal/version.version=${IMMUCORE_BRANCH}" \
+    -o /immucore .
 
 FROM ${BASE_IMAGE} AS base-kairos
 ARG MODEL=generic
@@ -28,3 +42,14 @@ RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
     if [ "$FIPS" == "fips" ]; then FIPS_FLAG="--fips"; else FIPS_FLAG=""; fi; \
     eval /kairos-init -l debug -s install -m \"${MODEL}\" -t \"${TRUSTED_BOOT}\" ${K8S_FLAG} ${K8S_VERSION_FLAG} --version \"${VERSION}\" \"${FIPS_FLAG}\" && \
     eval /kairos-init -l debug -s init -m \"${MODEL}\" -t \"${TRUSTED_BOOT}\" ${K8S_FLAG} ${K8S_VERSION_FLAG} --version \"${VERSION}\" \"${FIPS_FLAG}\"
+
+# TEST OVERRIDE: replace the installed immucore with the branch build.
+# Resolves the real installed path (no hardcoding) and fails the build if immucore
+# was not installed or the new binary does not run. The UKI initramfs is regenerated
+# from this rootfs by auroraboot build-uki, so the replaced binary is what gets booted.
+RUN --mount=type=bind,from=immucore-build,src=/immucore,dst=/tmp/immucore \
+    dst="$(command -v immucore)"; \
+    [ -n "$dst" ] || { echo "immucore not found in image - kairos-init did not install it"; exit 1; }; \
+    echo "Overriding immucore at: $dst"; \
+    install -m 0755 /tmp/immucore "$dst"; \
+    immucore version

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/spectrocloud/peg/matcher"
@@ -123,6 +124,14 @@ bundles:
 			}, 5*time.Minute, 10*time.Second).Should(ContainSubstring("peerguard"))
 
 			stateAssertVM(vm, "persistent.found", "true")
+			By("Checking that / has 0755 permissions", func() {
+				// Parity with the UKI suite. In normal (non-UKI) boot / is the
+				// image rootfs whose root is 0755; this guards against a
+				// regression where / ends up world-writable (0777).
+				out, err := vm.Sudo(`stat -c "%a" /`)
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(strings.TrimSpace(out)).To(Equal("755"), out)
+			})
 			By("Checking install/recovery services are disabled", func() {
 				if !isFlavor(vm, "alpine") {
 					for _, service := range []string{"kairos-interactive", "kairos-recovery"} {

--- a/tests/uki_test.go
+++ b/tests/uki_test.go
@@ -220,6 +220,15 @@ func genericTests(vm VM) {
 		Expect(out).To(ContainSubstring("ro"))
 		Expect(out).ToNot(ContainSubstring("rw"))
 	})
+	By("Checking that / has 0755 permissions", func() {
+		// In UKI mode immucore pins the sysroot tmpfs to mode 0755. Without an
+		// explicit mode= the kernel uses 0777 & ~umask, which is non-deterministic
+		// in early boot and can leave / as 0777. Some software (e.g. snapd) requires
+		// / to be 0755. Regression guard for the sysroot tmpfs perms fix.
+		out, err := vm.Sudo(`stat -c "%a" /`)
+		Expect(err).ToNot(HaveOccurred(), out)
+		Expect(strings.TrimSpace(out)).To(Equal("755"), out)
+	})
 	By("Checking the boot mode (boot)", func() {
 		out, err := vm.Sudo("stat /run/cos/uki_boot_mode")
 		Expect(err).ToNot(HaveOccurred(), out)


### PR DESCRIPTION
## What

Forces the UKI test bench to build and boot the **branch** immucore (`kairos-io/immucore@fix/uki-sysroot-perms-0755`, commit `3703c41` — *fix(uki): pin sysroot tmpfs to mode 0755*) instead of the kairos-init pinned release.

## How

`images/Dockerfile`:
- New `immucore-build` stage clones + compiles immucore from the branch (`CGO_ENABLED=0`, tags `nogit nounpack`, version stamped to the branch name).
- A post-`kairos-init` `RUN` replaces the installed binary at its resolved path (`command -v immucore`), failing the build if immucore is absent or the new binary won't run.
- The UKI initramfs is regenerated from this rootfs by auroraboot `build-uki`, so the booted immucore is the branch build.
- Branch/repo are ARGs (`IMMUCORE_BRANCH`, `IMMUCORE_REPO`).

Verified locally: the `immucore-build` stage compiles clean and `immucore version` reports `version=fix/uki-sysroot-perms-0755`.

## CI

`uki.yaml` (`build` → `test_generic` + `test_boot_assessment`) builds this Dockerfile via the factory action and runs the UKI bench under qemu+swtpm+secureboot — no workflow changes needed.

## Revert

Drop the `immucore-build` stage and the override `RUN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)