### PR TITLE
chore: bump kairos-init to v0.17.1

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ubuntu:20.04
-ARG KAIROS_INIT=v0.17.0
+ARG KAIROS_INIT=v0.17.1
 
 FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
 


### PR DESCRIPTION
Closes the chain that started with #4314.

## What this carries

`kairos-init` `v0.17.1` pins `immucore` `v0.20.3`, which carries [kairos-io/immucore#611](https://github.com/kairos-io/immucore/pull/611).

Before that fix, an automatic state reset on a BIOS or GRUB install **did nothing and said nothing**. `kairos-sdk` `v0.25.0` started reporting a `kairos.reset` command line as `AutoReset` instead of `Recovery`, immucore had no `AutoReset` arm in its two label functions, sysroot got an empty device, and the boot died in the initramfs. `rd.emergency=reboot` and `rd.shell=0` are on that command line, so the machine rebooted with no shell and no message, and `next_entry` is one-shot — from the outside it looked like a plain reboot, with the persistent partition untouched.

## Why it matters here

`v0.17.0`, which `master` pins today, carries immucore `v0.20.2` and is affected. **Every image this repository builds from `v0.17.0` has the bug.**

| step | version | affected |
|---|---|---|
| kairos-init `v0.17.0` | immucore `v0.20.2` | **yes** |
| kairos-init `v0.17.1` | immucore `v0.20.3` | no |

## Scope

One line. `images/Dockerfile:2` is the only real pin — the release workflows resolve the version from that file. The `examples/builds/*` Dockerfiles are on `v0.7.0-beta13` and are not part of this.

## Verified

`quay.io/kairos/kairos-init:v0.17.1` is live with all three architectures, published today at 13:38 UTC:

```
tag: v0.17.1 | digest: sha256:1d5ca09f5aaf... | present_child_count: 3
```

I held this pull request open locally until that image existed, so CI here does not fail on a missing base image.

`v0.17.1`'s `Makefile` reads `IMMUCORE_VERSION := v0.20.3`; `v0.17.0`'s reads `v0.20.2`.

## Related

- [kairos-io/immucore#613](https://github.com/kairos-io/immucore/pull/613) — the same gap in a third function, merged.
- [kairos-io/immucore#614](https://github.com/kairos-io/immucore/pull/614) — makes the linter catch a missing `state.Boot` case, merged.
- #4321 — the missing non-UKI test coverage that let #613 hide.

---

AI assisted this pull request. A human is attending and directed it.
