### PR TITLE
ci: let a fork pull request build, behind a reviewer gate

### DIFF
--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -1,7 +1,24 @@
 name: 'Build AMD64 images (PR)'
 
+# SETUP REQUIRED BEFORE THIS MERGES.
+#
+# The `external` environment must exist with required reviewers. Without it,
+# this file is strictly worse than what it replaces: `pull_request_target`
+# hands secrets to every fork pull request, and the `authorize` job below then
+# gates nothing. GitHub creates a referenced environment implicitly, with no
+# protection rules, so an absent environment fails open rather than closed.
+#
+# Settings -> Environments -> New environment -> `external`
+#   -> Required reviewers -> the maintainers team.
+# `internal` needs no protection rules; same-repo pull requests run unattended.
+#
+# Why this shape at all: GitHub does not pass secrets to a workflow triggered by
+# `pull_request` from a fork, so an outside contributor's build fails at the
+# registry login and every job after it skips. `pull_request_target` does pass
+# them, which is why the approval gate has to come with it.
+
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: write
@@ -12,8 +29,24 @@ concurrency:
   group: ci-pr-amd64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
+  # Nothing else in this workflow starts until this job does. A pull request
+  # from a fork lands in the `external` environment and waits for a reviewer;
+  # a same-repo pull request lands in `internal` and goes straight through, so
+  # maintainer and renovate branches keep running unattended.
+  #
+  # The job itself does nothing. The environment is the gate, and a reviewer
+  # approving it is a person saying they have read the diff they are about to
+  # run with the ci-temp-images credentials.
+  authorize:
+    name: authorize
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+
   build:
     name: ${{ matrix.image_name }}
+    needs: authorize
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     secrets:
       # The PR path only ever writes quay.io/kairos/ci-temp-images, so it uses
@@ -35,6 +68,9 @@ jobs:
             kubernetes_distro: "k3s"
             custom_job_name_format: "standard-amd64-generic-k3s"
     with:
+      # pull_request_target's context is the base branch, so the ref has to be
+      # named explicitly or this would build master and test nothing.
+      ref: refs/pull/${{ github.event.pull_request.number }}/head
       auroraboot_version: "v0.26.2"
       dockerfile_path: "images/Dockerfile"
       base_image: ${{ matrix.base_image }}
@@ -66,6 +102,7 @@ jobs:
       QUAY_PASSWORD: ${{ secrets.QUAY_PR_PASSWORD }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
+      ref: refs/pull/${{ github.event.pull_request.number }}/head
       base_image: "ghcr.io/kairos-io/hadron:v0.5.1"
       test: ${{ matrix.test }}
       secureboot: false
@@ -114,6 +151,7 @@ jobs:
       repository-projects: read
       statuses: read
     with:
+      ref: refs/pull/${{ github.event.pull_request.number }}/head
       base_image: "ghcr.io/kairos-io/hadron:v0.5.1"
       test: ${{ matrix.test }}
       variant: "standard"

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -1,21 +1,18 @@
 name: 'Build AMD64 images (PR)'
 
-# SETUP REQUIRED BEFORE THIS MERGES.
+# GitHub does not pass secrets to a workflow triggered by `pull_request` from a
+# fork, so an outside contributor's build fails at the registry login and every
+# job after it skips. `pull_request_target` does pass them, which is why the
+# approval gate below has to come with it. Background: issue #4307.
 #
-# The `external` environment must exist with required reviewers. Without it,
-# this file is strictly worse than what it replaces: `pull_request_target`
-# hands secrets to every fork pull request, and the `authorize` job below then
-# gates nothing. GitHub creates a referenced environment implicitly, with no
-# protection rules, so an absent environment fails open rather than closed.
+# `fork-pr-builds` already exists with the maintainers team as required
+# reviewers. It was created on 2026-08-13, alongside the factory `ref` input
+# this depends on, and this workflow is what finally uses it.
 #
-# Settings -> Environments -> New environment -> `external`
-#   -> Required reviewers -> the maintainers team.
-# `internal` needs no protection rules; same-repo pull requests run unattended.
-#
-# Why this shape at all: GitHub does not pass secrets to a workflow triggered by
-# `pull_request` from a fork, so an outside contributor's build fails at the
-# registry login and every job after it skips. `pull_request_target` does pass
-# them, which is why the approval gate has to come with it.
+# Do not rename it to something that does not exist. GitHub creates a
+# referenced environment implicitly and with no protection rules, so a typo
+# here fails open: every fork pull request would get the secrets and nothing
+# would gate it.
 
 on:
   pull_request_target:
@@ -30,16 +27,19 @@ concurrency:
   cancel-in-progress: true
 jobs:
   # Nothing else in this workflow starts until this job does. A pull request
-  # from a fork lands in the `external` environment and waits for a reviewer;
-  # a same-repo pull request lands in `internal` and goes straight through, so
+  # from a fork lands in `fork-pr-builds` and waits for a maintainer; a
+  # same-repo pull request lands in `internal` and goes straight through, so
   # maintainer and renovate branches keep running unattended.
+  #
+  # `internal` carries no protection rules on purpose. It exists only because
+  # the environment name has to resolve to something on both paths.
   #
   # The job itself does nothing. The environment is the gate, and a reviewer
   # approving it is a person saying they have read the diff they are about to
   # run with the ci-temp-images credentials.
   authorize:
     name: authorize
-    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-builds' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
       - run: 'true'

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -36,6 +36,19 @@ on:
         required: false
         type: boolean
         default: false
+      ref:
+        description: |
+          Git ref to check out. Leave empty for the ref that triggered the
+          calling workflow, which is right for every ordinary caller.
+
+          Set it only when the caller must test something other than its own
+          trigger ref. The motivating case is a `pull_request_target` workflow,
+          whose context is the base branch: without this the tests would run
+          the base branch's test code against an image built from the pull
+          request. Pass `refs/pull/<n>/head`.
+        required: false
+        type: string
+        default: ''
 
     secrets:
       QUAY_USERNAME:
@@ -103,6 +116,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref }}
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         timeout-minutes: 5


### PR DESCRIPTION
Closes #4307. **This is the caller side that [kairos-io/kairos-factory-action#58](https://github.com/kairos-io/kairos-factory-action/pull/58) deliberately left for a separate review** — not new design.

The plan in #4307 has been built in three steps, and this is the last one:

| step | what | state |
|---|---|---|
| 1 | `reusable-factory.yaml` gains a `ref` input | [factory#58](https://github.com/kairos-io/kairos-factory-action/pull/58), merged 2026-08-13 |
| 2 | qemu tests stop using `secrets: inherit` | #4309, merged 2026-08-14 |
| 3 | **the `pull_request_target` caller** | **this pull request** |

Step 2 was named in #4307 as a prerequisite — `secrets: inherit` would have handed every organisation secret to a job booting a PR-built image, which is "harmless today because forks get no secrets at all" and "becomes a real hole the moment `pull_request_target` exists". `reusable-qemu-test.yaml` now declares `QUAY_USERNAME` and `QUAY_PASSWORD` under `workflow_call.secrets`, so that hole is shut before this opens the door.

## The environment: `fork-pr-builds`, which already exists

An earlier revision of this pull request invented an `external` environment and asked a reader to create one. That was wrong, and it caused a duplicate to be created. **`fork-pr-builds` already existed** with the maintainers team as required reviewers — created 2026-08-13, sixteen minutes after [factory#58](https://github.com/kairos-io/kairos-factory-action/pull/58) merged, as part of this same plan, and never wired to anything until now.

| environment | created | why it exists |
|---|---|---|
| `fork-pr-builds` | 2026-08-13 07:40Z | made for this. **This is the one this uses.** |
| `external` | 2026-08-17 18:15Z | created only because this pull request's first revision asked for it. **Safe to delete.** |

**No setup is needed.** The one hazard left is a name that does *not* exist: GitHub creates a referenced environment implicitly and **without protection rules**, so a typo in that expression fails open — every fork pull request would get the secrets and nothing would gate them. The workflow header says exactly that.

`internal` is deliberately unprotected and will be created on first use. It carries no rules on purpose; it exists only because the environment name has to resolve to something on the same-repo path too.

## The problem

#4322 is the live example. Step 7 `Login to registry` fails, and all 30 steps after it skip:

```
7. Login to registry -> failure
8. Build Kairos image -> skipped
...
36. Upload RAW artifacts -> skipped
```

GitHub does not pass secrets to a workflow triggered by `pull_request` from a fork, so `secrets.QUAY_PR_USERNAME` is empty and the login fails. Every check on such a pull request is red or skipped, and the only way to see it green is a maintainer pushing the branch into this repository by hand.

## The shape, and why it has to be this shape

`pull_request_target` **does** pass secrets — that is the only mechanism GitHub offers here. On its own it is the classic pwn request: a stranger's code running with the `ci-temp-images` credentials, unattended.

So the trigger change comes with an `authorize` job in front of everything:

```yaml
  authorize:
    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-builds' || 'internal' }}
    runs-on: ubuntu-latest
    steps:
      - run: 'true'
```

- **Fork pull request** → `fork-pr-builds` → waits for a maintainer.
- **Same-repo pull request** → `internal` → straight through. Maintainer branches and renovate are unaffected, no new clicking.

The job does nothing. The environment is the gate, and approving it is a person saying they have read the diff they are about to run with those credentials.

## The part that is easy to miss

`pull_request_target` runs with **the base branch as its context**. Left alone, this would build `master`, run `master`'s tests, and report the result on the pull request as though it meant something — green checks that tested none of the proposed change.

So both consumers are told which ref to use:

```yaml
ref: refs/pull/${{ github.event.pull_request.number }}/head
```

`reusable-factory.yaml` already had that input, added for precisely this case. `reusable-qemu-test.yaml` did not, so this adds one, defaulting to `''` — which is `actions/checkout`'s own default, so **every other caller is unchanged**.

`refs/pull/<n>/head` is reachable from this repository, so no second repository is ever named.

## Scope

`image-pr.yaml` only, deliberately. `image-pr-arm.yaml` and `uki.yaml` have the same problem, but both use `QUAY_USERNAME`/`QUAY_PASSWORD` on a pull request path — the production credential that `image-pr.yaml`'s own comment says "does not belong on a PR path". They need a decision about that first, and this change should not make it for them.

## What is verified, and what is not

Verified: both files parse, the `authorize` gate precedes every job, all three consumers receive the ref, and the factory genuinely wires `inputs.ref` into its checkout (`reusable-factory.yaml:331`).

**Not verified: none of this has run.** A `pull_request_target` workflow only takes effect once it is on the default branch, so this pull request cannot exercise itself. The honest test after merging is a throwaway fork pull request: it should park awaiting approval, then build the fork's code once approved.

I would also recommend trimming the workflow-level `contents: write` afterwards. Under `pull_request_target` that token is a write token for this repository. The approval gate is what makes it safe today; a narrower token would make it safer.

---

AI assisted this pull request. A human is attending and directed it.
