### PR TITLE
ci: gate releases on a vulnerability scan of the shipped bundle

### DIFF
--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -6,9 +6,19 @@ on:
       - v*
 permissions: read-all
 jobs:
+  # Release gate: refuse to publish artifacts containing known-vulnerable
+  # dependencies. Scans the binaries this release will actually ship, for the
+  # kairos-init version pinned in images/Dockerfile. See
+  # .github/workflows/release-scan.yml and
+  # https://github.com/kairos-io/kairos/issues/3985.
+  vulnerability-scan:
+    uses: ./.github/workflows/release-scan.yml
+
   core:
     name: ${{ matrix.image_name }}
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    needs:
+      - vulnerability-scan
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}
@@ -114,6 +124,7 @@ jobs:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}
     needs:
+      - vulnerability-scan
       - get-k3s-versions
     permissions:
       id-token: write  # OIDC support

--- a/.github/workflows/release-scan.yml
+++ b/.github/workflows/release-scan.yml
@@ -15,8 +15,9 @@ name: 'Release vulnerability scan'
 # matters for dependency scanning.
 #
 
-# Triggers are deliberately narrow. This is a release gate, so release.yaml
-# calls it via workflow_call. It does NOT run on every pull request: the
+# Triggers are deliberately narrow. This is a release gate: release.yaml and
+# release-arm.yaml call it via workflow_call, and every publishing job depends
+# on it, so a release with unignored advisories never publishes. It does NOT run on every pull request: the
 # findings belong to the pinned dependency set, not to the change under review,
 # so an unrelated PR -- including an external contributor's -- would get a red
 # check for CVEs it did not introduce and cannot fix.

--- a/.github/workflows/release-scan.yml
+++ b/.github/workflows/release-scan.yml
@@ -13,11 +13,24 @@ name: 'Release vulnerability scan'
 # The scanned artifact is therefore NOT byte-identical to the shipped one. It is
 # composed from the same sources at the same pins, which is the property that
 # matters for dependency scanning.
+#
 
+# Triggers are deliberately narrow. This is a release gate, so release.yaml
+# calls it via workflow_call. It does NOT run on every pull request: the
+# findings belong to the pinned dependency set, not to the change under review,
+# so an unrelated PR -- including an external contributor's -- would get a red
+# check for CVEs it did not introduce and cannot fix.
+#
+# The pull_request trigger is scoped to the files that actually determine the
+# result: the kairos-init pin, the ignore list, and this workflow itself.
 on:
-  pull_request:
-  workflow_dispatch:
   workflow_call:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'images/Dockerfile'
+      - 'osv-scanner.toml'
+      - '.github/workflows/release-scan.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/release-scan.yml
+++ b/.github/workflows/release-scan.yml
@@ -1,0 +1,143 @@
+---
+name: 'Release vulnerability scan'
+
+# Scans the binaries Kairos actually ships, for the kairos-init version this
+# repo pins. Refs https://github.com/kairos-io/kairos/issues/3985.
+#
+# Why this exists as a separate job rather than relying on the scanning already
+# in release.yaml: kairos-init UPX-compresses the bundled binaries, and a
+# UPX-packed Go binary no longer exposes its module metadata, so the
+# dependencies we ship are invisible to a scanner. This job rebuilds the bundle
+# with SKIP_UPX=true purely so it can be read.
+#
+# The scanned artifact is therefore NOT byte-identical to the shipped one. It is
+# composed from the same sources at the same pins, which is the property that
+# matters for dependency scanning.
+
+on:
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  scan-shipped-bundle:
+    name: scan shipped bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout kairos
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Resolve the pinned kairos-init version
+        id: pin
+        run: |
+          set -euo pipefail
+          VERSION="$(grep -m1 '^ARG KAIROS_INIT=' images/Dockerfile | cut -d= -f2)"
+          if [ -z "${VERSION}" ]; then
+            echo "::error::could not read ARG KAIROS_INIT from images/Dockerfile"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Scanning the bundle composed by kairos-init ${VERSION}"
+
+      - name: Checkout kairos-init at that version
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: kairos-io/kairos-init
+          ref: ${{ steps.pin.outputs.version }}
+          path: kairos-init
+
+      # SKIP_UPX is the whole point of this job -- see the header comment.
+      - name: Download the shipped binaries, uncompressed
+        working-directory: kairos-init
+        run: SKIP_UPX=true make download
+
+      - name: Install osv-scanner
+        env:
+          OSV_SCANNER_VERSION: v2.5.0
+        run: |
+          set -euo pipefail
+          curl -sSfL --retry 5 --retry-all-errors --retry-delay 2 \
+            "https://github.com/google/osv-scanner/releases/download/${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64" \
+            -o /usr/local/bin/osv-scanner
+          chmod +x /usr/local/bin/osv-scanner
+          osv-scanner --version
+
+      # Two flags are load-bearing. Without either, the scan finds nothing and
+      # reports success -- a false green, which is worse than no gate at all.
+      #
+      #   --no-ignore                      kairos-init's .gitignore excludes
+      #                                    pkg/bundled/binaries/, and osv-scanner
+      #                                    honours .gitignore by default.
+      #   --experimental-plugins artifact  the default plugin set
+      #                                    (lockfile, sbom, directory) cannot
+      #                                    read Go binaries at all.
+      #
+      # continue-on-error because osv-scanner exits non-zero when it finds
+      # vulnerabilities; the reporting step below decides what that means.
+      - name: Scan
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          osv-scanner scan source \
+            --experimental-plugins artifact \
+            --no-ignore \
+            --recursive \
+            --config osv-scanner.toml \
+            --format json \
+            --output-file osv.json \
+            kairos-init/pkg/bundled/binaries
+
+      # A clean result only means something if the scanner actually read the
+      # binaries. Zero extracted packages is a broken scan, not a pass.
+      - name: Guard against a false green
+        run: |
+          set -euo pipefail
+          if [ ! -s osv.json ]; then
+            echo "::error::osv-scanner produced no output file"
+            exit 1
+          fi
+          PACKAGES="$(jq '[.results[].packages[]] | length' osv.json)"
+          echo "extracted packages: ${PACKAGES}"
+          if [ "${PACKAGES}" -eq 0 ]; then
+            echo "::error::scanner extracted 0 packages -- it did not read the shipped binaries. Treating as a failure, not as clean."
+            exit 1
+          fi
+
+      - name: Report and enforce
+        run: |
+          set -euo pipefail
+          jq -r '
+            [ .results[].packages[]
+              | . as $pkg
+              | .vulnerabilities[]?
+              | "| `\(.id)` | `\($pkg.package.name)@\($pkg.package.version)` |"
+            ] | unique | .[]' osv.json > findings.md || true
+          COUNT="$(wc -l < findings.md)"
+          {
+            echo "## Vulnerability scan of the shipped bundle"
+            echo
+            echo "kairos-init \`${{ steps.pin.outputs.version }}\`, scanned uncompressed."
+            echo
+            if [ "${COUNT}" -eq 0 ]; then
+              echo "No unignored advisories."
+            else
+              echo "| advisory | module |"
+              echo "|---|---|"
+              cat findings.md
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+          if [ "${COUNT}" -gt 0 ]; then
+            echo "::error::${COUNT} unignored advisories in the shipped bundle. Bump the affected component, or add a dated entry to osv-scanner.toml with a reason."
+            exit 1
+          fi
+
+      - name: Upload scan output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: osv-scan
+          path: osv.json
+          if-no-files-found: warn

--- a/.github/workflows/release-scan.yml
+++ b/.github/workflows/release-scan.yml
@@ -88,6 +88,12 @@ jobs:
       #   --experimental-plugins artifact  the default plugin set
       #                                    (lockfile, sbom, directory) cannot
       #                                    read Go binaries at all.
+      #   --all-packages                   without it, a scan with no findings
+      #                                    emits an EMPTY results array, which
+      #                                    is indistinguishable from a scan that
+      #                                    read nothing -- and would trip the
+      #                                    false-green guard below on every
+      #                                    clean release.
       #
       # continue-on-error because osv-scanner exits non-zero when it finds
       # vulnerabilities; the reporting step below decides what that means.
@@ -99,6 +105,7 @@ jobs:
             --experimental-plugins artifact \
             --no-ignore \
             --recursive \
+            --all-packages \
             --config osv-scanner.toml \
             --format json \
             --output-file osv.json \

--- a/.github/workflows/release-scan.yml
+++ b/.github/workflows/release-scan.yml
@@ -123,28 +123,35 @@ jobs:
       - name: Report and enforce
         run: |
           set -euo pipefail
+          # One advisory can affect several module versions in the same bundle
+          # (different binaries pin different versions), so a finding is an
+          # (advisory, module@version) pair and the two counts differ. Report
+          # both rather than calling every row an advisory.
           jq -r '
             [ .results[].packages[]
               | . as $pkg
               | .vulnerabilities[]?
               | "| `\(.id)` | `\($pkg.package.name)@\($pkg.package.version)` |"
             ] | unique | .[]' osv.json > findings.md || true
-          COUNT="$(wc -l < findings.md)"
+          FINDINGS="$(wc -l < findings.md)"
+          ADVISORIES="$(jq -r '[.results[].packages[].vulnerabilities[]?.id] | unique | length' osv.json)"
           {
             echo "## Vulnerability scan of the shipped bundle"
             echo
             echo "kairos-init \`${{ steps.pin.outputs.version }}\`, scanned uncompressed."
             echo
-            if [ "${COUNT}" -eq 0 ]; then
+            if [ "${FINDINGS}" -eq 0 ]; then
               echo "No unignored advisories."
             else
+              echo "**${ADVISORIES} advisories**, ${FINDINGS} findings across module versions."
+              echo
               echo "| advisory | module |"
               echo "|---|---|"
               cat findings.md
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
-          if [ "${COUNT}" -gt 0 ]; then
-            echo "::error::${COUNT} unignored advisories in the shipped bundle. Bump the affected component, or add a dated entry to osv-scanner.toml with a reason."
+          if [ "${FINDINGS}" -gt 0 ]; then
+            echo "::error::${ADVISORIES} unignored advisories (${FINDINGS} findings) in the shipped bundle. Bump the affected component, or add a dated entry to osv-scanner.toml with a reason."
             exit 1
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,19 @@ on:
       - v*
 permissions: read-all
 jobs:
+  # Release gate: refuse to publish artifacts containing known-vulnerable
+  # dependencies. Scans the binaries this release will actually ship, for the
+  # kairos-init version pinned in images/Dockerfile. See
+  # .github/workflows/release-scan.yml and
+  # https://github.com/kairos-io/kairos/issues/3985.
+  vulnerability-scan:
+    uses: ./.github/workflows/release-scan.yml
+
   core:
     name: ${{ matrix.image_name }}
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    needs:
+      - vulnerability-scan
     permissions:
       id-token: write  # OIDC support
       contents: write
@@ -115,6 +125,7 @@ jobs:
     name: ${{ matrix.image_name }}
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
     needs:
+      - vulnerability-scan
       - get-k3s-versions
     permissions:
       id-token: write  # OIDC support
@@ -161,6 +172,7 @@ jobs:
     name: ${{ matrix.image_name }}
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
     needs:
+      - vulnerability-scan
       - get-k0s-versions
     permissions:
       id-token: write  # OIDC support

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,129 @@
+# Vulnerability ignore list for the release gate in
+# .github/workflows/release-scan.yml. Refs
+# https://github.com/kairos-io/kairos/issues/3985.
+#
+# Policy
+# ------
+#   * If a fix is published and can be taken, BUMP THE COMPONENT. Do not add an
+#     entry here. This list is for what cannot currently be fixed, not for what
+#     is inconvenient to fix.
+#   * Every entry states a reason, prefixed with one of the categories below.
+#   * An expired entry fails the build. That is deliberate -- it forces a
+#     re-look rather than letting an ignore become permanent by neglect.
+#
+# Categories and their expiry, chosen so the gate stays trustworthy:
+#
+#   no-fix-available        90 days. Nothing upstream to wait for, so a short
+#                           expiry would turn the gate red every week with no
+#                           action available. Alarm fatigue is how a blocking
+#                           gate becomes one everyone force-merges past.
+#   prerelease-only-fix     ~2 weeks. A stable release is expected soon.
+#   major-upgrade-required  ~30 days, plus a tracking issue. Needs planned work,
+#                           not a decision taken during a release.
+#
+# Entries below were produced by a real scan of kairos-init v0.16.3's
+# uncompressed bundle on 2026-08-12.
+
+
+# ---------------------------------------------------------------------------
+# no-fix-available -- no fixed version published upstream.
+# All reached transitively through provider-kairos except x/crypto.
+# ---------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "GO-2024-3218"
+ignoreUntil = 2026-11-10
+reason = "no-fix-available: CVE-2023-26248, github.com/libp2p/go-libp2p-kad-dht. No fixed version published. Transitive via provider-kairos."
+
+[[IgnoredVulns]]
+id = "GHSA-q7pp-wcgr-pffx"
+ignoreUntil = 2026-11-10
+reason = "no-fix-available: CVE-2023-36308, github.com/disintegration/imaging. No fixed version published; upstream is effectively unmaintained."
+
+[[IgnoredVulns]]
+id = "GO-2026-5298"
+ignoreUntil = 2026-11-10
+reason = "no-fix-available: CVE-2026-12681, github.com/google/go-attestation. No fixed version published."
+
+[[IgnoredVulns]]
+id = "GO-2026-4736"
+ignoreUntil = 2026-11-10
+reason = "no-fix-available: CVE-2026-30405, github.com/osrg/gobgp/v3. No fixed version published."
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+ignoreUntil = 2026-11-10
+reason = "no-fix-available: golang.org/x/crypto. No fixed version published at any of the versions in the bundle."
+
+
+# ---------------------------------------------------------------------------
+# prerelease-only-fix -- the only published fix is Go 1.27.0-rc.2. Bumping the
+# toolchain to a release candidate to clear CVEs is not a sane release action;
+# these are taken with the stable 1.27.
+# ---------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "GO-2026-4970"
+ignoreUntil = 2026-08-26
+reason = "prerelease-only-fix: CVE-2026-39822, Go stdlib. Fixed only in 1.27.0-rc.2; take with the stable 1.27 toolchain bump."
+
+[[IgnoredVulns]]
+id = "GO-2026-5037"
+ignoreUntil = 2026-08-26
+reason = "prerelease-only-fix: CVE-2026-27145, Go stdlib. Fixed only in 1.27.0-rc.2."
+
+[[IgnoredVulns]]
+id = "GO-2026-5038"
+ignoreUntil = 2026-08-26
+reason = "prerelease-only-fix: CVE-2026-42504, Go stdlib. Fixed only in 1.27.0-rc.2."
+
+[[IgnoredVulns]]
+id = "GO-2026-5039"
+ignoreUntil = 2026-08-26
+reason = "prerelease-only-fix: CVE-2026-42507, Go stdlib. Fixed only in 1.27.0-rc.2."
+
+[[IgnoredVulns]]
+id = "GO-2026-5856"
+ignoreUntil = 2026-08-26
+reason = "prerelease-only-fix: CVE-2026-42505, Go stdlib. Fixed only in 1.27.0-rc.2."
+
+
+# ---------------------------------------------------------------------------
+# major-upgrade-required -- fixed in containerd 2.3.2, a 1.7 -> 2.3 major
+# upgrade inside provider-kairos. Planned work, not a release-time decision.
+# ---------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "GHSA-xhf5-7wjv-pqxp"
+ignoreUntil = 2026-09-11
+reason = "major-upgrade-required: CVE-2026-53488, containerd. Fixed in 2.3.2, a major upgrade in provider-kairos."
+
+[[IgnoredVulns]]
+id = "GO-2026-5758"
+ignoreUntil = 2026-09-11
+reason = "major-upgrade-required: CVE-2026-53488 (Go advisory alias), containerd. Fixed in 2.3.2."
+
+[[IgnoredVulns]]
+id = "GHSA-jpcc-p29g-p8mq"
+ignoreUntil = 2026-09-11
+reason = "major-upgrade-required: CVE-2026-47262, containerd. Fixed in 2.3.2."
+
+[[IgnoredVulns]]
+id = "GO-2026-5475"
+ignoreUntil = 2026-09-11
+reason = "major-upgrade-required: CVE-2026-47262 (Go advisory alias), containerd. Fixed in 2.3.2."
+
+[[IgnoredVulns]]
+id = "GO-2026-5064"
+ignoreUntil = 2026-09-11
+reason = "major-upgrade-required: CVE-2026-53492, containerd. Fixed in 2.3.2."
+
+[[IgnoredVulns]]
+id = "GO-2026-5338"
+ignoreUntil = 2026-09-11
+reason = "major-upgrade-required: CVE-2026-50195, containerd. Fixed in 2.3.2."
+
+[[IgnoredVulns]]
+id = "GO-2026-5622"
+ignoreUntil = 2026-09-11
+reason = "major-upgrade-required: CVE-2026-53489, containerd. Fixed in 2.3.2."

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -23,6 +23,9 @@
 #   upstream-regression     ~60 days. A fix exists but taking it breaks the
 #                           component; needs work in an upstream project we do
 #                           not control, so a short expiry buys nothing.
+#   upstream-fix-pending    ~30 days. The fix is written and submitted upstream
+#                           but not merged. Shorter clock than the above,
+#                           because this one is expected to resolve.
 #
 # Entries below were produced by a real scan of kairos-init v0.16.3's
 # uncompressed bundle on 2026-08-12.
@@ -166,3 +169,27 @@ reason = "upstream-regression: CVE-2026-57497, webtransport-go in edgevpn. Fix v
 id = "GO-2026-5970"
 ignoreUntil = 2026-10-11
 reason = "upstream-regression: CVE-2026-56852, golang.org/x/text in edgevpn. Fix v0.39.0 breaks libp2p peer connectivity in combination with the pion bumps. See mudler/edgevpn#1075."
+
+
+# ---------------------------------------------------------------------------
+# upstream-fix-pending -- both are in the `edgevpn` binary, which ships in every
+# Kairos release from mudler/edgevpn. The fix is written, tested and submitted
+# as https://github.com/mudler/edgevpn/pull/1075; it needs that PR merged and an
+# edgevpn release before EDGEVPN_VERSION can move in kairos-init.
+#
+# Both were also present in provider-kairos and were cleared there by the
+# v2.16.2 release; only the edgevpn copies remain.
+#
+# Both are remote denial-of-service via panic while parsing malformed input,
+# reachable only through go-libp2p's WebRTC transport.
+# ---------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "GHSA-34rh-wp3j-6cxc"
+ignoreUntil = 2026-09-11
+reason = "upstream-fix-pending: CVE-2026-54909, pion/stun in edgevpn. Fix v3.1.5 submitted as mudler/edgevpn#1075, awaiting merge and an edgevpn release."
+
+[[IgnoredVulns]]
+id = "GHSA-wg4g-wm44-ch5j"
+ignoreUntil = 2026-09-11
+reason = "upstream-fix-pending: CVE-2026-54908, pion/dtls in edgevpn. Fix v3.1.4 submitted as mudler/edgevpn#1075, awaiting merge and an edgevpn release."

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -20,6 +20,9 @@
 #   prerelease-only-fix     ~2 weeks. A stable release is expected soon.
 #   major-upgrade-required  ~30 days, plus a tracking issue. Needs planned work,
 #                           not a decision taken during a release.
+#   upstream-regression     ~60 days. A fix exists but taking it breaks the
+#                           component; needs work in an upstream project we do
+#                           not control, so a short expiry buys nothing.
 #
 # Entries below were produced by a real scan of kairos-init v0.16.3's
 # uncompressed bundle on 2026-08-12.
@@ -127,3 +130,39 @@ reason = "major-upgrade-required: CVE-2026-50195, containerd. Fixed in 2.3.2."
 id = "GO-2026-5622"
 ignoreUntil = 2026-09-11
 reason = "major-upgrade-required: CVE-2026-53489, containerd. Fixed in 2.3.2."
+
+
+# ---------------------------------------------------------------------------
+# upstream-regression -- a fix exists upstream, but taking it breaks the
+# component. Both of these are in the `edgevpn` binary, which ships in every
+# Kairos release from mudler/edgevpn.
+#
+# Bisected against edgevpn's pkg/node suite, which exercises real peer-to-peer
+# connectivity. Both make the "nodes can write to the ledger" spec time out at
+# 240s where an unmodified checkout passes in 10-13s:
+#
+#   webtransport-go v0.11.1 pulls quic-go 0.59.1 -> 0.60.0, and that alone
+#   reproduces it. go-libp2p pins quic-go tightly, so this likely needs a
+#   go-libp2p bump upstream first.
+#
+#   x/text v0.39.0 passes alone but fails in combination with the pion bumps.
+#   x/text supplies IDNA, which multiaddr uses for DNS peer addresses.
+#
+# The two advisories that could be taken safely are in
+# https://github.com/mudler/edgevpn/pull/1075. These two were left out of it
+# deliberately. Full bisection table on that PR.
+#
+# Note both are also present in provider-kairos, where they are already fixed
+# on main -- cutting a provider-kairos release clears them there, leaving only
+# the edgevpn copies these entries cover.
+# ---------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "GHSA-g35j-m5xg-vh3q"
+ignoreUntil = 2026-10-11
+reason = "upstream-regression: CVE-2026-57497, webtransport-go in edgevpn. Fix v0.11.1 pulls quic-go 0.60.0, which breaks libp2p peer connectivity. Needs a go-libp2p bump upstream. See mudler/edgevpn#1075."
+
+[[IgnoredVulns]]
+id = "GO-2026-5970"
+ignoreUntil = 2026-10-11
+reason = "upstream-regression: CVE-2026-56852, golang.org/x/text in edgevpn. Fix v0.39.0 breaks libp2p peer connectivity in combination with the pion bumps. See mudler/edgevpn#1075."


### PR DESCRIPTION
Refs #3985.

## Why the scanning we already have cannot catch this

`kairos-init` UPX-compresses the binaries we ship — `kairos-agent`, `immucore`, `kcrypt-discovery-challenger`, `provider-kairos`, `edgevpn`, `kairos-installer`. A UPX-packed Go binary no longer exposes its module metadata, so a scanner cannot enumerate the dependencies that actually end up on a user's disk.

The scanning in `release.yaml` also runs with `security_scan_mode: "report-only"` and `grype_sarif_fail_build: false`, so it cannot fail a build by design. **A green release today says nothing about CVEs in the shipped bundle.**

That is #3985's point, in @mauromorales's words on that issue:

> We currently run OSV-Scanner in the Kairos main repo, but it provides limited value because it mostly evaluates dependencies used by tests/tooling that we don't ship. What we actually need is vulnerability coverage for the shipped artifacts.

## What this does

Implements the approach @Itxaka sketched on #3985: resolve the pinned `kairos-init` version, check it out at that tag, `make download` with `SKIP_UPX=true` so the binaries stay readable, and scan the result.

The scanned artifact is deliberately **not** byte-identical to the shipped one — it is composed from the same sources at the same pins, which is the property that matters for dependency scanning.

## Two flags that are load-bearing

Both are commented in the workflow, because without either the scan finds nothing and **reports success**:

| flag | why |
|---|---|
| `--no-ignore` | `kairos-init/.gitignore` excludes `pkg/bundled/binaries/`, and osv-scanner honours `.gitignore` — so it walks straight past every binary we ship |
| `--experimental-plugins artifact` | the default plugin set (`lockfile, sbom, directory`) cannot read Go binaries at all |

I hit exactly this while developing it: the first run reported `0 Extract calls` and *"No package sources found"* — a green result that meant nothing. There is a separate step that fails the build when zero packages were extracted, so a broken scan cannot pass as a clean one.

## `osv-scanner.toml`

Anything with a published, takeable fix is meant to be **bumped**, not ignored. The file is limited to what cannot currently be fixed. Every entry carries a reason and an expiry, and an expired entry fails the build — deliberately, so an ignore cannot become permanent through neglect.

Expiry varies by category so the gate stays trustworthy rather than becoming background noise:

| category | expiry | why |
|---|---|---|
| `no-fix-available` | 90 days | nothing upstream to wait for; a short expiry would redden the gate weekly with no action available |
| `prerelease-only-fix` | ~2 weeks | a stable release is expected soon |
| `major-upgrade-required` | ~30 days | needs planned work, not a decision taken mid-release |

## Current state — this gate is red

Run against `kairos-init v0.16.3`'s uncompressed bundle on 2026-08-12: **89 binary-level instances, 30 advisories, 24 distinct CVEs**.

With the ignore list in this PR applied, **13 advisories remain**, all with published fixes and all genuine bumps:

`golang.org/x/image` (4) · `google.golang.org/grpc` (2) · `github.com/pion/dtls/v3` · `github.com/pion/stun/v3` · `github.com/quic-go/webtransport-go` · `go.opentelemetry.io/otel` · `github.com/klauspost/compress` · `golang.org/x/net` · `golang.org/x/text`

Almost all reached transitively through `provider-kairos`.

**So this will fail on merge until those are bumped, which is intended** — that is the gate working. Clearing them is separate work in the component repos, not something to fold in here.

## Wiring it up

`release.yaml` and `release-arm.yaml` both start with a `vulnerability-scan` job, and every publishing job depends on it:

| workflow | gated jobs |
|---|---|
| `release.yaml` | `core`, `standard-k3s`, `standard-k0s` |
| `release-arm.yaml` | `core`, `standard` |

A `v*` tag runs the scan first. If the bundle carries unignored advisories the factory jobs never start, so no artifacts and no GitHub release are produced.

The scan resolves `KAIROS_INIT` from `images/Dockerfile` **at the tagged commit**, so it describes the release being cut rather than whatever is current on `master`. One scan covers both architectures: it reads Go module metadata from the amd64 bundle, and the module set is identical across architectures because it comes from the same sources at the same pins.

Triggers are otherwise narrow — `workflow_dispatch`, plus `pull_request` scoped to `images/Dockerfile`, `osv-scanner.toml` and this workflow. It deliberately does **not** run on every PR: the findings belong to the pinned dependency set, not to the change under review, so an unrelated PR would show a red check for CVEs its author did not introduce and cannot fix.

**This means merging blocks releases until the outstanding advisories are cleared.** That is the intent, but it is the thing to agree on before merging rather than after.

## Testing

Verified in CI on this PR: [run 31581755101](https://github.com/kairos-io/kairos/actions/runs/31581755101). The path-scoped `pull_request` trigger fired, the pin resolved to `kairos-init v0.16.3`, the bundle downloaded uncompressed, the ignore list applied, the false-green guard passed, and the job failed at enforce on the real findings.

Testing it caught a bug: the first run reported "14 unignored advisories" against 13 found. Diffing the run's `osv.json` artifact against a local scan showed identical sets — the count was over `(advisory, module@version)` rows, and one advisory affects two module versions (`GO-2026-5970` at `golang.org/x/text@0.37.0` and `@0.38.0`). Fixed in `683d1d8`; it now reports both numbers.
