### PR TITLE
ci: scope image-pr-arm.yaml and uki.yaml off the production quay credential

### DIFF
--- a/.github/workflows/image-pr-arm.yaml
+++ b/.github/workflows/image-pr-arm.yaml
@@ -16,8 +16,12 @@ jobs:
     name: ${{ matrix.image_name }}
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     secrets:
-      registry_username: ${{ secrets.QUAY_USERNAME }}
-      registry_password: ${{ secrets.QUAY_PASSWORD }}
+      # The PR path only ever writes quay.io/kairos/ci-temp-images, so it uses
+      # the kairos+prci robot, which has Write on that repository and nothing
+      # else. QUAY_USERNAME/QUAY_PASSWORD is the credential release.yaml uses to
+      # publish permanent images and does not belong on a PR path.
+      registry_username: ${{ secrets.QUAY_PR_USERNAME }}
+      registry_password: ${{ secrets.QUAY_PR_PASSWORD }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -18,8 +18,12 @@ jobs:
     name: ${{ matrix.image_name }}
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
     secrets:
-      registry_username: ${{ secrets.QUAY_USERNAME }}
-      registry_password: ${{ secrets.QUAY_PASSWORD }}
+      # The PR path only ever writes quay.io/kairos/ci-temp-images, so it uses
+      # the kairos+prci robot, which has Write on that repository and nothing
+      # else. QUAY_USERNAME/QUAY_PASSWORD is the credential release.yaml uses to
+      # publish permanent images and does not belong on a PR path.
+      registry_username: ${{ secrets.QUAY_PR_USERNAME }}
+      registry_password: ${{ secrets.QUAY_PR_PASSWORD }}
     with:
       auroraboot_version: "v0.26.2"
       dockerfile_path: "images/Dockerfile"
@@ -140,8 +144,10 @@ jobs:
         uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+          # Only pushes and pulls quay.io/kairos/ci-temp-images. See the build
+          # job's secrets block above for why this is not QUAY_USERNAME.
+          username: ${{ secrets.QUAY_PR_USERNAME }}
+          password: ${{ secrets.QUAY_PR_PASSWORD }}
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -293,8 +299,10 @@ jobs:
         uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+          # Only pushes and pulls quay.io/kairos/ci-temp-images. See the build
+          # job's secrets block above for why this is not QUAY_USERNAME.
+          username: ${{ secrets.QUAY_PR_USERNAME }}
+          password: ${{ secrets.QUAY_PR_PASSWORD }}
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
## What

`image-pr-arm.yaml` and `uki.yaml` log in to quay with `QUAY_USERNAME`/`QUAY_PASSWORD` — the credential `release.yaml` uses to publish permanent images. Both workflows only ever push to `quay.io/kairos/ci-temp-images`, a scratch repository whose images expire after 6h.

This switches both to `QUAY_PR_USERNAME`/`QUAY_PR_PASSWORD`, the `kairos+prci` robot account scoped to write on `ci-temp-images` and nothing else.

## Why

`image-pr.yaml` already moved to the scoped credential as part of #4323's fork-pr-builds work. These two never got the same treatment, so every pull request run — including one from a fork with maintainer approval, once #4323 lands — hands the production publishing credential to a build that only needs scratch-repo access.

## Scope

Two files, credential names only. No trigger changes, no other behavior changes.

---

AI assisted this pull request. A human is attending and directed it.
