### PR TITLE
ci: bump the factory pin to v1.4.0 and drop the Jetson SBOM attestation

### DIFF
--- a/.github/workflows/image-master-arm.yaml
+++ b/.github/workflows/image-master-arm.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}
@@ -26,6 +26,11 @@ jobs:
       dockerfile_path: "images/Dockerfile"
       base_image: ${{ matrix.base_image }}
       model: ${{ matrix.model }}
+      # BuildKit refuses an attestation over 40 MiB and fails the whole push.
+      # The Jetson SBOM crosses it because of the CUDA userspace; the image
+      # itself builds and exports fine. Bumping packages cannot help, as the
+      # document scales with file count, not with version age.
+      sbom: ${{ !startsWith(matrix.model, 'nvidia-jetson') }}
       arch: "arm64"
       version: "auto"
       grype: ${{ matrix.grype }}

--- a/.github/workflows/image-master.yaml
+++ b/.github/workflows/image-master.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/image-pr-arm.yaml
+++ b/.github/workflows/image-pr-arm.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}
@@ -57,6 +57,11 @@ jobs:
       dockerfile_path: "images/Dockerfile"
       base_image: ${{ matrix.base_image }}
       model: ${{ matrix.model }}
+      # BuildKit refuses an attestation over 40 MiB and fails the whole push.
+      # The Jetson SBOM crosses it because of the CUDA userspace; the image
+      # itself builds and exports fine. Bumping packages cannot help, as the
+      # document scales with file count, not with version age.
+      sbom: ${{ !startsWith(matrix.model, 'nvidia-jetson') }}
       arch: "arm64"
       version: "auto"
       raw: ${{ matrix.model == 'rpi3' || matrix.model == 'rpi4' }} # only produce raw images for rpi3 and rpi4

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -16,7 +16,7 @@ jobs:
 
   core:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     needs:
       - vulnerability-scan
     secrets:
@@ -73,6 +73,11 @@ jobs:
       base_image: ${{ matrix.base_image }}
       arch: "arm64"
       model: ${{ matrix.model }}
+      # BuildKit refuses an attestation over 40 MiB and fails the whole push.
+      # The Jetson SBOM crosses it because of the CUDA userspace; the image
+      # itself builds and exports fine. Bumping packages cannot help, as the
+      # document scales with file count, not with version age.
+      sbom: ${{ !startsWith(matrix.model, 'nvidia-jetson') }}
       version: "auto"
       no_cache: true
       registry_domain: "quay.io"
@@ -119,7 +124,7 @@ jobs:
           echo "kubernetes_versions=$kubernetes_versions" >> $GITHUB_OUTPUT
   standard:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}
@@ -174,6 +179,11 @@ jobs:
       base_image: ${{ matrix.base_image }}
       arch: "arm64"
       model: ${{ matrix.model }}
+      # BuildKit refuses an attestation over 40 MiB and fails the whole push.
+      # The Jetson SBOM crosses it because of the CUDA userspace; the image
+      # itself builds and exports fine. Bumping packages cannot help, as the
+      # document scales with file count, not with version age.
+      sbom: ${{ !startsWith(matrix.model, 'nvidia-jetson') }}
       kubernetes_version: ${{ matrix.kubernetes_version }}
       kubernetes_distro: "k3s"
       version: "auto"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
   core:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     needs:
       - vulnerability-scan
     permissions:
@@ -123,7 +123,7 @@ jobs:
 
   standard-k3s:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     needs:
       - vulnerability-scan
       - get-k3s-versions
@@ -170,7 +170,7 @@ jobs:
       release: true
   standard-k0s:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     needs:
       - vulnerability-scan
       - get-k0s-versions

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@33ba3bfc227294ddd3b3d5ecc7b74f1a9ee468bf # v1.3.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
## The failure

ARM Jetson builds have failed on master since 2026-08-13 ([run 31680539079](https://github.com/kairos-io/kairos/actions/runs/31680539079)):

```
#12 [linux/arm64] generating sbom ...            DONE 12.3s
#13 exporting to image
#13   exporting layers                           done
#13   exporting manifest sha256:e63258b7...      done
#13   exporting config   sha256:982f44e9...      done
#13 ERROR: sbom.spdx.json exceeds 41943040 bytes
```

41943040 bytes is exactly **40 MiB**, a BuildKit limit on a single attestation.

**The image is not the problem.** Layers, manifest and config all export successfully; only the attestation step fails, and it takes the push down with it. Nothing about the image is unsafe, and no vulnerability is involved — Grype passes in the same job with zero criticals.

**Only the two Jetson models are affected.** `generic`, `rpi3` and `rpi4` pass in the same run. The CUDA userspace gives Jetson far higher package and file counts, so its SPDX document is far larger.

## Why bumping something is not the fix

The document scales with **how many** packages and files an image contains, not with how old they are. A newer package set is usually larger, so bumping pushes it further over the limit rather than under it. There is no version of anything that gets below 40 MiB.

## The change

[kairos-io/kairos-factory-action#59](https://github.com/kairos-io/kairos-factory-action/pull/59) added an `sbom` input for exactly this, defaulting to `true`. **v1.4.0 is the first release containing it**, so the pin moves from v1.3.0 to v1.4.0 across all ten references, and the two Jetson models opt out.

The opt-out keys off the model prefix rather than a per-entry matrix field:

```yaml
sbom: ${{ !startsWith(matrix.model, 'nvidia-jetson') }}
```

That matches the existing style of `iso: ${{ matrix.model == 'generic' }}` in the same block, and covers a future `nvidia-jetson-*` model without a second edit.

Verified against every model value across the three ARM workflows:

| model | SBOM |
|---|---|
| `generic` | kept |
| `rpi3` | kept |
| `rpi4` | kept |
| `nvidia-jetson-agx-orin` | **dropped** |
| `nvidia-jetson-orin-nx` | **dropped** |

**Every other caller keeps its SBOM.** The amd64 and UKI workflows take the pin bump only.

## This is a real loss, and there are better fixes

Jetson consumers get no attached bill of materials. Two better options are recorded in the input's own description upstream, so whoever revisits this reads them at the point of use:

1. **Shrink the document** — package-level SPDX without file-level entries is typically far under the limit and keeps a usable SBOM.
2. **Publish the SBOM as a separate artifact** rather than an inline attestation, which the 40 MiB cap does not apply to.

Both need more work than this does. This unblocks publishing the affected images meanwhile.

## Verification

All three ARM workflow files parse. The pin appears ten times and all ten are now v1.4.0 (`730309d`). Not otherwise exercised — the Jetson jobs run on merge.
