### PR TITLE
fix: add renovate regex to match auroraboot_version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,8 @@
         "/.github/workflows/.*.ya?ml/"
       ],
       "matchStrings": [
-        "quay.io/kairos/auroraboot:(?<currentValue>[a-zA-Z0-9_.-]+)"
+        "quay.io/kairos/auroraboot:(?<currentValue>[a-zA-Z0-9_.-]+)",
+        "auroraboot_version:\\s*[\\\"']?(?<currentValue>[a-zA-Z0-9_.-]+)[\\\"']?"
       ],
       "depNameTemplate": "quay.io/kairos/auroraboot",
       "datasourceTemplate": "docker"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

This PR fixes renovate not picking up `auroraboot_version` but just catching the full docker image names.

https://github.com/kairos-io/kairos/pull/4273/changes

Given the Github Actions just is a variable `v0.0.0` its not a fully referenced OCI image.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kairos-io/kairos/issues/4294
