### PR TITLE
chore: bump kairos-factory-action pin to v1.4.1

### DIFF
--- a/.github/workflows/image-master-arm.yaml
+++ b/.github/workflows/image-master-arm.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/image-master.yaml
+++ b/.github/workflows/image-master.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/image-pr-arm.yaml
+++ b/.github/workflows/image-pr-arm.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     secrets:
       # The PR path only ever writes quay.io/kairos/ci-temp-images, so it uses
       # the kairos+prci robot, which has Write on that repository and nothing

--- a/.github/workflows/image-pr.yaml
+++ b/.github/workflows/image-pr.yaml
@@ -47,7 +47,7 @@ jobs:
   build:
     name: ${{ matrix.image_name }}
     needs: authorize
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     secrets:
       # The PR path only ever writes quay.io/kairos/ci-temp-images, so it uses
       # the kairos+prci robot, which has Write on that repository and nothing

--- a/.github/workflows/release-arm.yaml
+++ b/.github/workflows/release-arm.yaml
@@ -16,7 +16,7 @@ jobs:
 
   core:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     needs:
       - vulnerability-scan
     secrets:
@@ -124,7 +124,7 @@ jobs:
           echo "kubernetes_versions=$kubernetes_versions" >> $GITHUB_OUTPUT
   standard:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     secrets:
       registry_username: ${{ secrets.QUAY_USERNAME }}
       registry_password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
   core:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     needs:
       - vulnerability-scan
     permissions:
@@ -123,7 +123,7 @@ jobs:
 
   standard-k3s:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     needs:
       - vulnerability-scan
       - get-k3s-versions
@@ -170,7 +170,7 @@ jobs:
       release: true
   standard-k0s:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     needs:
       - vulnerability-scan
       - get-k0s-versions

--- a/.github/workflows/uki.yaml
+++ b/.github/workflows/uki.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: ${{ matrix.image_name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@730309d995590a11ea0620ccad0c4832b5fb03a9 # v1.4.0
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@9bf6ee71187036eb832f28c29f0c699507bc1ca3 # v1.4.1
     secrets:
       # The PR path only ever writes quay.io/kairos/ci-temp-images, so it uses
       # the kairos+prci robot, which has Write on that repository and nothing


### PR DESCRIPTION
## What

Bumps `kairos-io/kairos-factory-action`'s pinned commit from the `v1.4.0` tag to `v1.4.1` in all 7 files / 10 references that use it.

## Why

[kairos-io/kairos-factory-action#60](https://github.com/kairos-io/kairos-factory-action/pull/60) (merged, released as `v1.4.1`) fixes `reusable-factory.yaml`'s checkout step: it now sets `allow-unsafe-pr-checkout: true` when a caller passes a non-empty `ref`, which is exactly what [kairos-io/kairos#4323](https://github.com/kairos-io/kairos/pull/4323)'s `fork-pr-builds` gate does. Without it, `actions/checkout` refuses to fetch a fork's code inside a `pull_request_target` workflow — hit live on [kairos-io/kairos#4328](https://github.com/kairos-io/kairos/pull/4328)'s first approved run.

`image-pr.yaml` is the urgent one: it's already merged and live, so every fork PR whose `fork-pr-builds` deployment gets approved hits this same failure until the pin moves. The other six references share the pin and move together in one small, mechanical change rather than six.

## What is verified, and what is not

Verified: all seven files parse, and every reference to the old commit is gone (`grep` confirms 0 remaining).

**Not verified: no build has run against the new pin yet.** [kairos-io/kairos#4328](https://github.com/kairos-io/kairos/pull/4328) is the pull request that proves it, once this merges.

---

AI assisted this pull request. A human is attending and directed it.
