### PR TITLE
ci: pass prefer_secboot via env in find-ovmf-firmware action

### DIFF
--- a/.github/actions/find-ovmf-firmware/action.yml
+++ b/.github/actions/find-ovmf-firmware/action.yml
@@ -14,6 +14,8 @@ runs:
   steps:
     - id: find_ovmf
       shell: bash
+      env:
+        PREFER_SECBOOT: ${{ inputs.prefer_secboot }}
       run: |
         # In Ubuntu 24.04, OVMF files have different names.
         # The _4M variant is 4MB (newer standard), vs the older 2MB variant.
@@ -21,8 +23,6 @@ runs:
         # OVMF_CODE_4M.fd is the standard variant without secure boot.
         #
         # Note: The CODE and VARS files must match in size (both 4M or both 2M).
-
-        PREFER_SECBOOT="${{ inputs.prefer_secboot }}"
 
         if [ -f /usr/share/OVMF/OVMF_CODE.fd ]; then
           # Legacy 2MB variant (Ubuntu 22.04 and earlier)


### PR DESCRIPTION
## Summary

The `find-ovmf-firmware` composite action interpolated `${{ inputs.prefer_secboot }}` directly into the `run:` block:

```yaml
run: |
  PREFER_SECBOOT="${{ inputs.prefer_secboot }}"
```

This is the pattern flagged by semgrep's `yaml.github-actions.security.run-shell-injection.run-shell-injection` rule (CWE-78): the `${{ ... }}` value is spliced into the script text before bash parses it, so a malicious input containing a `"` could close the quoted string and inject shell commands.

**This is not exploitable today.** All three call sites pass the literal string `true`:

- `.github/workflows/reusable-qemu-test.yaml:207`
- `.github/workflows/uki.yaml:237`
- `.github/workflows/uki.yaml:365`

There is no `workflow_dispatch` / `workflow_call` / PR-metadata path into the input. But the sink is one wiring change away from becoming a real vulnerability, and the fix is a one-line refactor, so we may as well close it now.

## Fix

Pass the value through `env:` instead. The runner sets it as a real environment variable, and bash reads it at expansion time rather than splicing it into the script text. The existing `[ "$PREFER_SECBOOT" = "true" ]` reference is already properly double-quoted, so no other changes are needed.

Fixes #4337

## Test plan

- [ ] Trigger a workflow that runs the `uki` or `reusable-qemu-test` job and confirm the firmware path is still resolved correctly (the `secboot=true` branch is exercised by both call sites)