### PR TITLE
kairos-init: deploy the multi-call kairos binary with symlinks

### DIFF
--- a/.github/workflows/_build-image-kairos-init.yaml
+++ b/.github/workflows/_build-image-kairos-init.yaml
@@ -1,13 +1,13 @@
-name: Build images (step)
+name: Build kairos-init image
 
-# Reusable step: multi-arch (linux/amd64 + linux/arm64) container
-# images for kcrypt-challenger and kairos-init, using the per-arch
-# binaries the build-binaries step uploaded as workflow artifacts.
+# Reusable step: multi-arch (linux/amd64 + linux/arm64) container image
+# for kairos-init, built from the kairos-init tarball that
+# _build-kairos-init.yaml uploaded per arch.
 #
 # On PR the caller typically pushes to ghcr.io/kairos-io/kairos with a
-# pr-<N> tag; on master to :master; on release tags to quay.io/kairos
-# at :<tag> and :latest. `push_images=false` builds without pushing
-# (compile-verify).
+# pr-<N> tag; on master to :master(-scratch); on release tags to
+# quay.io/kairos at :<tag> and :latest. `push=false` builds without
+# pushing (compile-verify).
 
 on:
   workflow_call:
@@ -27,13 +27,13 @@ on:
         type: string
         default: ''
 
-      push_images:
+      push:
         description: 'true to push to the registry, false to only build (verify)'
         type: boolean
         default: false
 
       registry_login:
-        description: '"ghcr" | "quay" | "" (no login; only valid when push_images is false)'
+        description: '"ghcr" | "quay" | "" (no login; only valid when push is false)'
         type: string
         default: ''
 
@@ -48,7 +48,7 @@ permissions:
   packages: write
 
 jobs:
-  images:
+  image:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,20 +57,21 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
 
-      - name: Download default-variant artifacts (amd64 + arm64)
+      - name: Download kairos-init artifacts (amd64 + arm64)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          pattern: 'binaries-linux-@(amd64|arm64)'
+          pattern: 'kairos-init-linux-@(amd64|arm64)'
           path: dist/download
 
       - name: Reassemble dist/linux-<arch>/
-        # Container images consume binaries from dist/linux-<arch>/, so
-        # extract the per-arch archives back into that layout.
+        # The Dockerfile consumes dist/linux-${TARGETARCH}/kairos-init.
         run: |
           set -euo pipefail
           for arch in amd64 arm64; do
             mkdir -p "dist/linux-$arch"
-            for tarball in "dist/download/binaries-linux-$arch"/*.tar.gz; do
+            d="dist/download/kairos-init-linux-$arch"
+            [ -d "$d" ] || continue
+            for tarball in "$d"/*.tar.gz; do
               [ -f "$tarball" ] || continue
               tar -xzf "$tarball" -C "dist/linux-$arch"
             done
@@ -84,7 +85,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to ghcr.io
-        if: inputs.push_images && inputs.registry_login == 'ghcr'
+        if: inputs.push && inputs.registry_login == 'ghcr'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -92,33 +93,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to quay.io
-        if: inputs.push_images && inputs.registry_login == 'quay'
+        if: inputs.push && inputs.registry_login == 'quay'
         uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Build & (optionally) push kcrypt-challenger
-        env:
-          REGISTRY: ${{ inputs.image_registry }}
-          TAG: ${{ inputs.image_tag }}
-          EXTRA_TAG: ${{ inputs.image_extra_tag }}
-          PUSH: ${{ inputs.push_images }}
-        run: |
-          set -euo pipefail
-          args=(--platform "linux/amd64,linux/arm64" -f cmd/kcrypt-challenger/Dockerfile
-                -t "$REGISTRY/kcrypt-challenger:$TAG")
-          [ -n "$EXTRA_TAG" ] && args+=(-t "$REGISTRY/kcrypt-challenger:$EXTRA_TAG")
-          [ "$PUSH" = "true" ] && args+=(--push)
-          docker buildx build "${args[@]}" .
-
       - name: Build & (optionally) push kairos-init
         env:
           REGISTRY: ${{ inputs.image_registry }}
           TAG: ${{ inputs.image_tag }}
           EXTRA_TAG: ${{ inputs.image_extra_tag }}
-          PUSH: ${{ inputs.push_images }}
+          PUSH: ${{ inputs.push }}
         run: |
           set -euo pipefail
           args=(--platform "linux/amd64,linux/arm64" -f kairos-init/Dockerfile

--- a/.github/workflows/_build-image-kcrypt-challenger.yaml
+++ b/.github/workflows/_build-image-kcrypt-challenger.yaml
@@ -1,0 +1,115 @@
+name: Build kcrypt-challenger image
+
+# Reusable step: multi-arch (linux/amd64 + linux/arm64) container image
+# for the kcrypt-challenger controller-manager, built from the
+# kcrypt-challenger tarballs that _build-kcrypt-challenger.yaml uploaded
+# per arch. Only the default variant ships as an image today (see
+# cmd/kcrypt-challenger/Dockerfile -- reads from dist/linux-<arch>/, no
+# -fips variant).
+#
+# Runs in parallel to the kairos-init image build; nothing on the
+# build-iso / qemu-tests path depends on this.
+
+on:
+  workflow_call:
+    inputs:
+      image_registry:
+        description: 'Container image registry prefix, e.g. quay.io/kairos'
+        type: string
+        required: true
+
+      image_tag:
+        description: 'Primary image tag'
+        type: string
+        required: true
+
+      image_extra_tag:
+        description: 'Optional second image tag (e.g. "latest" on release), empty otherwise'
+        type: string
+        default: ''
+
+      push:
+        description: 'true to push to the registry, false to only build (verify)'
+        type: boolean
+        default: false
+
+      registry_login:
+        description: '"ghcr" | "quay" | "" (no login; only valid when push is false)'
+        type: string
+        default: ''
+
+      ref:
+        description: 'git ref to check out (defaults to the trigger event ref)'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - name: Download kcrypt-challenger artifacts (amd64 + arm64, default only)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: 'kcrypt-challenger-linux-@(amd64|arm64)'
+          path: dist/download
+
+      - name: Reassemble dist/linux-<arch>/
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            mkdir -p "dist/linux-$arch"
+            d="dist/download/kcrypt-challenger-linux-$arch"
+            [ -d "$d" ] || continue
+            for tarball in "$d"/*.tar.gz; do
+              [ -f "$tarball" ] || continue
+              tar -xzf "$tarball" -C "dist/linux-$arch"
+            done
+            ls -l "dist/linux-$arch"
+          done
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        if: inputs.push && inputs.registry_login == 'ghcr'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to quay.io
+        if: inputs.push && inputs.registry_login == 'quay'
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build & (optionally) push kcrypt-challenger
+        env:
+          REGISTRY: ${{ inputs.image_registry }}
+          TAG: ${{ inputs.image_tag }}
+          EXTRA_TAG: ${{ inputs.image_extra_tag }}
+          PUSH: ${{ inputs.push }}
+        run: |
+          set -euo pipefail
+          args=(--platform "linux/amd64,linux/arm64" -f cmd/kcrypt-challenger/Dockerfile
+                -t "$REGISTRY/kcrypt-challenger:$TAG")
+          [ -n "$EXTRA_TAG" ] && args+=(-t "$REGISTRY/kcrypt-challenger:$EXTRA_TAG")
+          [ "$PUSH" = "true" ] && args+=(--push)
+          docker buildx build "${args[@]}" .

--- a/.github/workflows/_build-iso.yaml
+++ b/.github/workflows/_build-iso.yaml
@@ -1,10 +1,10 @@
-name: Build ISO (step)
+name: Build ISO
 
 # Reusable step: build a single Kairos OS ISO/UKI via
 # kairos-io/kairos-factory-action, using the caller-supplied kairos-init
 # container image. This is the "connect the fresh kairos-init to the
 # ISO build" step -- the caller passes the exact image reference the
-# build-images step just published, and this step overrides
+# build-image-kairos-init step just published, and this step overrides
 # images/Dockerfile's KAIROS_INIT_IMAGE ARG so the ISO embeds it.
 #
 # Single-cell by design: the caller expands the matrix over base_image

--- a/.github/workflows/_build-kairos-init.yaml
+++ b/.github/workflows/_build-kairos-init.yaml
@@ -1,0 +1,114 @@
+name: Build kairos-init
+
+# Reusable step: for each arch, download the multi-call kairos that
+# _build-kairos.yaml produced under both the default and FIPS variants,
+# fetch the external binaries kairos-init also embeds, then compile
+# the kairos-init binary and upload it as its own workflow artifact.
+#
+# Matrix is per-arch (no variant): kairos-init is a single binary
+# that carries both default and FIPS multi-call kairos internally
+# and dispatches at install time.
+
+on:
+  workflow_call:
+    inputs:
+      matrix_scope:
+        description: |
+          "ci" -> amd64 + arm64 (PR + master).
+          "release" -> amd64 + arm64 + riscv64.
+        type: string
+        required: true
+
+      ref:
+        description: 'git ref to check out (defaults to the trigger event ref)'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        env:
+          SCOPE: ${{ inputs.matrix_scope }}
+        run: |
+          if [[ "$SCOPE" == "release" ]]; then
+            echo 'matrix={"include":[{"arch":"amd64"},{"arch":"arm64"},{"arch":"riscv64"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"include":[{"arch":"amd64"},{"arch":"arm64"}]}' >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Download default multi-call kairos artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: kairos-linux-${{ matrix.arch }}
+          path: dist/download/default
+
+      - name: Download FIPS multi-call kairos artifact
+        # FIPS is not built on riscv64.
+        if: matrix.arch != 'riscv64'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: kairos-linux-${{ matrix.arch }}-fips
+          path: dist/download/fips
+
+      - name: Reassemble dist/linux-${{ matrix.arch }}{,-fips}/
+        run: |
+          set -euo pipefail
+          mkdir -p "dist/linux-${{ matrix.arch }}"
+          for tarball in dist/download/default/*.tar.gz; do
+            [ -f "$tarball" ] || continue
+            tar -xzf "$tarball" -C "dist/linux-${{ matrix.arch }}"
+          done
+          if [ "${{ matrix.arch }}" != "riscv64" ]; then
+            mkdir -p "dist/linux-${{ matrix.arch }}-fips"
+            for tarball in dist/download/fips/*.tar.gz; do
+              [ -f "$tarball" ] || continue
+              tar -xzf "$tarball" -C "dist/linux-${{ matrix.arch }}-fips"
+            done
+          fi
+          ls -l "dist/linux-${{ matrix.arch }}"
+          [ "${{ matrix.arch }}" = "riscv64" ] || ls -l "dist/linux-${{ matrix.arch }}-fips"
+
+      - name: Build kairos-init
+        # kairos-init compiles under the default variant flag; the
+        # FIPS multi-call kairos is embedded via bundled_fips.go.
+        run: make kairos-init ARCH=${{ matrix.arch }} VARIANT=default
+
+      - name: Package kairos-init archive
+        run: make archives ARCH=${{ matrix.arch }} VARIANT=default
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: kairos-init-linux-${{ matrix.arch }}
+          # The archives step above rebuilds the whole dist/archives/
+          # directory including tarballs for every binary present in
+          # dist/linux-<arch>/. Ship only the kairos-init tarball
+          # here; the multi-call kairos already has its own artifact
+          # from _build-kairos.yaml and re-uploading would duplicate.
+          path: dist/archives/kairos-init-*.tar.gz

--- a/.github/workflows/_build-kairos.yaml
+++ b/.github/workflows/_build-kairos.yaml
@@ -1,0 +1,81 @@
+name: Build kairos
+
+# Reusable step: cross-compile the multi-call kairos binary for the
+# requested ARCH/VARIANT matrix and upload per-cell workflow artifacts.
+#
+# This is the input to _build-kairos-init.yaml (which embeds both
+# variants' kairos into the kairos-init binary + container image).
+# kcrypt-challenger builds on its own parallel pipe -- nothing here
+# needs it.
+
+on:
+  workflow_call:
+    inputs:
+      matrix_scope:
+        description: |
+          "ci" -> amd64 + arm64, both default and FIPS (PR + master).
+          "release" -> full 5-cell matrix (amd64+arm64+riscv64 default
+          plus amd64+arm64 FIPS).
+        type: string
+        required: true
+
+      ref:
+        description: 'git ref to check out (defaults to the trigger event ref)'
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        env:
+          SCOPE: ${{ inputs.matrix_scope }}
+        run: |
+          if [[ "$SCOPE" == "release" ]]; then
+            echo 'matrix={"include":[{"arch":"amd64","variant":"default"},{"arch":"arm64","variant":"default"},{"arch":"riscv64","variant":"default"},{"arch":"amd64","variant":"fips"},{"arch":"arm64","variant":"fips"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"include":[{"arch":"amd64","variant":"default"},{"arch":"arm64","variant":"default"},{"arch":"amd64","variant":"fips"},{"arch":"arm64","variant":"fips"}]}' >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install cross-compiler (FIPS-arm64)
+        if: matrix.variant == 'fips' && matrix.arch == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y crossbuild-essential-arm64
+
+      - name: Build kairos
+        run: make kairos ARCH=${{ matrix.arch }} VARIANT=${{ matrix.variant }}
+
+      - name: Package archives
+        run: make archives ARCH=${{ matrix.arch }} VARIANT=${{ matrix.variant }}
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: kairos-linux-${{ matrix.arch }}${{ matrix.variant == 'fips' && '-fips' || '' }}
+          path: dist/archives/*

--- a/.github/workflows/_build-kcrypt-challenger.yaml
+++ b/.github/workflows/_build-kcrypt-challenger.yaml
@@ -1,18 +1,23 @@
-name: Build binaries (step)
+name: Build kcrypt-challenger
 
-# Reusable step: cross-compile every Kairos binary for the requested
-# ARCH/VARIANT matrix and upload per-cell workflow artifacts.
-# Downstream steps consume the artifacts to build container images
-# and, on tag events, to attach to a GitHub Release.
+# Reusable step: cross-compile the kcrypt-challenger controller-manager
+# binary for the requested ARCH/VARIANT matrix and upload per-cell
+# workflow artifacts.
+#
+# Runs in parallel to _build-kairos.yaml. Nothing on the kairos-init /
+# build-iso / qemu-tests path depends on this; only the
+# _build-image-kcrypt-challenger.yaml step downstream (and via that
+# the release / promote workflows) consumes the artifact.
 
 on:
   workflow_call:
     inputs:
       matrix_scope:
         description: |
-          "ci" -> amd64 + arm64 default only (PR + master).
+          "ci" -> amd64 + arm64, both default and FIPS (PR + master).
           "release" -> full 5-cell matrix (amd64+arm64+riscv64 default
-          plus amd64+arm64 FIPS).
+          plus amd64+arm64 FIPS). Keeps parity with _build-kairos.yaml
+          so both pipes have matching FIPS coverage.
         type: string
         required: true
 
@@ -38,7 +43,7 @@ jobs:
           if [[ "$SCOPE" == "release" ]]; then
             echo 'matrix={"include":[{"arch":"amd64","variant":"default"},{"arch":"arm64","variant":"default"},{"arch":"riscv64","variant":"default"},{"arch":"amd64","variant":"fips"},{"arch":"arm64","variant":"fips"}]}' >> "$GITHUB_OUTPUT"
           else
-            echo 'matrix={"include":[{"arch":"amd64","variant":"default"},{"arch":"arm64","variant":"default"}]}' >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[{"arch":"amd64","variant":"default"},{"arch":"arm64","variant":"default"},{"arch":"amd64","variant":"fips"},{"arch":"arm64","variant":"fips"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -65,8 +70,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y crossbuild-essential-arm64
 
-      - name: Build binaries
-        run: make binaries ARCH=${{ matrix.arch }} VARIANT=${{ matrix.variant }}
+      - name: Build kcrypt-challenger
+        run: make kcrypt-challenger ARCH=${{ matrix.arch }} VARIANT=${{ matrix.variant }}
 
       - name: Package archives
         run: make archives ARCH=${{ matrix.arch }} VARIANT=${{ matrix.variant }}
@@ -74,5 +79,5 @@ jobs:
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: binaries-linux-${{ matrix.arch }}${{ matrix.variant == 'fips' && '-fips' || '' }}
+          name: kcrypt-challenger-linux-${{ matrix.arch }}${{ matrix.variant == 'fips' && '-fips' || '' }}
           path: dist/archives/*

--- a/.github/workflows/_lint.yaml
+++ b/.github/workflows/_lint.yaml
@@ -1,12 +1,12 @@
-name: Lint (step)
+name: Lint
 
 # Reusable step: workflow-file linting via the same
 # kairos-io/linting-composite-action the pre-monorepo lint.yaml
 # used, extended with a `ref` input so the composite's own
 # checkout can be pointed at the PR HEAD when this pipeline runs
 # under pull_request_target. Wired as a hard gate before
-# build-images in every pipeline; a red lint suite blocks image
-# push, same shape unit-tests has.
+# the image-build jobs in every pipeline; a red lint suite blocks
+# image push, same shape unit-tests has.
 
 on:
   workflow_call:

--- a/.github/workflows/_uki-test.yaml
+++ b/.github/workflows/_uki-test.yaml
@@ -1,4 +1,4 @@
-name: UKI qemu test (step)
+name: UKI qemu test
 
 # Reusable step: boot a UKI/trusted-boot ISO under qemu with OVMF +
 # swtpm and run the ginkgo suite filtered by a UKI-specific label.

--- a/.github/workflows/_unit-tests.yaml
+++ b/.github/workflows/_unit-tests.yaml
@@ -1,4 +1,4 @@
-name: Unit tests (step)
+name: Unit tests
 
 # Reusable step: `go test ./...` for the whole monorepo. Same
 # invocation as the standalone unit-tests.yaml; extracted so both the

--- a/.github/workflows/_upload-release.yaml
+++ b/.github/workflows/_upload-release.yaml
@@ -1,4 +1,4 @@
-name: Upload release (step)
+name: Upload release
 
 # Reusable step: attach every arch's binary archives and a consolidated
 # checksums file to the GitHub Release the current tag created. Only
@@ -28,7 +28,7 @@ jobs:
       - name: Download every arch's archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          pattern: 'binaries-linux-*'
+          pattern: '@(kairos|kairos-init|kcrypt-challenger)-linux-*'
           path: dist/download
 
       - name: Consolidate archives + checksums

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -46,21 +46,47 @@ jobs:
     uses: ./.github/workflows/_lint.yaml
     secrets: inherit
 
-  build-binaries:
-    uses: ./.github/workflows/_build-binaries.yaml
+  # kairos-init pipe: gates build-iso + qemu-tests.
+  build-kairos:
+    uses: ./.github/workflows/_build-kairos.yaml
     with:
       matrix_scope: ci
     secrets: inherit
 
-  build-images:
-    needs: [build-binaries, unit-tests, lint]
-    uses: ./.github/workflows/_build-images.yaml
+  build-kairos-init:
+    needs: build-kairos
+    uses: ./.github/workflows/_build-kairos-init.yaml
+    with:
+      matrix_scope: ci
+    secrets: inherit
+
+  build-image-kairos-init:
+    needs: [build-kairos-init, unit-tests, lint]
+    uses: ./.github/workflows/_build-image-kairos-init.yaml
     with:
       image_registry: ghcr.io/kairos-io/kairos
       # Scratch tag: qemu tests consume this, promote-images copies
       # the manifest to :master on green.
       image_tag: master-scratch
-      push_images: true
+      push: true
+      registry_login: ghcr
+    secrets: inherit
+
+  # kcrypt-challenger pipe: parallel to the kairos pipe, only gates
+  # promote-images (nothing on the qemu path consumes it).
+  build-kcrypt-challenger:
+    uses: ./.github/workflows/_build-kcrypt-challenger.yaml
+    with:
+      matrix_scope: ci
+    secrets: inherit
+
+  build-image-kcrypt-challenger:
+    needs: [build-kcrypt-challenger, unit-tests, lint]
+    uses: ./.github/workflows/_build-image-kcrypt-challenger.yaml
+    with:
+      image_registry: ghcr.io/kairos-io/kairos
+      image_tag: master-scratch
+      push: true
       registry_login: ghcr
     secrets: inherit
 
@@ -69,7 +95,7 @@ jobs:
   # promote-images below waits on build-iso-arm too so a broken
   # arm build still keeps :master-scratch from advancing to :master.
   build-iso:
-    needs: build-images
+    needs: build-image-kairos-init
     strategy:
       fail-fast: false
       matrix:
@@ -82,7 +108,7 @@ jobs:
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
-      # Consume the scratch kairos-init that build-images just published.
+      # Consume the scratch kairos-init that build-image-kairos-init just published.
       kairos_init_image: ghcr.io/kairos-io/kairos/kairos-init:master-scratch
       arch: ${{ matrix.arch }}
       base_image: ${{ matrix.base_image }}
@@ -97,7 +123,7 @@ jobs:
     secrets: inherit
 
   build-iso-arm:
-    needs: build-images
+    needs: build-image-kairos-init
     strategy:
       fail-fast: false
       matrix:
@@ -226,7 +252,10 @@ jobs:
   # pinned :master-scratch@sha256:xxx before promotion, the same
   # sha256 is what :master now points at.
   promote-images:
-    needs: [qemu-tests-core, qemu-tests-standard, qemu-tests-uki, build-iso-arm]
+    # qemu suites + arm build gate the kairos-init side; the
+    # kcrypt-challenger image is on a parallel pipe and must also be
+    # pushed to :master-scratch before this job can promote it.
+    needs: [qemu-tests-core, qemu-tests-standard, qemu-tests-uki, build-iso-arm, build-image-kcrypt-challenger]
     runs-on: ubuntu-latest
     steps:
       - name: Login to ghcr.io

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -74,25 +74,56 @@ jobs:
       ref: refs/pull/${{ github.event.pull_request.number }}/head
     secrets: inherit
 
-  build-binaries:
+  # The kairos-init pipe (multi-call kairos -> kairos-init -> image ->
+  # iso -> qemu). This is the critical path for the qemu suites below.
+  build-kairos:
     needs: authorize
-    uses: ./.github/workflows/_build-binaries.yaml
+    uses: ./.github/workflows/_build-kairos.yaml
     with:
       matrix_scope: ci
       ref: refs/pull/${{ github.event.pull_request.number }}/head
     secrets: inherit
 
-  # unit-tests + lint are hard gates for anything that publishes
-  # downstream. An image push is visible outside the run, so a red
-  # test or lint suite must stop it. build-binaries runs in parallel
-  # with tests since it is not visible until images / isos consume it.
-  build-images:
-    needs: [build-binaries, unit-tests, lint]
-    uses: ./.github/workflows/_build-images.yaml
+  build-kairos-init:
+    needs: build-kairos
+    uses: ./.github/workflows/_build-kairos-init.yaml
+    with:
+      matrix_scope: ci
+      ref: refs/pull/${{ github.event.pull_request.number }}/head
+    secrets: inherit
+
+  # unit-tests + lint gate any image push (visible outside the run).
+  # The kairos-init image is what build-iso consumes.
+  build-image-kairos-init:
+    needs: [build-kairos-init, unit-tests, lint]
+    uses: ./.github/workflows/_build-image-kairos-init.yaml
     with:
       image_registry: ghcr.io/kairos-io/kairos
       image_tag: pr-${{ github.event.pull_request.number }}
-      push_images: true
+      push: true
+      registry_login: ghcr
+      ref: refs/pull/${{ github.event.pull_request.number }}/head
+    secrets: inherit
+
+  # The kcrypt-challenger pipe runs in parallel to the kairos pipe.
+  # Nothing on the build-iso / qemu-tests path depends on it -- the
+  # encryption tests today pin a published kcrypt-challenger tag, not
+  # the just-built one -- so it only gates promote / upload-release.
+  build-kcrypt-challenger:
+    needs: authorize
+    uses: ./.github/workflows/_build-kcrypt-challenger.yaml
+    with:
+      matrix_scope: ci
+      ref: refs/pull/${{ github.event.pull_request.number }}/head
+    secrets: inherit
+
+  build-image-kcrypt-challenger:
+    needs: [build-kcrypt-challenger, unit-tests, lint]
+    uses: ./.github/workflows/_build-image-kcrypt-challenger.yaml
+    with:
+      image_registry: ghcr.io/kairos-io/kairos
+      image_tag: pr-${{ github.event.pull_request.number }}
+      push: true
       registry_login: ghcr
       ref: refs/pull/${{ github.event.pull_request.number }}/head
     secrets: inherit
@@ -110,7 +141,7 @@ jobs:
   # still fails the whole PR, but qemu proceeds in parallel.
 
   build-iso:
-    needs: build-images
+    needs: build-image-kairos-init
     strategy:
       fail-fast: false
       matrix:
@@ -146,7 +177,7 @@ jobs:
     secrets: inherit
 
   build-iso-arm:
-    needs: build-images
+    needs: build-image-kairos-init
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,21 +110,47 @@ jobs:
            ' | jq -c '.')
           echo "kubernetes_versions=$kubernetes_versions" >> "$GITHUB_OUTPUT"
 
-  build-binaries:
-    uses: ./.github/workflows/_build-binaries.yaml
+  # kairos-init pipe: gates build-iso + qemu-tests.
+  build-kairos:
+    uses: ./.github/workflows/_build-kairos.yaml
     with:
       matrix_scope: release
     secrets: inherit
 
-  build-images:
-    needs: [build-binaries, unit-tests, lint]
-    uses: ./.github/workflows/_build-images.yaml
+  build-kairos-init:
+    needs: build-kairos
+    uses: ./.github/workflows/_build-kairos-init.yaml
+    with:
+      matrix_scope: release
+    secrets: inherit
+
+  build-image-kairos-init:
+    needs: [build-kairos-init, unit-tests, lint]
+    uses: ./.github/workflows/_build-image-kairos-init.yaml
     with:
       image_registry: quay.io/kairos
       # Scratch tag: qemu tests consume this, promote-images copies
       # to the final tag + :latest on green.
       image_tag: ${{ github.ref_name }}-scratch
-      push_images: true
+      push: true
+      registry_login: quay
+    secrets: inherit
+
+  # kcrypt-challenger pipe: parallel to the kairos pipe, only gates
+  # promote-images / upload-release.
+  build-kcrypt-challenger:
+    uses: ./.github/workflows/_build-kcrypt-challenger.yaml
+    with:
+      matrix_scope: release
+    secrets: inherit
+
+  build-image-kcrypt-challenger:
+    needs: [build-kcrypt-challenger, unit-tests, lint]
+    uses: ./.github/workflows/_build-image-kcrypt-challenger.yaml
+    with:
+      image_registry: quay.io/kairos
+      image_tag: ${{ github.ref_name }}-scratch
+      push: true
       registry_login: quay
     secrets: inherit
 
@@ -134,7 +160,7 @@ jobs:
   # so a broken arm build blocks the final tag advance and the
   # release-artifact upload.
   build-iso:
-    needs: [build-images, vulnerability-scan]
+    needs: [build-image-kairos-init, vulnerability-scan]
     strategy:
       fail-fast: false
       matrix:
@@ -150,7 +176,7 @@ jobs:
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
-      # Consume the scratch kairos-init that build-images just published.
+      # Consume the scratch kairos-init that build-image-kairos-init just published.
       kairos_init_image: quay.io/kairos/kairos-init:${{ github.ref_name }}-scratch
       arch: ${{ matrix.arch }}
       base_image: ${{ matrix.base_image }}
@@ -164,7 +190,7 @@ jobs:
     secrets: inherit
 
   build-iso-arm:
-    needs: [build-images, vulnerability-scan]
+    needs: [build-image-kairos-init, vulnerability-scan]
     strategy:
       fail-fast: false
       matrix:
@@ -220,7 +246,7 @@ jobs:
   # already exercises), just built + published as release
   # artifacts. Same shape release-legacy.yaml carried.
   build-iso-k3s:
-    needs: [build-images, vulnerability-scan, get-k3s-versions]
+    needs: [build-image-kairos-init, vulnerability-scan, get-k3s-versions]
     strategy:
       fail-fast: false
       matrix:
@@ -242,7 +268,7 @@ jobs:
     secrets: inherit
 
   build-iso-k0s:
-    needs: [build-images, vulnerability-scan, get-k0s-versions]
+    needs: [build-image-kairos-init, vulnerability-scan, get-k0s-versions]
     strategy:
       fail-fast: false
       matrix:
@@ -345,7 +371,10 @@ jobs:
   # by reference (digest preserved, no image bytes pulled). Also
   # tag :latest on the final promotion.
   promote-images:
-    needs: [qemu-tests-core, qemu-tests-standard, qemu-tests-uki, build-iso-arm, build-iso-k3s, build-iso-k0s]
+    # qemu suites + iso matrices gate the kairos-init side; the
+    # kcrypt-challenger image is on a parallel pipe and must also be
+    # pushed to :<tag>-scratch before this job can promote it.
+    needs: [qemu-tests-core, qemu-tests-standard, qemu-tests-uki, build-iso-arm, build-iso-k3s, build-iso-k0s, build-image-kcrypt-challenger]
     runs-on: ubuntu-latest
     steps:
       - name: Login to quay.io
@@ -368,6 +397,8 @@ jobs:
           done
 
   upload-release:
-    needs: [unit-tests, qemu-tests-core, qemu-tests-standard, qemu-tests-uki, build-iso-arm, build-iso-k3s, build-iso-k0s]
+    # Uploads every tarball to the GitHub Release. Waits on both
+    # pipes so the release ships kairos + kairos-init + kcrypt-challenger.
+    needs: [unit-tests, qemu-tests-core, qemu-tests-standard, qemu-tests-uki, build-iso-arm, build-iso-k3s, build-iso-k0s, build-kcrypt-challenger]
     uses: ./.github/workflows/_upload-release.yaml
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@
 
 GO      ?= go
 GOFLAGS ?= -trimpath
-BIN_DIR ?= bin
 
 # VERSION is the human-readable version string every binary reports.
 # Format: git describe (e.g. v1.2.3, or v1.2.3-5-gabc1234 between tags, plus
@@ -21,51 +20,6 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 # to add your own -X flags; if you override LDFLAGS, remember to include -X
 # for the version or every binary will report "dev".
 LDFLAGS ?= -s -w -X github.com/kairos-io/kairos/internal/version.Version=$(VERSION)
-
-.PHONY: all
-all: kairos kairos-slim kcrypt-challenger
-
-# Multi-call binary. Symlink it (or hard-link) as immucore, kairos-agent,
-# or kcrypt-discovery-challenger to invoke a specific sub-tool by argv[0].
-# The form `kairos <sub-tool> [args]` also works.
-.PHONY: kairos
-kairos:
-	@mkdir -p $(BIN_DIR)
-	$(GO) build $(GOFLAGS) -ldflags='$(LDFLAGS)' -o $(BIN_DIR)/kairos ./cmd/kairos
-
-# Slim variant intended for the initramfs: kairos-agent (and its transitive
-# deps) is not linked in. Same binary otherwise; dispatches immucore and
-# kcrypt-discovery-challenger.
-.PHONY: kairos-slim
-kairos-slim:
-	@mkdir -p $(BIN_DIR)
-	$(GO) build $(GOFLAGS) -tags initramfs -ldflags='$(LDFLAGS)' -o $(BIN_DIR)/kairos-slim ./cmd/kairos
-
-# In-cluster kcrypt challenger server (kubernetes controller manager).
-# Shipped as its own container image; not linked into the multi-call binary.
-.PHONY: kcrypt-challenger
-kcrypt-challenger:
-	@mkdir -p $(BIN_DIR)
-	$(GO) build $(GOFLAGS) -ldflags='$(LDFLAGS)' -o $(BIN_DIR)/kcrypt-challenger ./cmd/kcrypt-challenger
-
-# Optional: standalone builds of each sub-tool. Not what a real deployment
-# uses (that would use `kairos` plus argv[0] symlinks via `make symlinks`),
-# but useful if a consumer wants one specific binary from a specific commit.
-.PHONY: standalone
-standalone:
-	@mkdir -p $(BIN_DIR)
-	$(GO) build $(GOFLAGS) -ldflags='$(LDFLAGS)' -o $(BIN_DIR)/immucore ./immucore
-	$(GO) build $(GOFLAGS) -ldflags='$(LDFLAGS)' -o $(BIN_DIR)/kairos-agent ./agent
-	$(GO) build $(GOFLAGS) -ldflags='$(LDFLAGS)' -o $(BIN_DIR)/kcrypt-discovery-challenger ./kcrypt/cmd/discovery
-
-# Layout a real deployment ships: one kairos binary + argv[0] symlinks.
-# Depends on `kairos` (not `all`) so it does not build the slim/challenger
-# variants unless you ask for them separately.
-.PHONY: symlinks
-symlinks: kairos
-	ln -sf kairos $(BIN_DIR)/immucore
-	ln -sf kairos $(BIN_DIR)/kairos-agent
-	ln -sf kairos $(BIN_DIR)/kcrypt-discovery-challenger
 
 .PHONY: test
 test: kairos-init-embed-stubs
@@ -81,10 +35,10 @@ test: kairos-init-embed-stubs
 .PHONY: kairos-init-embed-stubs
 kairos-init-embed-stubs:
 	@mkdir -p kairos-init/pkg/bundled/binaries/fips
-	@for f in kairos-agent immucore kcrypt-discovery-challenger provider-kairos kairos-installer edgevpn version-info.yaml; do \
+	@for f in kairos provider-kairos kairos-installer edgevpn version-info.yaml; do \
 	    [ -e kairos-init/pkg/bundled/binaries/$$f ] || : > kairos-init/pkg/bundled/binaries/$$f; \
 	done
-	@for f in kairos-agent immucore kcrypt-discovery-challenger provider-kairos; do \
+	@for f in kairos provider-kairos; do \
 	    [ -e kairos-init/pkg/bundled/binaries/fips/$$f ] || : > kairos-init/pkg/bundled/binaries/fips/$$f; \
 	done
 
@@ -142,18 +96,31 @@ lint-workflows-actions:
 	        \( -name 'pr.yaml' -o -name 'master.yaml' -o -name 'release.yaml' -o -name '_*.yaml' \))
 
 # ============================================================================
-# Release targets: cross-compile the full binary set for a specific ARCH and
-# optionally a FIPS variant, so CI and local dev can produce the same
-# artifacts. Nothing here publishes; publishing is the workflow's job.
+# Release targets. Nothing here publishes; publishing is the workflow's job.
 #
-# Usage:
-#   make binaries ARCH=amd64            # default variant for linux/amd64
-#   make binaries ARCH=arm64 VARIANT=fips
-#   make binaries-all                   # matrix run: default for every ARCH
-#   make archives ARCH=amd64            # tar.gz-package the built binaries
-#   make image-kcrypt-challenger ARCH=amd64  # docker buildx load (no push)
-#   make image-kairos-init ARCH=amd64        # ditto
-#   make images ARCH=amd64                    # both container images
+# Pipeline:
+#   1. `make kairos`      -- build the multi-call kairos.
+#   2. `make kcrypt-challenger` -- build the k8s challenger server.
+#   3. `make standalones` -- build the backward-compat entry points
+#                            (immucore, kairos-agent,
+#                            kcrypt-discovery-challenger). Temporary --
+#                            nothing in the pipeline consumes these,
+#                            they only exist for tarball backward compat.
+#   4. `make kairos-init` -- fetch externals + prep + compile
+#                            kairos-init. Needs the multi-call kairos
+#                            for BOTH default and FIPS variants already
+#                            present under dist/linux-<arch>{,-fips}/.
+#
+# All build targets honour ARCH (default: host arch) and VARIANT (default:
+# `default`, or `fips`). Setting ARCH to something other than the host
+# produces a cross-compiled binary; ARCH matching the host is a native
+# build. Same target either way -- Go picks the toolchain.
+#
+# Each step is per (ARCH, VARIANT) except kairos-init which is
+# per ARCH (embeds both variants; ships from the default cell only).
+#
+# `make binaries` is a local convenience that runs the whole pipeline
+# in one go. CI drives the steps individually across matrix cells.
 # ============================================================================
 
 DIST_DIR ?= dist
@@ -161,53 +128,81 @@ DOCKER   ?= docker
 ARCH     ?= $(shell go env GOARCH)
 VARIANT  ?= default
 
-# Where the cross-compiled binaries land for a given ARCH+VARIANT.
+# Where compiled binaries land for a given ARCH+VARIANT.
 DIST_SUBDIR := linux-$(ARCH)$(if $(filter fips,$(VARIANT)),-fips)
 DIST_ARCH_DIR := $(DIST_DIR)/$(DIST_SUBDIR)
 
 # Build env for the current ARCH+VARIANT. FIPS binaries use
-# GOEXPERIMENT=boringcrypto; arm64 FIPS additionally needs the aarch64
-# cross-linker (installed by the CI job that runs FIPS-arm64 builds).
-CROSS_ENV := GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0
+# GOEXPERIMENT=boringcrypto; on a non-arm64 host, arm64 FIPS also needs
+# the aarch64 gcc (installed by the CI job that runs FIPS-arm64 builds).
+BUILD_ENV := GOOS=linux GOARCH=$(ARCH) CGO_ENABLED=0
 ifeq ($(VARIANT),fips)
-  CROSS_ENV += GOEXPERIMENT=boringcrypto
+  BUILD_ENV += GOEXPERIMENT=boringcrypto
   ifeq ($(ARCH),arm64)
-    CROSS_ENV += CC=aarch64-linux-gnu-gcc
+    BUILD_ENV += CC=aarch64-linux-gnu-gcc
   endif
 endif
 
-CROSS_BUILD = $(CROSS_ENV) $(GO) build $(GOFLAGS) -ldflags='$(LDFLAGS)'
+GO_BUILD = $(BUILD_ENV) $(GO) build $(GOFLAGS) -ldflags='$(LDFLAGS)'
 
-# The six binaries that build without any cross-binary preparation.
-# kairos-init is built separately below because it //go:embeds them.
-.PHONY: binaries-early
-binaries-early: | $(DIST_ARCH_DIR)
-	$(CROSS_BUILD) -o $(DIST_ARCH_DIR)/kairos                      ./cmd/kairos
-	$(CROSS_BUILD) -tags initramfs -o $(DIST_ARCH_DIR)/kairos-slim ./cmd/kairos
-	$(CROSS_BUILD) -o $(DIST_ARCH_DIR)/kcrypt-challenger           ./cmd/kcrypt-challenger
-	$(CROSS_BUILD) -o $(DIST_ARCH_DIR)/immucore                    ./immucore
-	$(CROSS_BUILD) -o $(DIST_ARCH_DIR)/kairos-agent                ./agent
-	$(CROSS_BUILD) -o $(DIST_ARCH_DIR)/kcrypt-discovery-challenger ./kcrypt/cmd/discovery
+# Multi-call binary. Symlink it (or hard-link) as immucore, kairos-agent,
+# or kcrypt-discovery-challenger to invoke a specific sub-tool by argv[0].
+# The form `kairos <sub-tool> [args]` also works.
+.PHONY: kairos
+kairos: | $(DIST_ARCH_DIR)
+	$(GO_BUILD) -o $(DIST_ARCH_DIR)/kairos ./cmd/kairos
 
-# Populate kairos-init/pkg/bundled/binaries/ with what //go:embed needs:
-# the three in-tree binaries we just built plus the still-external ones
-# (provider-kairos, kairos-installer, edgevpn) curled from their releases.
-# Runs BEFORE kairos-init compiles.
+# In-cluster kcrypt challenger server (kubernetes controller manager).
+# Shipped as its own container image; not linked into the multi-call binary.
+.PHONY: kcrypt-challenger
+kcrypt-challenger: | $(DIST_ARCH_DIR)
+	$(GO_BUILD) -o $(DIST_ARCH_DIR)/kcrypt-challenger ./cmd/kcrypt-challenger
+
+# Layout a real deployment ships: one kairos binary + argv[0] symlinks.
+.PHONY: symlinks
+symlinks: kairos
+	ln -sf kairos $(DIST_ARCH_DIR)/immucore
+	ln -sf kairos $(DIST_ARCH_DIR)/kairos-agent
+	ln -sf kairos $(DIST_ARCH_DIR)/kcrypt-discovery-challenger
+
+# Backward-compat entry points. Only reachable by explicitly running
+# `make standalones`; CI does not build these and the release archives
+# do not ship them. Kept as a local escape hatch until the main.go
+# files under agent/, immucore/, and kcrypt/cmd/discovery/ are deleted.
+.PHONY: standalones
+standalones: | $(DIST_ARCH_DIR)
+	$(GO_BUILD) -o $(DIST_ARCH_DIR)/immucore                    ./immucore
+	$(GO_BUILD) -o $(DIST_ARCH_DIR)/kairos-agent                ./agent
+	$(GO_BUILD) -o $(DIST_ARCH_DIR)/kcrypt-discovery-challenger ./kcrypt/cmd/discovery
+
+# Populate kairos-init/pkg/bundled/binaries/. Expects the multi-call
+# kairos for BOTH default and FIPS variants to already be present at
+# dist/linux-<arch>/kairos and dist/linux-<arch>-fips/kairos.
+# FIPS is skipped on riscv64 (bundled_fips.go's build tag excludes it).
 .PHONY: kairos-init-embed
-kairos-init-embed: binaries-early
-	ARCH=$(ARCH) VARIANT=$(VARIANT) BIN_SOURCE=$(CURDIR)/$(DIST_ARCH_DIR) \
+kairos-init-embed:
+	ARCH=$(ARCH) VARIANT=$(VARIANT) \
+	    BIN_SOURCE=$(CURDIR)/$(DIST_DIR)/linux-$(ARCH) \
+	    BIN_SOURCE_FIPS=$(CURDIR)/$(DIST_DIR)/linux-$(ARCH)-fips \
 	    scripts/prepare-kairos-init-binaries.sh
 
-# kairos-init is built after its embed dir is populated. Version is the same
-# monorepo version every other binary reports.
-.PHONY: kairos-init-bin
-kairos-init-bin: kairos-init-embed
-	$(CROSS_BUILD) -o $(DIST_ARCH_DIR)/kairos-init ./kairos-init
+.PHONY: kairos-init
+kairos-init: kairos-init-embed
+	$(GO_BUILD) -o $(DIST_DIR)/linux-$(ARCH)/kairos-init ./kairos-init
 
-# One arch+variant, all seven binaries. This is what a single CI matrix
-# cell runs.
+# Local convenience: build the whole pipeline for one arch. Mirrors CI:
+# the multi-call kairos and kcrypt-challenger run per (arch, variant),
+# kairos-init runs once per arch (it embeds both variants and ships
+# out of the default directory). FIPS is skipped on riscv64.
+# Standalones are not part of this -- run `make standalones` explicitly
+# if you want them.
 .PHONY: binaries
-binaries: binaries-early kairos-init-bin
+binaries:
+	$(MAKE) kairos kcrypt-challenger ARCH=$(ARCH) VARIANT=default
+ifneq ($(ARCH),riscv64)
+	$(MAKE) kairos kcrypt-challenger ARCH=$(ARCH) VARIANT=fips
+endif
+	$(MAKE) kairos-init ARCH=$(ARCH) VARIANT=default
 
 # All default-variant arches. Rarely useful locally; more of a convenience
 # to reproduce what release CI does across the default matrix.
@@ -216,40 +211,44 @@ ARCHES ?= amd64 arm64 riscv64
 binaries-all:
 	@set -e; for arch in $(ARCHES); do \
 	  echo "=== binaries: linux/$$arch (default) ==="; \
-	  $(MAKE) binaries ARCH=$$arch VARIANT=default; \
+	  $(MAKE) binaries ARCH=$$arch; \
 	done
 
 $(DIST_ARCH_DIR):
 	mkdir -p $@
 
-# tar.gz-package each binary produced by `make binaries` into
+# tar.gz-package binaries under dist/$(DIST_SUBDIR) into
 # dist/archives/<binary>-<version>-linux-<arch>[-fips].tar.gz plus a
-# per-arch-variant checksums file.
-BINARIES := kairos kairos-slim kcrypt-challenger immucore kairos-agent kcrypt-discovery-challenger kairos-init
-
+# per-arch-variant checksums file. The BINARIES list is derived from
+# whatever is actually present under DIST_ARCH_DIR, so `archives` can
+# run against the output of any single pipeline step in isolation
+# (kairos, standalones, kairos-init, ...) or against the umbrella
+# `binaries` build.
 .PHONY: archives
-archives: binaries
+archives:
 	@mkdir -p $(DIST_DIR)/archives
-	@set -e; for b in $(BINARIES); do \
+	@set -e; for f in $(DIST_ARCH_DIR)/*; do \
+	  [ -f "$$f" ] || continue; \
+	  b=$$(basename $$f); \
 	  tar -czf $(DIST_DIR)/archives/$$b-$(VERSION)-$(DIST_SUBDIR).tar.gz \
 	      -C $(DIST_ARCH_DIR) $$b; \
 	done
-	cd $(DIST_DIR)/archives && \
-	  sha256sum $(foreach b,$(BINARIES),$(b)-$(VERSION)-$(DIST_SUBDIR).tar.gz) \
+	@cd $(DIST_DIR)/archives && \
+	  sha256sum *-$(VERSION)-$(DIST_SUBDIR).tar.gz \
 	  > checksums-$(DIST_SUBDIR).txt
 
 # --- container images ---
 #
 # Local (buildx --load) container image builds. CI overrides with --push
 # and multi-platform. Both Dockerfiles pick up their binary from
-# dist/linux-<TARGETARCH>/, which `make binaries-early` (kcrypt-challenger)
-# or `make kairos-init-bin` (kairos-init) has populated.
+# dist/linux-<TARGETARCH>/, which the corresponding build step
+# (`make kcrypt-challenger`, `make kairos-init`) has populated.
 
 IMAGE_REGISTRY ?= ghcr.io/kairos-io/kairos
 IMAGE_TAG      ?= dev
 
 .PHONY: image-kcrypt-challenger
-image-kcrypt-challenger: binaries-early
+image-kcrypt-challenger: kcrypt-challenger
 	$(DOCKER) buildx build --load \
 	  --platform linux/$(ARCH) \
 	  --build-arg TARGETARCH=$(ARCH) \
@@ -257,7 +256,7 @@ image-kcrypt-challenger: binaries-early
 	  -f cmd/kcrypt-challenger/Dockerfile .
 
 .PHONY: image-kairos-init
-image-kairos-init: kairos-init-bin
+image-kairos-init: kairos-init
 	$(DOCKER) buildx build --load \
 	  --platform linux/$(ARCH) \
 	  --build-arg TARGETARCH=$(ARCH) \
@@ -269,4 +268,4 @@ images: image-kcrypt-challenger image-kairos-init
 
 .PHONY: clean
 clean:
-	rm -rf $(BIN_DIR) $(DIST_DIR)
+	rm -rf $(DIST_DIR)

--- a/cmd/kairos/register_agent.go
+++ b/cmd/kairos/register_agent.go
@@ -1,5 +1,3 @@
-//go:build !initramfs
-
 package main
 
 import (

--- a/kairos-init/pkg/bundled/alpineInit/immucore.files
+++ b/kairos-init/pkg/bundled/alpineInit/immucore.files
@@ -14,8 +14,8 @@
 /lib/udev/*
 /usr/lib/udev/*
 /usr/lib/libudev*
+/usr/bin/kairos
 /usr/bin/immucore
-/usr/bin/kairos-agent
 /usr/bin/rsync
 /usr/bin/dbus-uuidgen
 /usr/sbin/multipath

--- a/kairos-init/pkg/bundled/bundled.go
+++ b/kairos-init/pkg/bundled/bundled.go
@@ -5,14 +5,8 @@ import (
 )
 
 //nolint:staticcheck
-//go:embed binaries/kairos-agent
-var EmbeddedAgent []byte
-
-//go:embed binaries/immucore
-var EmbeddedImmucore []byte
-
-//go:embed binaries/kcrypt-discovery-challenger
-var EmbeddedKcryptChallenger []byte
+//go:embed binaries/kairos
+var EmbeddedKairos []byte
 
 //go:embed binaries/provider-kairos
 var EmbeddedKairosProvider []byte
@@ -232,7 +226,7 @@ install() {
     declare systemdutildir=${systemdutildir}
     declare systemdsystemunitdir=${systemdsystemunitdir}
 
-    inst_check_multiple immucore kairos-agent
+    inst_check_multiple immucore
     # add utils used by yip stages
     inst_check_multiple sync udevadm blkid lsblk e2fsck mount umount rsync cryptsetup gawk awk mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat
     # add mkfs.fat using inst_multiple which doesnt check for existence

--- a/kairos-init/pkg/bundled/bundled_fips.go
+++ b/kairos-init/pkg/bundled/bundled_fips.go
@@ -4,14 +4,8 @@ package bundled
 
 import _ "embed"
 
-//go:embed binaries/fips/kairos-agent
-var EmbeddedAgentFips []byte
-
-//go:embed binaries/fips/immucore
-var EmbeddedImmucoreFips []byte
-
-//go:embed binaries/fips/kcrypt-discovery-challenger
-var EmbeddedKcryptChallengerFips []byte
+//go:embed binaries/fips/kairos
+var EmbeddedKairosFips []byte
 
 //go:embed binaries/fips/provider-kairos
 var EmbeddedKairosProviderFips []byte

--- a/kairos-init/pkg/bundled/bundled_fips_riscv64.go
+++ b/kairos-init/pkg/bundled/bundled_fips_riscv64.go
@@ -4,8 +4,6 @@ package bundled
 
 // FIPS binaries are not available for riscv64.
 var (
-	EmbeddedAgentFips            []byte
-	EmbeddedImmucoreFips         []byte
-	EmbeddedKcryptChallengerFips []byte
-	EmbeddedKairosProviderFips   []byte
+	EmbeddedKairosFips         []byte
+	EmbeddedKairosProviderFips []byte
 )

--- a/kairos-init/pkg/stages/steps_install.go
+++ b/kairos-init/pkg/stages/steps_install.go
@@ -524,6 +524,14 @@ func GetInstallKairosBinaries(sis values.System, l logger.KairosLogger) error {
 		"/system/discovery/kcrypt-discovery-challenger": config.DefaultConfig.VersionOverrides.KcryptChallenger,
 	}
 
+	// One embedded write of /usr/bin/kairos serves every dest via
+	// symlink. Track the write with a local so a leftover file or
+	// symlink at that path (from a re-run against an already-baked
+	// rootfs, or an older kairos-init layout) does not shadow our
+	// write: os.Stat follows symlinks, so a legacy link that points
+	// somewhere valid would falsely satisfy the guard.
+	kairosWritten := false
+
 	for dest, version := range binaries {
 		if version != "" {
 			// Create the directory if it doesn't exist
@@ -549,28 +557,31 @@ func GetInstallKairosBinaries(sis values.System, l logger.KairosLogger) error {
 				return err
 			}
 		} else {
-			// Use embedded binaries
-			var data []byte
-			switch dest {
-			case constants.AgentDefaultPath:
-				data = bundled.EmbeddedAgent
-			case "/usr/bin/immucore":
-				data = bundled.EmbeddedImmucore
-			case "/system/discovery/kcrypt-discovery-challenger":
-				data = bundled.EmbeddedKcryptChallenger
-			}
-
-			// Create the directory if it doesn't exist
-			if _, err := os.Stat(filepath.Dir(dest)); os.IsNotExist(err) {
-				err := os.MkdirAll(filepath.Dir(dest), 0755)
-				if err != nil {
-					l.Logger.Error().Err(err).Str("dir", filepath.Dir(dest)).Msg("Failed to create directory")
+			const kairosPath = "/usr/bin/kairos"
+			if !kairosWritten {
+				blob := bundled.EmbeddedKairos
+				if config.DefaultConfig.Fips {
+					blob = bundled.EmbeddedKairosFips
 				}
+				if err := os.MkdirAll(filepath.Dir(kairosPath), 0755); err != nil {
+					l.Logger.Error().Err(err).Str("dir", filepath.Dir(kairosPath)).Msg("Failed to create directory")
+					return err
+				}
+				_ = os.Remove(kairosPath)
+				if err := os.WriteFile(kairosPath, blob, 0755); err != nil {
+					l.Logger.Error().Err(err).Str("binary", kairosPath).Msg("Failed to write embedded kairos binary")
+					return err
+				}
+				kairosWritten = true
 			}
-
-			err := os.WriteFile(dest, data, 0755)
-			if err != nil {
-				l.Logger.Error().Err(err).Str("binary", dest).Msg("Failed to write embedded binary")
+			if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+				l.Logger.Error().Err(err).Str("dir", filepath.Dir(dest)).Msg("Failed to create directory")
+				return err
+			}
+			// os.Symlink refuses to overwrite an existing entry.
+			_ = os.Remove(dest)
+			if err := os.Symlink(kairosPath, dest); err != nil {
+				l.Logger.Error().Err(err).Str("dest", dest).Str("target", kairosPath).Msg("Failed to symlink to kairos multi-call binary")
 				return err
 			}
 		}
@@ -673,13 +684,6 @@ func GetInstallProviderBinaries(sis values.System, l logger.KairosLogger) error 
 		}
 	}
 
-	// Link /system/providers/agent-provider-kairos to /usr/bin/kairos, not sure what uses it?
-	// TODO: Check if this is needed, maybe we can remove it?
-	err = os.Symlink("/system/providers/agent-provider-kairos", "/usr/bin/kairos")
-	if err != nil {
-		l.Logger.Error().Err(err).Msg("Failed to create symlink")
-		return err
-	}
 	return nil
 }
 
@@ -776,6 +780,12 @@ func DownloadAndExtract(url, dest string, binaryName ...string) error {
 		}
 
 		if header.Typeflag == tar.TypeReg && strings.HasSuffix(header.Name, targetBinary) {
+			// os.Create follows a symlink at dest and writes through
+			// to its target. With the multi-call layout, dest may be
+			// a legacy symlink to /usr/bin/kairos (e.g. /usr/bin/immucore
+			// from a prior kairos-init run), and writing through would
+			// truncate the multi-call binary. Break the link first.
+			_ = os.Remove(dest)
 			outFile, err := os.Create(dest)
 			if err != nil {
 				return fmt.Errorf("failed to create file: %w", err)

--- a/scripts/prepare-kairos-init-binaries.sh
+++ b/scripts/prepare-kairos-init-binaries.sh
@@ -2,31 +2,19 @@
 # Populate kairos-init/pkg/bundled/binaries/ so `go build ./kairos-init`
 # has files to //go:embed.
 #
-# kairos-init is a single-flavor binary that embeds BOTH default and
-# FIPS versions of the other Kairos binaries; it switches between them
-# at install time based on the user's --fips flag. So every kairos-init
-# build (except on riscv64) needs both binaries/ and binaries/fips/
-# populated regardless of VARIANT. bundled_fips.go's build constraint
-# is `!riscv64`, not `fips`, which is what forces this.
-#
-# What lands where:
-#   binaries/kairos-agent, immucore, kcrypt-discovery-challenger
-#     Copied from BIN_SOURCE (dist/linux-<arch>/), which the
-#     binaries-early Make target populated with in-tree default builds.
-#   binaries/provider-kairos, kairos-installer, edgevpn
-#     Downloaded from their pre-monorepo GitHub Releases at the
-#     versions pinned below. When those repos are absorbed too the
-#     fetches become cp-from-BIN_SOURCE.
-#   binaries/fips/kairos-agent, immucore, kcrypt-discovery-challenger,
-#   provider-kairos
-#     Downloaded from FIPS release tarballs of the respective repos.
-#     Kairos-init switches to these at install time when --fips is set.
-#     Skipped on riscv64 because bundled_fips.go is excluded there.
+# kairos-init embeds default and FIPS binaries side by side and picks
+# between them at install time based on the user's --fips flag. Because
+# bundled_fips.go's build constraint is `!riscv64` (not `fips`), every
+# non-riscv64 build needs both binaries/ and binaries/fips/ populated
+# regardless of VARIANT.
 
 set -euo pipefail
 
 : "${ARCH:?ARCH must be set (amd64, arm64, or riscv64)}"
 : "${BIN_SOURCE:?BIN_SOURCE must point at the dist/linux-<arch>/ output}"
+if [[ "$ARCH" != "riscv64" ]]; then
+    : "${BIN_SOURCE_FIPS:?BIN_SOURCE_FIPS must point at the dist/linux-<arch>-fips/ output}"
+fi
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST_ROOT="$REPO_ROOT/kairos-init/pkg/bundled/binaries"
@@ -38,21 +26,17 @@ fi
 
 # --- External binary versions ---
 # Bump these when the corresponding repo cuts a release you want to consume.
-# Follow-up: absorb provider-kairos and kairos-installer into the monorepo
-# so these fetches are replaced by in-tree cp; only edgevpn (github.com/mudler)
-# stays external. FIPS versions of the in-tree binaries stay external until
-# the release pipeline builds FIPS variants in-tree and hands them here.
+# Absorbing provider-kairos and kairos-installer into the monorepo would
+# replace these fetches by in-tree cp; only edgevpn (github.com/mudler) is
+# genuinely external.
 : "${PROVIDER_KAIROS_VERSION:=v2.16.4}"
 : "${INSTALLER_VERSION:=v0.1.5}"
 : "${EDGEVPN_VERSION:=v0.35.4}"
-: "${AGENT_FIPS_VERSION:=v2.31.4}"
-: "${IMMUCORE_FIPS_VERSION:=v0.20.4}"
-: "${KCRYPT_DISCOVERY_FIPS_VERSION:=v0.13.4}"
 
-# --- Copy in-tree default binaries ---
-for b in kairos-agent immucore kcrypt-discovery-challenger; do
-    cp "$BIN_SOURCE/$b" "$DEST_ROOT/$b"
-done
+cp "$BIN_SOURCE/kairos" "$DEST_ROOT/kairos"
+if [[ "$ARCH" != "riscv64" ]]; then
+    cp "$BIN_SOURCE_FIPS/kairos" "$DEST_FIPS/kairos"
+fi
 
 # --- Fetch defaults from external repos (provider-kairos, kairos-installer, edgevpn) ---
 tmpdir=$(mktemp -d)
@@ -81,18 +65,16 @@ case "$ARCH" in
   *)     edgevpn_arch=$ARCH ;;
 esac
 
-# Defaults
+# Defaults (external repos only; the in-tree kairos multi-call and its
+# FIPS twin were cp'd from BIN_SOURCE / BIN_SOURCE_FIPS above).
 fetch provider-kairos  "$PROVIDER_KAIROS_VERSION" default ""  ""             ""
 fetch kairos-installer "$INSTALLER_VERSION"       default ""  ""             ""
 fetch edgevpn          "$EDGEVPN_VERSION"         default ""  "$edgevpn_arch" mudler
 
-# FIPS embeds (bundled_fips.go is compiled on every non-riscv64 build,
-# so these files must exist for `go build` to satisfy //go:embed).
+# FIPS provider-kairos stays external (mudler/kairos-io repo). No FIPS
+# variant of edgevpn or kairos-installer.
 if [[ "$ARCH" != "riscv64" ]]; then
-    fetch kairos-agent                 "$AGENT_FIPS_VERSION"           fips "-fips" ""              ""
-    fetch immucore                     "$IMMUCORE_FIPS_VERSION"        fips "-fips" ""              ""
-    fetch kcrypt-discovery-challenger  "$KCRYPT_DISCOVERY_FIPS_VERSION" fips "-fips" ""              ""
-    fetch provider-kairos              "$PROVIDER_KAIROS_VERSION"      fips "-fips" ""              ""
+    fetch provider-kairos "$PROVIDER_KAIROS_VERSION" fips "-fips" "" ""
 fi
 
 # Move each fetched executable into the right destination dir.

--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/spectrocloud/peg/matcher"
@@ -123,6 +124,29 @@ bundles:
 			}, 5*time.Minute, 10*time.Second).Should(ContainSubstring("peerguard"))
 
 			stateAssertVM(vm, "persistent.found", "true")
+
+			By("Checking the multi-call binary layout", func() {
+				out, err := vm.Sudo("test -f /usr/bin/kairos && ! test -L /usr/bin/kairos && echo ok")
+				Expect(err).ToNot(HaveOccurred(), out)
+				Expect(out).To(ContainSubstring("ok"), "/usr/bin/kairos should be a real file, not a symlink")
+
+				for _, link := range []string{
+					"/usr/bin/kairos-agent",
+					"/usr/bin/immucore",
+					"/system/discovery/kcrypt-discovery-challenger",
+				} {
+					out, err := vm.Sudo(fmt.Sprintf("readlink -f %s", link))
+					Expect(err).ToNot(HaveOccurred(), out)
+					Expect(strings.TrimSpace(out)).To(Equal("/usr/bin/kairos"),
+						"expected %s to resolve to /usr/bin/kairos, got %q", link, out)
+					// And confirm it is a symlink, not a real duplicate.
+					out, err = vm.Sudo(fmt.Sprintf("test -L %s && echo symlink", link))
+					Expect(err).ToNot(HaveOccurred(), out)
+					Expect(out).To(ContainSubstring("symlink"),
+						"%s should be a symlink to /usr/bin/kairos", link)
+				}
+			})
+
 			By("Checking install/recovery services are disabled", func() {
 				if !isFlavor(vm, "alpine") {
 					for _, service := range []string{"kairos-interactive", "kairos-recovery"} {

--- a/tests/uki_test.go
+++ b/tests/uki_test.go
@@ -220,6 +220,26 @@ func genericTests(vm VM) {
 		Expect(out).To(ContainSubstring("ro"))
 		Expect(out).ToNot(ContainSubstring("rw"))
 	})
+	By("Checking the multi-call binary layout (UKI)", func() {
+		out, err := vm.Sudo("test -f /usr/bin/kairos && ! test -L /usr/bin/kairos && echo ok")
+		Expect(err).ToNot(HaveOccurred(), out)
+		Expect(out).To(ContainSubstring("ok"), "/usr/bin/kairos should be a real file, not a symlink")
+
+		for _, link := range []string{
+			"/usr/bin/kairos-agent",
+			"/usr/bin/immucore",
+			"/system/discovery/kcrypt-discovery-challenger",
+		} {
+			out, err := vm.Sudo(fmt.Sprintf("readlink -f %s", link))
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(strings.TrimSpace(out)).To(Equal("/usr/bin/kairos"),
+				"expected %s to resolve to /usr/bin/kairos, got %q", link, out)
+			out, err = vm.Sudo(fmt.Sprintf("test -L %s && echo symlink", link))
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(ContainSubstring("symlink"),
+				"%s should be a symlink to /usr/bin/kairos", link)
+		}
+	})
 	By("Checking the boot mode (boot)", func() {
 		out, err := vm.Sudo("stat /run/cos/uki_boot_mode")
 		Expect(err).ToNot(HaveOccurred(), out)


### PR DESCRIPTION
## What

Rolls the multi-call `kairos` binary through kairos-init's install path — the last piece of the monorepo work that motivated the whole subtree merge (MIGRATION.md item 24).

At install time, three separate ~150M binaries collapse into one 32M `kairos`:

```
/usr/bin/kairos                                real file (32M)
/usr/bin/kairos-agent                          -> /usr/bin/kairos
/usr/bin/immucore                              -> /usr/bin/kairos
/system/discovery/kcrypt-discovery-challenger  -> /usr/bin/kairos
```

`cmd/kairos` dispatches on argv[0], so every existing script and systemd unit keeps working — `kairos-agent upgrade` still runs the agent, `immucore` still runs immucore, etc.

## Other things in this PR

- **Dropped the slim binary variant.** We considered shipping a `kairos-slim` (agent-less) for the initramfs to save ~8M of initramfs size. After weighing on Slack we picked the simpler shape: one fat binary everywhere, no `-tags initramfs` build tag, no dead code.
- **Removed `kairos-agent` from the initramfs manifests** (dracut + Alpine mkinitfs). Traced the code — nothing in initramfs actually invokes it (immucore uses in-process yip; the SUC upgrader `nsenter`s into the host).
- **Fixed a stray collision**: `kairos-init` had legacy code creating `/usr/bin/kairos` as a symlink to the provider binary, which would have clobbered our multi-call binary. Removed (author's own comment said "not sure what uses it? TODO"). Grepped — nothing uses it.
- **Added a test** in the standard and UKI qemu install suites that verifies the on-disk invariant: `/usr/bin/kairos` is a real file, the others are symlinks to it. Catches silent regressions where a refactor accidentally duplicates a binary.

## Follow-up (not in this PR)

Same consolidation for the FIPS embed. Right now bundled_fips.go still uses the three-blob layout and pulls those blobs from the pre-monorepo archived-repo FIPS release tarballs, even though release CI already builds an in-tree FIPS multi-call kairos that goes unused. Needs qemu-tests-fips coverage first, which we don't have wired yet. Tracked as item 24b in MIGRATION.md.
