### PR TITLE
chore: bump kairos-init to v0.16.1

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ubuntu:20.04
-ARG KAIROS_INIT=v0.15.3
+ARG KAIROS_INIT=v0.16.1
 
 FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ubuntu:20.04
-ARG KAIROS_INIT=v0.15.2
+ARG KAIROS_INIT=v0.15.3
 
 FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
 


### PR DESCRIPTION
## Summary
- Bump `KAIROS_INIT` to **v0.16.1** in `images/Dockerfile`
- Brings in kairos-sdk v0.23.3+ and kairos-agent v2.30.2 (riscv64 openSUSE GRUB EFI path, kairos-sdk#806)

Part of #4083.

## Test plan
- [ ] CI image builds pass with `quay.io/kairos/kairos-init:v0.16.1`
- [ ] openSUSE Tumbleweed riscv64 manual EFI install finds grub at `/usr/share/efi/riscv64/grub.efi`