### PR TITLE
chore: bump kairos-init to v0.17.0

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ubuntu:20.04
-ARG KAIROS_INIT=v0.16.3
+ARG KAIROS_INIT=v0.17.0
 
 FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
 


### PR DESCRIPTION
Bumps the pinned kairos-init image from `v0.16.3` to `v0.17.0`.

## Why

The release vulnerability scan failed on the `v4.2.0-rc2` tag. It reported 18 unignored advisories, across 43 findings, in the shipped bundle. Both `Release AMD64 artifacts` and `Release ARM artifacts` stopped at that job, so rc2 published no artifacts.

`v0.16.3` is the cause. It pins provider-kairos `v2.16.1`, and it builds every Go component with Go 1.26.5.

## What v0.17.0 changes

It bumps all five Go components:

| component | v0.16.3 | v0.17.0 |
|---|---|---|
| immucore | v0.20.1 | v0.20.2 |
| kairos-agent | v2.31.1 | v2.31.2 |
| kcrypt-discovery-challenger | v0.13.3 | v0.13.4 |
| provider-kairos | v2.16.1 | v2.16.3 |
| kairos-installer | v0.1.4 | v0.1.5 |

This clears all 18 advisories:

- **8 advisories in the Go stdlib.** Every component above now declares `go 1.26.6`. The scan found 1.26.4 and 1.26.5.
- **2 advisories in `golang.org/x/mod`,** in kairos-agent. v2.31.2 moves it to v0.40.0.
- **9 advisories in provider-kairos dependencies.** v2.16.3 carries `x/image` v0.43.0, `grpc` v1.83.0, `x/net` v0.57.0, `otel` v1.45.0 and `klauspost/compress` v1.19.1.

edgevpn stays at `v0.35.3`. Its advisories keep their dated entries in `osv-scanner.toml`, and the fix is still upstream in mudler/edgevpn#1075.

## Note on #4272

#4272 bumps the same pin to `v0.16.4`. That version keeps kairos-agent v2.31.1 and Go 1.26.5, so the scan still fails on it. This PR supersedes it.

## Test plan

The release scan job on the next release candidate is the real check. It must report no unignored advisories.
