### PR TITLE
ci: clear boringcrypto false positives from the release scan

### DIFF
--- a/.github/workflows/release-scan.yml
+++ b/.github/workflows/release-scan.yml
@@ -127,6 +127,70 @@ jobs:
             exit 1
           fi
 
+      # osv-scanner compares the stdlib version string verbatim. A binary built
+      # with the boringcrypto toolchain reports its version as, for example,
+      # "1.26.6-X:boringcrypto", and semver orders that BELOW plain "1.26.6"
+      # because the suffix reads as a prerelease. So every stdlib advisory
+      # fixed in 1.26.6 still matches the FIPS binaries, even though they were
+      # built from that toolchain and carry the fix -- the very same advisories
+      # report clean against the non-FIPS binaries at plain "1.26.6".
+      #
+      # This drops exactly that case: a stdlib finding on a -X:boringcrypto
+      # build whose base version is at or past a published fix on the SAME
+      # major.minor track. A genuinely old boringcrypto build, or one whose
+      # only published fix sits on another track, is left in place -- the
+      # filter fails closed. Whatever it removes is listed in the job summary,
+      # so this suppresses nothing silently.
+      - name: Normalize boringcrypto stdlib versions
+        run: |
+          set -euo pipefail
+          cp osv.json osv.raw.json
+          jq '
+            def strip_pre: sub("-.*$"; "");
+            def arr: strip_pre | split(".") | map(tonumber? // 0);
+            def covered($base):
+              [ .affected[]?.ranges[]?.events[]?.fixed // empty ]
+              | map(arr)
+              | any(.[0] == $base[0] and .[1] == $base[1] and .[2] <= $base[2]);
+            .results |= map(
+              .packages |= map(
+                if (.package.name == "stdlib"
+                    and (.package.version | test("-X:boringcrypto$")))
+                then
+                  (.package.version | arr) as $base
+                  | .vulnerabilities = [ .vulnerabilities[]? | select(covered($base) | not) ]
+                else . end
+              )
+            )' osv.raw.json > osv.json
+
+          jq -r '
+            [ .results[].packages[]
+              | . as $pkg
+              | .vulnerabilities[]?
+              | "\(.id) \($pkg.package.name)@\($pkg.package.version)"
+            ] | unique | .[]' osv.raw.json | sort > all.before
+          jq -r '
+            [ .results[].packages[]
+              | . as $pkg
+              | .vulnerabilities[]?
+              | "\(.id) \($pkg.package.name)@\($pkg.package.version)"
+            ] | unique | .[]' osv.json | sort > all.after
+          SUPPRESSED="$(comm -23 all.before all.after || true)"
+          if [ -n "${SUPPRESSED}" ]; then
+            {
+              echo "## Boringcrypto stdlib findings normalized"
+              echo
+              echo "Fixed on the same major.minor track as the build's base version:"
+              echo
+              echo '```'
+              echo "${SUPPRESSED}"
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+            echo "normalized $(echo "${SUPPRESSED}" | wc -l) boringcrypto stdlib findings"
+          else
+            echo "no boringcrypto stdlib findings to normalize"
+          fi
+
       - name: Report and enforce
         run: |
           set -euo pipefail

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -193,3 +193,60 @@ reason = "upstream-fix-pending: CVE-2026-54909, pion/stun in edgevpn. Fix v3.1.5
 id = "GHSA-wg4g-wm44-ch5j"
 ignoreUntil = 2026-09-11
 reason = "upstream-fix-pending: CVE-2026-54908, pion/dtls in edgevpn. Fix v3.1.4 submitted as mudler/edgevpn#1075, awaiting merge and an edgevpn release."
+
+
+# ---------------------------------------------------------------------------
+# upstream-fix-pending -- Go stdlib advisories carried by the `edgevpn` binary,
+# which kairos-init consumes as a prebuilt tarball from mudler/edgevpn. Found
+# by a scan of kairos-init v0.17.0's uncompressed bundle on 2026-08-14.
+#
+# All eight are fixed in Go 1.26.6. Every binary Kairos builds itself already
+# ships at 1.26.6 and reports clean; edgevpn v0.35.3 was released from 1.26.4,
+# and the version of Go a release was built with is not something a consumer
+# can override. There is no code change to make anywhere -- these clear the
+# moment mudler cuts any edgevpn release from a current toolchain, which is
+# why the clock here is short rather than the 90 days no-fix-available buys.
+#
+# EDGEVPN_VERSION in kairos-init moves at the same time as the pion fixes
+# above, so these should be re-looked at together with mudler/edgevpn#1075.
+# ---------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "GO-2026-5026"
+ignoreUntil = 2026-09-13
+reason = "upstream-fix-pending: CVE-2026-39821, golang.org/x/net/idna in the edgevpn binary. Fixed in Go 1.26.6; edgevpn v0.35.3 was built with 1.26.4. Needs an edgevpn release from a current toolchain."
+
+[[IgnoredVulns]]
+id = "GO-2026-5942"
+ignoreUntil = 2026-09-13
+reason = "upstream-fix-pending: CVE-2026-46600, golang.org/x/net/dns/dnsmessage in the edgevpn binary. Fixed in Go 1.26.6; edgevpn v0.35.3 was built with 1.26.4. Needs an edgevpn release from a current toolchain."
+
+[[IgnoredVulns]]
+id = "GO-2026-5972"
+ignoreUntil = 2026-09-13
+reason = "upstream-fix-pending: CVE-2026-33818, encoding/asn1 in the edgevpn binary. Fixed in Go 1.26.6; edgevpn v0.35.3 was built with 1.26.4. Needs an edgevpn release from a current toolchain."
+
+[[IgnoredVulns]]
+id = "GO-2026-6088"
+ignoreUntil = 2026-09-13
+reason = "upstream-fix-pending: CVE-2026-56859, encoding/xml in the edgevpn binary. Fixed in Go 1.26.6; edgevpn v0.35.3 was built with 1.26.4. Needs an edgevpn release from a current toolchain."
+
+[[IgnoredVulns]]
+id = "GO-2026-6089"
+ignoreUntil = 2026-09-13
+reason = "upstream-fix-pending: CVE-2026-56853, net/http in the edgevpn binary. Fixed in Go 1.26.6; edgevpn v0.35.3 was built with 1.26.4. Needs an edgevpn release from a current toolchain."
+
+[[IgnoredVulns]]
+id = "GO-2026-6090"
+ignoreUntil = 2026-09-13
+reason = "upstream-fix-pending: CVE-2026-56862, crypto/tls in the edgevpn binary. Fixed in Go 1.26.6; edgevpn v0.35.3 was built with 1.26.4. Needs an edgevpn release from a current toolchain."
+
+[[IgnoredVulns]]
+id = "GO-2026-6091"
+ignoreUntil = 2026-09-13
+reason = "upstream-fix-pending: CVE-2026-56858, html/template in the edgevpn binary. Fixed in Go 1.26.6; edgevpn v0.35.3 was built with 1.26.4. Needs an edgevpn release from a current toolchain."
+
+[[IgnoredVulns]]
+id = "GO-2026-6218"
+ignoreUntil = 2026-09-13
+reason = "upstream-fix-pending: CVE-2026-56860, net/url in the edgevpn binary. Fixed in Go 1.26.6; edgevpn v0.35.3 was built with 1.26.4. Needs an edgevpn release from a current toolchain."


### PR DESCRIPTION
Follow-up to #4317. That bump moved every Go component Kairos builds to 1.26.6, but the release gate still reports **8 unignored advisories (16 findings)**, so `v4.2.0-rc3` would still publish no artifacts.

## The FIPS findings are not real

All 8 are Go stdlib advisories, and all 8 are fixed in `1.26.6`. Where they land:

| binary | stdlib | advisories |
|---|---|---|
| `binaries/{immucore, kairos-agent, kcrypt-discovery-challenger, provider-kairos, kairos-installer}` | `1.26.6` | 0 |
| `binaries/fips/{immucore, kairos-agent, kcrypt-discovery-challenger, provider-kairos}` | `1.26.6-X:boringcrypto` | 8 each |
| `binaries/edgevpn` | `1.26.4` | 8 |

osv-scanner compares the stdlib version string verbatim. A binary built with the boringcrypto toolchain reports `1.26.6-X:boringcrypto`, and semver orders that *below* plain `1.26.6` because the suffix reads as a prerelease. So every advisory fixed in 1.26.6 still matches the FIPS binaries — while the identical advisories report clean against the non-FIPS binaries built from the same toolchain.

## What this does

**1. Normalizes that case out of `osv.json` after the scan.** A stdlib finding on a `-X:boringcrypto` build is dropped only when its base version is at or past a published fix on the *same* `major.minor` track. A genuinely old boringcrypto build, or one whose only published fix sits on another track, is left in place — the filter fails closed. Everything it removes is listed in the job summary, so nothing is suppressed silently.

**2. Dated `upstream-fix-pending` entries for the edgevpn copies.** kairos-init consumes edgevpn as a prebuilt tarball from mudler/edgevpn; v0.35.3 was released from Go 1.26.4, and a consumer cannot override the toolchain a release was built with. There is no code change to make anywhere — these clear the moment mudler cuts any edgevpn release from a current toolchain, which is why the clock is 30 days rather than the 90 that `no-fix-available` buys. They come up for re-look alongside the pion entries and mudler/edgevpn#1075.

## Test plan

Replayed against the real scan output from #4317's run:

- 32 boringcrypto findings normalized away; edgevpn's 8 untouched by the filter, then covered by the new entries → **0 remaining findings**
- 1425 packages still extracted, so the false-green guard still passes on a genuine scan
- `osv-scanner.toml` parses; 29 entries, no duplicate IDs

The release scan on the next release candidate is the real check.

## Note on coverage

`IgnoredVulns` keys on advisory ID with no path scoping, so the 8 new entries also apply to the non-FIPS binaries. Those sit at 1.26.6 and are clean today, but a future regression below 1.26.6 in one of them would be masked until the entries expire on 2026-09-13. That is the same tradeoff every existing entry in this file carries, and the dated expiry is the control for it.
