### PR TITLE
ci: extend the fork-pr-builds gate to image-pr-arm.yaml and uki.yaml

### DIFF
--- a/.github/workflows/image-pr-arm.yaml
+++ b/.github/workflows/image-pr-arm.yaml
@@ -1,7 +1,18 @@
 name: 'Build ARM images (PR)'
 
+# Same gate as image-pr.yaml, and for the same reason: GitHub does not pass
+# secrets to a `pull_request` run from a fork, so this workflow failed at the
+# registry login for every outside contributor. `pull_request_target` passes
+# them, gated by the fork-pr-builds environment below. Background: #4307,
+# #4323.
+#
+# `fork-pr-builds` already exists with the maintainers team as required
+# reviewers (created 2026-08-13). Do not rename it to something that does not
+# exist -- GitHub creates a referenced environment implicitly and with no
+# protection rules, so a typo here fails open.
+
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: write
@@ -12,8 +23,19 @@ concurrency:
   group: ci-pr-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
+  # Nothing else in this workflow starts until this job does. See
+  # image-pr.yaml's authorize job for the full reasoning -- this is the same
+  # gate, unchanged.
+  authorize:
+    name: authorize
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-builds' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+
   build:
     name: ${{ matrix.image_name }}
+    needs: authorize
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     secrets:
       # The PR path only ever writes quay.io/kairos/ci-temp-images, so it uses
@@ -57,6 +79,9 @@ jobs:
             grype: false # too many vulns under the L4T rootfs
             custom_job_name_format: ""
     with:
+      # pull_request_target's context is the base branch, so the ref has to be
+      # named explicitly or this would build master and test nothing.
+      ref: refs/pull/${{ github.event.pull_request.number }}/head
       auroraboot_version: "v0.26.2"
       dockerfile_path: "images/Dockerfile"
       base_image: ${{ matrix.base_image }}

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -156,6 +156,11 @@ jobs:
           # a pull_request_target run tests the base branch's test code
           # against an image built from the pull request's own code.
           ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || '' }}
+          # actions/checkout refuses to fetch a non-default ref inside a
+          # pull_request_target workflow otherwise -- see reusable-factory.yaml's
+          # own checkout step (kairos-io/kairos-factory-action#60) for the fix
+          # this mirrors.
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
       - name: Set Version
         run: echo "VERSION=$(git describe --tags --dirty )" >> $GITHUB_ENV
       - name: Install Go
@@ -315,6 +320,11 @@ jobs:
           # a pull_request_target run tests the base branch's test code
           # against an image built from the pull request's own code.
           ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || '' }}
+          # actions/checkout refuses to fetch a non-default ref inside a
+          # pull_request_target workflow otherwise -- see reusable-factory.yaml's
+          # own checkout step (kairos-io/kairos-factory-action#60) for the fix
+          # this mirrors.
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
       - name: Set Version
         run: echo "VERSION=$(git describe --tags --dirty )" >> $GITHUB_ENV
       - name: Install Go

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -1,6 +1,22 @@
 name: Build UKI images
+
+# Same gate as image-pr.yaml, and for the same reason: GitHub does not pass
+# secrets to a `pull_request` run from a fork, so this workflow failed at the
+# registry login for every outside contributor. `pull_request_target` passes
+# them, gated by the fork-pr-builds environment below. Background: #4307,
+# #4323.
+#
+# The push-to-master trigger is untouched: pull_request_target's approval gate
+# only applies to the pull_request path, and authorize's environment
+# expression below checks github.event_name first so a push never routes
+# through fork-pr-builds.
+#
+# `fork-pr-builds` already exists with the maintainers team as required
+# reviewers (created 2026-08-13). Do not rename it to something that does not
+# exist -- GitHub creates a referenced environment implicitly and with no
+# protection rules, so a typo here fails open.
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - master
@@ -14,8 +30,21 @@ concurrency:
   group: ci-uki-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
+  # Nothing else in this workflow starts until this job does. See
+  # image-pr.yaml's authorize job for the full reasoning -- this is the same
+  # gate, extended with an explicit event_name check so a push to master
+  # (which has no `github.event.pull_request` at all) always lands in
+  # `internal` rather than evaluating the fork check against a null PR object.
+  authorize:
+    name: authorize
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-builds' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+
   build:
     name: ${{ matrix.image_name }}
+    needs: authorize
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     secrets:
       # The PR path only ever writes quay.io/kairos/ci-temp-images, so it uses
@@ -25,6 +54,11 @@ jobs:
       registry_username: ${{ secrets.QUAY_PR_USERNAME }}
       registry_password: ${{ secrets.QUAY_PR_PASSWORD }}
     with:
+      # pull_request_target's context is the base branch, so the ref has to be
+      # named explicitly on that path or this would build master and test
+      # nothing. Empty on a push -- reusable-factory.yaml then falls back to
+      # the ref that triggered it, which is already correct for a push.
+      ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || '' }}
       auroraboot_version: "v0.26.2"
       dockerfile_path: "images/Dockerfile"
       base_image: ${{ matrix.base_image }}
@@ -118,6 +152,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: '0'
+          # Same reasoning as the build job's ref input above: without this,
+          # a pull_request_target run tests the base branch's test code
+          # against an image built from the pull request's own code.
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || '' }}
       - name: Set Version
         run: echo "VERSION=$(git describe --tags --dirty )" >> $GITHUB_ENV
       - name: Install Go
@@ -273,6 +311,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: '0'
+          # Same reasoning as the build job's ref input above: without this,
+          # a pull_request_target run tests the base branch's test code
+          # against an image built from the pull request's own code.
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || '' }}
       - name: Set Version
         run: echo "VERSION=$(git describe --tags --dirty )" >> $GITHUB_ENV
       - name: Install Go


### PR DESCRIPTION
## What

#4323 moved `image-pr.yaml` to `pull_request_target` plus the `fork-pr-builds` approval gate — scoped to that one file on purpose. `image-pr-arm.yaml` and `uki.yaml` build on every pull request too, and both still ran on plain `pull_request`, so a fork PR got no secrets at all and failed at the registry login. Same symptom this repo's CI is showing right now on any fork PR that touches these two workflows.

This extends the identical pattern to both:

- `pull_request_target` instead of `pull_request`
- the same `authorize` job, gating on `fork-pr-builds` for a fork PR and `internal` otherwise
- a `ref` input threaded to every checkout (the factory call, and `uki.yaml`'s two inline `test_generic`/`test_boot_assessment` checkouts), so the run tests the pull request's own code instead of the base branch

## uki.yaml's push trigger

`uki.yaml` also runs on `push` to `master`, which has no `github.event.pull_request` at all. `authorize`'s environment expression checks `github.event_name == 'pull_request_target'` first, so a push always resolves to `internal` and never evaluates the fork check against a null PR object. The `ref` input takes the same guard, falling back to empty on a push — `actions/checkout`'s own default, per the comment already in `reusable-factory.yaml`'s checkout step confirming empty behaves exactly like unset.

## What is verified, and what is not

Verified: both files parse, `authorize` precedes every job that needs it (directly or via `needs: build`), and every checkout that matters gets the `ref` input.

**Not verified: this has never run**, same as #4323 itself — a `pull_request_target` workflow only takes effect once it is on the default branch, so this pull request cannot exercise its own change. This pull request is itself a normal fork PR, though, so it should exercise **#4323's** gate on `image-pr.yaml` (unrelated to this diff, since that workflow triggers on any pull request) — worth watching for whether that one requests approval and then runs cleanly with secrets.

---

AI assisted this pull request. A human is attending and directed it.
