### PR TITLE
ci: trim the workflow_run rationale down to the commit message

### DIFF
--- a/.github/workflows/upload-cloud-images.yaml
+++ b/.github/workflows/upload-cloud-images.yaml
@@ -1,18 +1,8 @@
 name: Upload cloud images
 
-# This used to trigger on the same `push: tags: v*` event as "Release AMD64
-# artifacts", independently. GitHub Actions has no cross-workflow `needs:`, so
-# nothing sequenced them: this workflow queried quay.io/kairos/hadron for the
-# tag "Release AMD64 artifacts" publishes, and it ran first -- sometimes by
-# minutes. mauromorales/mission-control#174 has timestamps from v4.2.0-rc1
-# proving it: AWS and GCP both failed to resolve the tag almost three minutes
-# before the job that publishes it had even finished.
-#
-# workflow_run makes this a real dependency instead of a timing guess: this
-# workflow now only starts once "Release AMD64 artifacts" has actually
-# completed, and the `if: ... == 'success'` guard on every job below means a
-# failed or skipped release run (e.g. blocked by the vulnerability scan gate)
-# is not treated as "the tag might exist, try anyway".
+# Sequenced after "Release AMD64 artifacts" actually publishes the hadron tag
+# these jobs need, instead of racing the same tag push. See the commit
+# message for why (mauromorales/mission-control#174 has the evidence).
 on:
   workflow_run:
     workflows: ["Release AMD64 artifacts"]


### PR DESCRIPTION
## What

Follow-up to #4333, per [jimmykarily's review comment](https://github.com/kairos-io/kairos/pull/4333#discussion_r3803262440) that landed after the PR was already merged: the top-of-file comment carried the full backstory (the old race condition, the v4.2.0-rc1 timestamp evidence, why the success-only guard matters) instead of just explaining what the code does. That explanation belongs in the commit message, not inline.

## What changed

Trimmed the comment to one line pointing at the commit message and mauromorales/mission-control#174 for the full reasoning. No functional change — `on:`, the per-job guards, and the `ref:` pins are all untouched.

---

AI assisted this pull request. A human is attending and directed it.
