### PR TITLE
ci: pass the qemu tests only the secrets they use

### DIFF
--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -53,7 +53,12 @@ jobs:
       kubernetes_distro: ${{ matrix.kubernetes_distro }}
   core-tests:
     name: ${{ format('core-tests (hadron, amd64, generic) {0}', matrix.test) }}
-    secrets: inherit
+    # Explicit rather than `secrets: inherit`. reusable-qemu-test.yaml only ever
+    # reads these two, and these jobs boot an image built from the pull request
+    # under review -- so they get the registry credential and nothing else.
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       base_image: "ghcr.io/kairos-io/hadron:v0.5.1"
@@ -81,7 +86,12 @@ jobs:
   standard-tests:
     name: ${{ format('standard-tests (hadron, amd64, generic) {0}', matrix.test) }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
-    secrets: inherit
+    # Explicit rather than `secrets: inherit`. reusable-qemu-test.yaml only ever
+    # reads these two, and these jobs boot an image built from the pull request
+    # under review -- so they get the registry credential and nothing else.
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
     permissions:
       contents: write
       security-events: write

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -16,8 +16,12 @@ jobs:
     name: ${{ matrix.image_name }}
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
     secrets:
-      registry_username: ${{ secrets.QUAY_USERNAME }}
-      registry_password: ${{ secrets.QUAY_PASSWORD }}
+      # The PR path only ever writes quay.io/kairos/ci-temp-images, so it uses
+      # the kairos+prci robot, which has Write on that repository and nothing
+      # else. QUAY_USERNAME/QUAY_PASSWORD is the credential release.yaml uses to
+      # publish permanent images and does not belong on a PR path.
+      registry_username: ${{ secrets.QUAY_PR_USERNAME }}
+      registry_password: ${{ secrets.QUAY_PR_PASSWORD }}
     strategy:
       fail-fast: false
       matrix:
@@ -53,12 +57,13 @@ jobs:
       kubernetes_distro: ${{ matrix.kubernetes_distro }}
   core-tests:
     name: ${{ format('core-tests (hadron, amd64, generic) {0}', matrix.test) }}
-    # Explicit rather than `secrets: inherit`. reusable-qemu-test.yaml only ever
-    # reads these two, and these jobs boot an image built from the pull request
-    # under review -- so they get the registry credential and nothing else.
+    # Explicit rather than `secrets: inherit`, and scoped to the ci-temp-images
+    # robot. These jobs boot an image built from the pull request under review;
+    # they pull it from ci-temp-images and push a bundles-test image back there,
+    # so Write on that one repository is all they need.
     secrets:
-      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      QUAY_USERNAME: ${{ secrets.QUAY_PR_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PR_PASSWORD }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       base_image: "ghcr.io/kairos-io/hadron:v0.5.1"
@@ -86,12 +91,13 @@ jobs:
   standard-tests:
     name: ${{ format('standard-tests (hadron, amd64, generic) {0}', matrix.test) }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
-    # Explicit rather than `secrets: inherit`. reusable-qemu-test.yaml only ever
-    # reads these two, and these jobs boot an image built from the pull request
-    # under review -- so they get the registry credential and nothing else.
+    # Explicit rather than `secrets: inherit`, and scoped to the ci-temp-images
+    # robot. These jobs boot an image built from the pull request under review;
+    # they pull it from ci-temp-images and push a bundles-test image back there,
+    # so Write on that one repository is all they need.
     secrets:
-      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      QUAY_USERNAME: ${{ secrets.QUAY_PR_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PR_PASSWORD }}
     permissions:
       contents: write
       security-events: write

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -37,6 +37,14 @@ on:
         type: boolean
         default: false
 
+    secrets:
+      QUAY_USERNAME:
+        description: "Registry user for pulling the image under test from ci-temp-images."
+        required: true
+      QUAY_PASSWORD:
+        description: "Registry token matching QUAY_USERNAME."
+        required: true
+
 jobs:
   test:  # decentralized k8s needs to run in github hosted workers for network stuff to work
     runs-on: ${{ inputs.test == 'provider-decentralized-k8s' && 'ubuntu-24.04' || 'fast' }}

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -39,10 +39,13 @@ on:
 
     secrets:
       QUAY_USERNAME:
-        description: "Registry user for pulling the image under test from ci-temp-images."
+        description: |
+          Registry user for quay.io/kairos/ci-temp-images. Needs WRITE, not just
+          read: this workflow pulls the image under test and also pushes a
+          bundles-test image back to the same repository.
         required: true
       QUAY_PASSWORD:
-        description: "Registry token matching QUAY_USERNAME."
+        description: "Registry token matching QUAY_USERNAME. Same write scope."
         required: true
 
 jobs:


### PR DESCRIPTION
Groundwork for #4307, and worth having on its own merits.

## Two changes

**1. Scope the secrets the qemu tests receive.** `reusable-qemu-test.yaml` declared no `workflow_call` secrets, so callers had no option but `secrets: inherit` — which hands **every repository and organisation secret** to jobs whose whole purpose is booting an image built from the pull request under review. It now declares the two it actually reads, and `image-pr.yaml` passes exactly those.

**2. Move the PR path onto the `ci-temp-images` robot.** Everything on this path writes exactly one repository, `quay.io/kairos/ci-temp-images`: the factory pushes the image under test, and `reusable-qemu-test.yaml` pulls it back and pushes a `bundles-test` image alongside. The `kairos+prci` robot has Write on that repository and nothing else.

| job | before | after |
|---|---|---|
| `build` | `QUAY_USERNAME` / `QUAY_PASSWORD` | `QUAY_PR_USERNAME` / `QUAY_PR_PASSWORD` |
| `core-tests` | `secrets: inherit` | `QUAY_PR_*` |
| `standard-tests` | `secrets: inherit` | `QUAY_PR_*` |

## This is a behavioural change, and it has a prerequisite

An earlier version of this description said "no behaviour change". That was true of change 1 alone and is **not** true now — change 2 switches which credential the PR path uses.

**It requires `QUAY_PR_USERNAME` and `QUAY_PR_PASSWORD` to exist as repository secrets.** They do, confirmed on 2026-08-13.

`QUAY_USERNAME` is the credential `release.yaml` uses to publish permanent images to `quay.io/kairos/<flavor>`. Sharing it with a path that builds contributor code was already more exposure than the work needs; it becomes the difference between a bounded and an unbounded leak once #4307 makes that path reachable from a fork.

Unchanged: `image-master.yaml`, `image-master-arm.yaml`, `uki.yaml`, `release.yaml` and `release-arm.yaml` all still use `QUAY_USERNAME`. Master builds and releases are untouched.

## Risk

If `kairos+prci` turns out to lack a permission the factory needs, the first **internal** pull request after merge fails at registry login. That is immediately visible and is fixed by granting the missing permission, not by reverting to `QUAY_USERNAME`. I could not enumerate the robot's permissions to rule this out — it has Write on `ci-temp-images`, which covers everything I can see this path touching.

## Testing

Both files parse and the `secrets:` block registers under `workflow_call`. CI on this pull request fails at registry login for the pre-existing reason — it originates from a fork, and forks receive no secrets at all, which is the very problem #4307 exists to fix. That failure is unrelated to this change and cannot be made green from a fork.

The first meaningful test is an internal pull request after merge, since those receive secrets.

---

<sub>🤖 Prepared by `mauro-agent`, an AI agent operated by @mauromorales, with his review.</sub>
