### PR TITLE
chore: bump kairos-init to v0.17.2, clear the two edgevpn pion CVEs

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ubuntu:20.04
-ARG KAIROS_INIT=v0.17.1
+ARG KAIROS_INIT=v0.17.2
 
 FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -172,30 +172,6 @@ reason = "upstream-regression: CVE-2026-56852, golang.org/x/text in edgevpn. Fix
 
 
 # ---------------------------------------------------------------------------
-# upstream-fix-pending -- both are in the `edgevpn` binary, which ships in every
-# Kairos release from mudler/edgevpn. The fix is written, tested and submitted
-# as https://github.com/mudler/edgevpn/pull/1075; it needs that PR merged and an
-# edgevpn release before EDGEVPN_VERSION can move in kairos-init.
-#
-# Both were also present in provider-kairos and were cleared there by the
-# v2.16.2 release; only the edgevpn copies remain.
-#
-# Both are remote denial-of-service via panic while parsing malformed input,
-# reachable only through go-libp2p's WebRTC transport.
-# ---------------------------------------------------------------------------
-
-[[IgnoredVulns]]
-id = "GHSA-34rh-wp3j-6cxc"
-ignoreUntil = 2026-09-11
-reason = "upstream-fix-pending: CVE-2026-54909, pion/stun in edgevpn. Fix v3.1.5 submitted as mudler/edgevpn#1075, awaiting merge and an edgevpn release."
-
-[[IgnoredVulns]]
-id = "GHSA-wg4g-wm44-ch5j"
-ignoreUntil = 2026-09-11
-reason = "upstream-fix-pending: CVE-2026-54908, pion/dtls in edgevpn. Fix v3.1.4 submitted as mudler/edgevpn#1075, awaiting merge and an edgevpn release."
-
-
-# ---------------------------------------------------------------------------
 # upstream-fix-pending -- Go stdlib advisories carried by the `edgevpn` binary,
 # which kairos-init consumes as a prebuilt tarball from mudler/edgevpn. Found
 # by a scan of kairos-init v0.17.0's uncompressed bundle on 2026-08-14.


### PR DESCRIPTION
## Why

[kairos-io/kairos-init v0.17.2](https://github.com/kairos-io/kairos-init/releases/tag/v0.17.2) pins `edgevpn` v0.35.4, which carries [mudler/edgevpn#1075](https://github.com/mudler/edgevpn/pull/1075) — the `pion/stun` and `pion/dtls` fixes for two advisories this repo's `osv-scanner.toml` was ignoring pending exactly that release:

- `GHSA-34rh-wp3j-6cxc` (CVE-2026-54909)
- `GHSA-wg4g-wm44-ch5j` (CVE-2026-54908)

Both ignores, and their shared header comment, come out in this PR.

The **other** two edgevpn entries just above that block (`GHSA-g35j-m5xg-vh3q`, `GO-2026-5970`) are untouched — both are upstream regressions `edgevpn#1075` deliberately left out of the fix, unrelated to this bump.

v0.17.2 also carries `provider-kairos` v2.16.4 (the `golang.org/x/image` `GO-2026-6222` fix) and `immucore` v0.20.4.

## What changes

- `images/Dockerfile`: `ARG KAIROS_INIT` from `v0.17.1` to `v0.17.2`.
- `osv-scanner.toml`: drops the two now-cleared ignores and their header comment.

## Verified

`osv-scanner.toml` still parses (27 `IgnoredVulns` entries, down from 29), and no reference to either cleared advisory ID remains in the file. Did not build or run the release scan itself.

---

AI assisted this pull request. A human is attending and directed it.
