### PR TITLE
ci: bump the factory pin to v1.3.0

### DIFF
--- a/.github/workflows/image-master-arm.yaml
+++ b/.github/workflows/image-master-arm.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/image-master.yaml
+++ b/.github/workflows/image-master.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/image-pr-arm.yaml
+++ b/.github/workflows/image-pr-arm.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -16,7 +16,7 @@ jobs:
 
   core:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
     needs:
       - vulnerability-scan
     secrets:
@@ -119,7 +119,7 @@ jobs:
           echo "kubernetes_versions=$kubernetes_versions" >> $GITHUB_OUTPUT
   standard:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
   core:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
     needs:
       - vulnerability-scan
     permissions:
@@ -123,7 +123,7 @@ jobs:
 
   standard-k3s:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
     needs:
       - vulnerability-scan
       - get-k3s-versions
@@ -170,7 +170,7 @@ jobs:
       release: true
   standard-k0s:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
     needs:
       - vulnerability-scan
       - get-k0s-versions

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@8952c3a5f4f6255cc63af88cb3637a9684970c8d # v1.1.3
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Bumps `reusable-factory.yaml` from `v1.1.3` to `v1.3.0` across **all seven** workflows that pin it.

## Why

v1.3.0 adds the optional `ref` input ([kairos-factory-action#58](https://github.com/kairos-io/kairos-factory-action/pull/58)), needed for #4307. Without it a `pull_request_target` job cannot build the pull request it is running for — that event's context is the base branch, so the factory would check out `master`, pass, and report **green on code it never compiled**.

## What comes with it

`v1.1.3..v1.3.0` is four commits, and it is not a no-op:

| commit | change |
|---|---|
| `c3c3e368` | `actions/checkout` v6 → v7 |
| `ae071a3a` | `codeql-action` digest bump |
| `4d042585` | **#54** — reworks the GitHub Release step, adds `release_extraction_notes` (default `true`) |
| `33ba3bfc` | the `ref` input |

**#54 changes release output.** It appends raw-image extraction instructions to release notes when a build produces `.raw` artifacts, and `release-arm.yaml` does exactly that:

```yaml
raw: ${{ matrix.model == 'rpi3' || matrix.model == 'rpi4' }}
```

So **arm release notes will gain that section**. This was originally split into two PRs to keep that away from the 4.2.0 release; Mauro confirmed the change is wanted, so all seven pins move together and the tree stays on one factory version.

Note this also skips **v1.2.0**, which this repo never adopted — the table above is the complete set of what is being taken on.

## Files

`image-pr.yaml`, `image-pr-arm.yaml`, `image-master.yaml`, `image-master-arm.yaml`, `uki.yaml`, `release.yaml`, `release-arm.yaml`. One line each; no `v1.1.3` pins remain.

## Testing

All seven parse. CI on this pull request fails at registry login for the pre-existing reason — it originates from a fork, and forks receive no secrets, which is the problem #4307 exists to fix. The pin itself is exercised by the first internal pull request, and the release-notes change by the first arm release after merge.

---

<sub>🤖 Prepared by `mauro-agent`, an AI agent operated by @mauromorales, with his review.</sub>
