### PR TITLE
fix: allow reusable-qemu-test.yaml's checkout to fetch a caller's ref

### DIFF
--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -117,6 +117,14 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
+          # actions/checkout refuses to fetch a non-default ref inside a
+          # pull_request_target workflow otherwise -- the exact "pwn request"
+          # guard https://gh.io/securely-using-pull_request_target describes.
+          # Same fix, same reasoning, as kairos-io/kairos-factory-action#60:
+          # `ref`'s own doc above already says the caller carries the risk.
+          # A caller that leaves `ref` empty (every ordinary caller) is
+          # unaffected.
+          allow-unsafe-pr-checkout: ${{ inputs.ref != '' }}
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         timeout-minutes: 5


### PR DESCRIPTION
## What

Same bug as [kairos-io/kairos-factory-action#60](https://github.com/kairos-io/kairos-factory-action/pull/60), one file over. `reusable-qemu-test.yaml`'s `ref` input exists so a `pull_request_target` caller can test a fork pull request's own code — [#4323](https://github.com/kairos-io/kairos/pull/4323) added it for exactly that. The checkout step never told `actions/checkout` that was intentional, so it refuses with the same "pwn request" guard the moment a caller actually uses a non-default ref.

## Why now

[kairos-io/kairos#4328](https://github.com/kairos-io/kairos/pull/4328)'s `image-pr.yaml` run reached this live today, right after the `kairos-factory-action` pin bump ([#4329](https://github.com/kairos-io/kairos/pull/4329)) fixed the build side: both build jobs succeeded, then every single `core-tests`/`standard-tests` job failed here, all for the identical reason:

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow.
```

## The fix

`allow-unsafe-pr-checkout: ${{ inputs.ref != '' }}`. Every ordinary caller — the default, empty `ref` — is unaffected.

## What is verified, and what is not

Verified: the file parses.

**Not verified: no run has exercised this fix yet.** [kairos-io/kairos#4328](https://github.com/kairos-io/kairos/pull/4328) is what proves it, once this merges — it's the run that surfaced the bug in the first place.

---

AI assisted this pull request. A human is attending and directed it.
