### PR TITLE
encryption tests: consume the just-built kcrypt-challenger image

### DIFF
--- a/.github/encryption-tests.sh
+++ b/.github/encryption-tests.sh
@@ -11,73 +11,70 @@ CERT_MANAGER_VERSION="v1.16.5"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 CLUSTER_NAME=$(echo $RANDOM | md5sum | head -c 10; echo;)
 
+KUBECONFIG=$(mktemp)
+export KUBECONFIG
 
-if [ "$LABEL" != "local-encryption" ]; then
-  KUBECONFIG=$(mktemp)
-  export KUBECONFIG
+cleanup() {
+  echo "Cleaning up $CLUSTER_NAME"
+  k3d cluster delete "$CLUSTER_NAME" || true
+  rm -rf "$KUBECONFIG"
+}
+trap cleanup EXIT
 
-  cleanup() {
-    echo "Cleaning up $CLUSTER_NAME"
-    k3d cluster delete "$CLUSTER_NAME" || true
-    rm -rf "$KUBECONFIG"
-  }
-  trap cleanup EXIT
+# Create a cluster and bind ports 80 and 443 on the host
+# This will allow us to access challenger server on 10.0.2.2 which is the IP
+# on which qemu "sees" the host.
+# We change the CIDR because k3s creates iptables rules that block DNS traffic to this CIDR
+# (something like that). If you run k3d inside a k3s cluster (inside a Pod), DNS won't work
+# inside the k3d server container unless you use a different CIDR.
+# Here we are avoiding CIDR "10.43.x.x"
+k3d cluster create "$CLUSTER_NAME" --k3s-arg "--cluster-cidr=10.49.0.1/16@server:0" --k3s-arg "--service-cidr=10.48.0.1/16@server:0" -p '80:80@server:0' -p '443:443@server:0' --image "$K3S_IMAGE"
+k3d kubeconfig get "$CLUSTER_NAME" > "$KUBECONFIG"
 
-  # Create a cluster and bind ports 80 and 443 on the host
-  # This will allow us to access challenger server on 10.0.2.2 which is the IP
-  # on which qemu "sees" the host.
-  # We change the CIDR because k3s creates iptables rules that block DNS traffic to this CIDR
-  # (something like that). If you run k3d inside a k3s cluster (inside a Pod), DNS won't work
-  # inside the k3d server container unless you use a different CIDR.
-  # Here we are avoiding CIDR "10.43.x.x"
-  k3d cluster create "$CLUSTER_NAME" --k3s-arg "--cluster-cidr=10.49.0.1/16@server:0" --k3s-arg "--service-cidr=10.48.0.1/16@server:0" -p '80:80@server:0' -p '443:443@server:0' --image "$K3S_IMAGE"
-  k3d kubeconfig get "$CLUSTER_NAME" > "$KUBECONFIG"
+# Wait for cluster to be fully ready before proceeding
+echo "Waiting for cluster to be ready..."
+kubectl wait --for=condition=Ready nodes --all --timeout=2m
 
-  # Wait for cluster to be fully ready before proceeding
-  echo "Waiting for cluster to be ready..."
-  kubectl wait --for=condition=Ready nodes --all --timeout=2m
+# Import the image to the cluster
+#docker pull quay.io/kairos/kcrypt-challenger:latest
+#k3d image import -c "$CLUSTER_NAME" quay.io/kairos/kcrypt-challenger:latest
 
-  # Import the image to the cluster
-  #docker pull quay.io/kairos/kcrypt-challenger:latest
-  #k3d image import -c "$CLUSTER_NAME" quay.io/kairos/kcrypt-challenger:latest
+# Install cert manager
+kubectl apply -f "https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
 
-  # Install cert manager
-  kubectl apply -f "https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+# Wait for cert-manager deployments to become available
+echo "Waiting for cert-manager deployments to be available..."
+kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
 
-  # Wait for cert-manager deployments to become available
-  echo "Waiting for cert-manager deployments to be available..."
-  kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
+# Replace the CLUSTER_IP in the kustomize resource
+# Only needed for debugging so that we can access the server from the host
+# (the 10.0.2.2 IP address is only useful from within qemu)
+CLUSTER_IP=$(docker inspect "k3d-${CLUSTER_NAME}-server-0"  | jq -r '.[0].NetworkSettings.Networks[].IPAddress')
+export CLUSTER_IP
 
-  # Replace the CLUSTER_IP in the kustomize resource
-  # Only needed for debugging so that we can access the server from the host
-  # (the 10.0.2.2 IP address is only useful from within qemu)
-  CLUSTER_IP=$(docker inspect "k3d-${CLUSTER_NAME}-server-0"  | jq -r '.[0].NetworkSettings.Networks[].IPAddress')
-  export CLUSTER_IP
+envsubst \
+    < "$SCRIPT_DIR/../tests/assets/encryption/challenger-server-ingress.template.yaml" \
+    > "$SCRIPT_DIR/../tests/assets/encryption/challenger-server-ingress.yaml"
 
-  envsubst \
-      < "$SCRIPT_DIR/../tests/assets/encryption/challenger-server-ingress.template.yaml" \
-      > "$SCRIPT_DIR/../tests/assets/encryption/challenger-server-ingress.yaml"
+# KCRYPT_CHALLENGER_IMAGE is required. No default on purpose:
+# a silent fallback to a published tag would let a CI misconfig
+# run the tests against an image that has nothing to do with
+# the change under test and claim success.
+: "${KCRYPT_CHALLENGER_IMAGE:?KCRYPT_CHALLENGER_IMAGE not set. Pass the image ref for the kcrypt-challenger to test, e.g. ghcr.io/kairos-io/kairos/kcrypt-challenger:pr-4356}"
+# envsubst wants the literal '${VAR}' text as its whitelist argument;
+# single-quoting keeps the shell from expanding it first.
+# shellcheck disable=SC2016
+envsubst '${KCRYPT_CHALLENGER_IMAGE}' \
+    < "$SCRIPT_DIR/../tests/assets/encryption/challenger-patch.template.yaml" \
+    > "$SCRIPT_DIR/../tests/assets/encryption/challenger-patch.yaml"
 
-  # KCRYPT_CHALLENGER_IMAGE is required. No default on purpose:
-  # a silent fallback to a published tag would let a CI misconfig
-  # run the tests against an image that has nothing to do with
-  # the change under test and claim success.
-  : "${KCRYPT_CHALLENGER_IMAGE:?KCRYPT_CHALLENGER_IMAGE not set. Pass the image ref for the kcrypt-challenger to test, e.g. ghcr.io/kairos-io/kairos/kcrypt-challenger:pr-4356}"
-  # envsubst wants the literal '${VAR}' text as its whitelist argument;
-  # single-quoting keeps the shell from expanding it first.
-  # shellcheck disable=SC2016
-  envsubst '${KCRYPT_CHALLENGER_IMAGE}' \
-      < "$SCRIPT_DIR/../tests/assets/encryption/challenger-patch.template.yaml" \
-      > "$SCRIPT_DIR/../tests/assets/encryption/challenger-patch.yaml"
+# Install the challenger server kustomization
+kubectl apply -k "$SCRIPT_DIR/../tests/assets/encryption/"
+kubectl wait --for=condition=Available deployment/kcrypt-controller-controller-manager -n default --timeout=2m
 
-  # Install the challenger server kustomization
-  kubectl apply -k "$SCRIPT_DIR/../tests/assets/encryption/"
-  kubectl wait --for=condition=Available deployment/kcrypt-controller-controller-manager -n default --timeout=2m
-
-  # 10.0.2.2 is where the vm sees the host
-  # https://stackoverflow.com/a/6752280
-  export KMS_ADDRESS="10.0.2.2.challenger.sslip.io"
-fi
+# 10.0.2.2 is where the vm sees the host
+# https://stackoverflow.com/a/6752280
+export KMS_ADDRESS="10.0.2.2.challenger.sslip.io"
 
 
 pushd "$SCRIPT_DIR/../tests/"

--- a/.github/encryption-tests.sh
+++ b/.github/encryption-tests.sh
@@ -63,6 +63,9 @@ if [ "$LABEL" != "local-encryption" ]; then
   # run the tests against an image that has nothing to do with
   # the change under test and claim success.
   : "${KCRYPT_CHALLENGER_IMAGE:?KCRYPT_CHALLENGER_IMAGE not set. Pass the image ref for the kcrypt-challenger to test, e.g. ghcr.io/kairos-io/kairos/kcrypt-challenger:pr-4356}"
+  # envsubst wants the literal '${VAR}' text as its whitelist argument;
+  # single-quoting keeps the shell from expanding it first.
+  # shellcheck disable=SC2016
   envsubst '${KCRYPT_CHALLENGER_IMAGE}' \
       < "$SCRIPT_DIR/../tests/assets/encryption/challenger-patch.template.yaml" \
       > "$SCRIPT_DIR/../tests/assets/encryption/challenger-patch.yaml"

--- a/.github/encryption-tests.sh
+++ b/.github/encryption-tests.sh
@@ -58,6 +58,15 @@ if [ "$LABEL" != "local-encryption" ]; then
       < "$SCRIPT_DIR/../tests/assets/encryption/challenger-server-ingress.template.yaml" \
       > "$SCRIPT_DIR/../tests/assets/encryption/challenger-server-ingress.yaml"
 
+  # KCRYPT_CHALLENGER_IMAGE is required. No default on purpose:
+  # a silent fallback to a published tag would let a CI misconfig
+  # run the tests against an image that has nothing to do with
+  # the change under test and claim success.
+  : "${KCRYPT_CHALLENGER_IMAGE:?KCRYPT_CHALLENGER_IMAGE not set. Pass the image ref for the kcrypt-challenger to test, e.g. ghcr.io/kairos-io/kairos/kcrypt-challenger:pr-4356}"
+  envsubst '${KCRYPT_CHALLENGER_IMAGE}' \
+      < "$SCRIPT_DIR/../tests/assets/encryption/challenger-patch.template.yaml" \
+      > "$SCRIPT_DIR/../tests/assets/encryption/challenger-patch.yaml"
+
   # Install the challenger server kustomization
   kubectl apply -k "$SCRIPT_DIR/../tests/assets/encryption/"
   kubectl wait --for=condition=Available deployment/kcrypt-controller-controller-manager -n default --timeout=2m

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -72,8 +72,9 @@ jobs:
       registry_login: ghcr
     secrets: inherit
 
-  # kcrypt-challenger pipe: parallel to the kairos pipe, only gates
-  # promote-images (nothing on the qemu path consumes it).
+  # kcrypt-challenger pipe: parallel to the kairos pipe. The encryption
+  # cells of qemu-tests-standard-encryption below consume its image; the
+  # rest of the qemu path does not. Also gates promote-images.
   build-kcrypt-challenger:
     uses: ./.github/workflows/_build-kcrypt-challenger.yaml
     with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -208,12 +208,6 @@ jobs:
           - {test: 'provider-upgrade-k8s'}
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
-          - {test: 'encryption-local'}
-          - {test: 'encryption-remote-auto'}
-          - {test: 'encryption-remote-static'}
-          - {test: 'encryption-remote-https-pinned'}
-          - {test: 'encryption-remote-https-bad-cert'}
-          - {test: 'encryption-kcrypt-cli'}
           - {test: 'provider-upgrade-latest-k8s-with-kubernetes', release-matcher: 'kairos-hadron-*-standard-amd64-generic-*k3sv*.iso'}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -225,6 +219,31 @@ jobs:
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       release-matcher: ${{ matrix.release-matcher || '' }}
+    secrets: inherit
+
+  # See pr.yaml for the rationale on splitting encryption cells out.
+  qemu-tests-standard-encryption:
+    needs: [build-iso, build-image-kcrypt-challenger]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {test: 'encryption-local'}
+          - {test: 'encryption-remote-auto'}
+          - {test: 'encryption-remote-static'}
+          - {test: 'encryption-remote-https-pinned'}
+          - {test: 'encryption-remote-https-bad-cert'}
+          - {test: 'encryption-kcrypt-cli'}
+    uses: ./.github/workflows/reusable-qemu-test.yaml
+    with:
+      test: ${{ matrix.test }}
+      base_image: 'ghcr.io/kairos-io/hadron:v0.5.1'
+      variant: 'standard'
+      arch: 'amd64'
+      model: 'generic'
+      secureboot: false
+      container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+      kcrypt_challenger_image: ghcr.io/kairos-io/kairos/kcrypt-challenger:master-scratch
     secrets: inherit
 
   qemu-tests-uki:
@@ -255,7 +274,7 @@ jobs:
     # qemu suites + arm build gate the kairos-init side; the
     # kcrypt-challenger image is on a parallel pipe and must also be
     # pushed to :master-scratch before this job can promote it.
-    needs: [qemu-tests-core, qemu-tests-standard, qemu-tests-uki, build-iso-arm, build-image-kcrypt-challenger]
+    needs: [qemu-tests-core, qemu-tests-standard, qemu-tests-standard-encryption, qemu-tests-uki, build-iso-arm, build-image-kcrypt-challenger]
     runs-on: ubuntu-latest
     steps:
       - name: Login to ghcr.io

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -283,12 +283,6 @@ jobs:
           - {test: 'provider-upgrade-k8s'}
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
-          - {test: 'encryption-local'}
-          - {test: 'encryption-remote-auto'}
-          - {test: 'encryption-remote-static'}
-          - {test: 'encryption-remote-https-pinned'}
-          - {test: 'encryption-remote-https-bad-cert'}
-          - {test: 'encryption-kcrypt-cli'}
           - {test: 'provider-upgrade-latest-k8s-with-kubernetes', release-matcher: 'kairos-hadron-*-standard-amd64-generic-*k3sv*.iso'}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -300,6 +294,35 @@ jobs:
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       release-matcher: ${{ matrix.release-matcher || '' }}
+      ref: refs/pull/${{ github.event.pull_request.number }}/head
+    secrets: inherit
+
+  # encryption-* tests spin up a k3s cluster with a kcrypt-challenger
+  # Deployment, and that deployment now runs the image this PR just
+  # built. Split out from qemu-tests-standard so only these cells gate
+  # on build-image-kcrypt-challenger.
+  qemu-tests-standard-encryption:
+    needs: [build-iso, build-image-kcrypt-challenger]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {test: 'encryption-local'}
+          - {test: 'encryption-remote-auto'}
+          - {test: 'encryption-remote-static'}
+          - {test: 'encryption-remote-https-pinned'}
+          - {test: 'encryption-remote-https-bad-cert'}
+          - {test: 'encryption-kcrypt-cli'}
+    uses: ./.github/workflows/reusable-qemu-test.yaml
+    with:
+      test: ${{ matrix.test }}
+      base_image: 'ghcr.io/kairos-io/hadron:v0.5.1'
+      variant: 'standard'
+      arch: 'amd64'
+      model: 'generic'
+      secureboot: false
+      container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+      kcrypt_challenger_image: ghcr.io/kairos-io/kairos/kcrypt-challenger:pr-${{ github.event.pull_request.number }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head
     secrets: inherit
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -136,8 +136,10 @@ jobs:
       registry_login: quay
     secrets: inherit
 
-  # kcrypt-challenger pipe: parallel to the kairos pipe, only gates
-  # promote-images / upload-release.
+  # kcrypt-challenger pipe: parallel to the kairos pipe. The encryption
+  # cells of qemu-tests-standard-encryption below consume its image; the
+  # rest of the qemu path does not. Also gates promote-images and
+  # upload-release.
   build-kcrypt-challenger:
     uses: ./.github/workflows/_build-kcrypt-challenger.yaml
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -331,6 +331,24 @@ jobs:
           - {test: 'provider-upgrade-k8s'}
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
+    uses: ./.github/workflows/reusable-qemu-test.yaml
+    with:
+      test: ${{ matrix.test }}
+      base_image: 'ghcr.io/kairos-io/hadron:v0.5.1'
+      variant: 'standard'
+      arch: 'amd64'
+      model: 'generic'
+      secureboot: false
+      container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+    secrets: inherit
+
+  # See pr.yaml for the rationale on splitting encryption cells out.
+  qemu-tests-standard-encryption:
+    needs: [build-iso, build-image-kcrypt-challenger]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - {test: 'encryption-local'}
           - {test: 'encryption-remote-auto'}
           - {test: 'encryption-remote-static'}
@@ -346,6 +364,7 @@ jobs:
       model: 'generic'
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+      kcrypt_challenger_image: quay.io/kairos/kcrypt-challenger:${{ github.ref_name }}-scratch
     secrets: inherit
 
   qemu-tests-uki:
@@ -374,7 +393,7 @@ jobs:
     # qemu suites + iso matrices gate the kairos-init side; the
     # kcrypt-challenger image is on a parallel pipe and must also be
     # pushed to :<tag>-scratch before this job can promote it.
-    needs: [qemu-tests-core, qemu-tests-standard, qemu-tests-uki, build-iso-arm, build-iso-k3s, build-iso-k0s, build-image-kcrypt-challenger]
+    needs: [qemu-tests-core, qemu-tests-standard, qemu-tests-standard-encryption, qemu-tests-uki, build-iso-arm, build-iso-k3s, build-iso-k0s, build-image-kcrypt-challenger]
     runs-on: ubuntu-latest
     steps:
       - name: Login to quay.io
@@ -399,6 +418,6 @@ jobs:
   upload-release:
     # Uploads every tarball to the GitHub Release. Waits on both
     # pipes so the release ships kairos + kairos-init + kcrypt-challenger.
-    needs: [unit-tests, qemu-tests-core, qemu-tests-standard, qemu-tests-uki, build-iso-arm, build-iso-k3s, build-iso-k0s, build-kcrypt-challenger]
+    needs: [unit-tests, qemu-tests-core, qemu-tests-standard, qemu-tests-standard-encryption, qemu-tests-uki, build-iso-arm, build-iso-k3s, build-iso-k0s, build-kcrypt-challenger]
     uses: ./.github/workflows/_upload-release.yaml
     secrets: inherit

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -69,6 +69,16 @@ on:
         required: false
         type: string
         default: 'quay.io/kairos/ci-temp-images'
+      kcrypt_challenger_image:
+        description: |
+          Fully-qualified image reference for the kcrypt-challenger
+          Deployment the encryption suite spins up (e.g.
+          `ghcr.io/kairos-io/kairos/kcrypt-challenger:pr-1234`). Only
+          consumed by encryption-* tests; the script errors out if the
+          test is encryption-* and this is empty.
+        required: false
+        type: string
+        default: ''
 
     secrets:
       QUAY_USERNAME:
@@ -308,6 +318,7 @@ jobs:
           CPUS: 2
           DRIVE_SIZE: 50000
           CONTAINER_IMAGE: ${{ env.IMAGE_NAME }}
+          KCRYPT_CHALLENGER_IMAGE: ${{ inputs.kcrypt_challenger_image }}
         run: |
           # Pick a k3s image
           export ISO=$PWD/$(ls *.iso|grep -v ipxe | grep k3s | head -1 )

--- a/tests/assets/encryption/challenger-patch.template.yaml
+++ b/tests/assets/encryption/challenger-patch.template.yaml
@@ -11,7 +11,7 @@ spec:
         - name: kube-rbac-proxy
           $patch: delete
         - name: manager
-          image: quay.io/kairos/kcrypt-challenger:v0.12.1
+          image: ${KCRYPT_CHALLENGER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
             - "--health-probe-bind-address"

--- a/tests/assets/encryption/kustomization.yaml
+++ b/tests/assets/encryption/kustomization.yaml
@@ -2,7 +2,7 @@
 namespace: default
 
 bases:
-  - github.com/kairos-io/kcrypt-challenger/config/default
+  - ../../../kcrypt/config/default
 
 resources:
   - challenger-server-ingress.yaml


### PR DESCRIPTION
## What this PR does

Our encryption tests spin up a small Kubernetes cluster with a kcrypt-challenger server deployed in it. Until now, that deployment always ran a released image (`quay.io/kairos/kcrypt-challenger:v0.12.1`), no matter what the PR changed. So we were building a fresh kcrypt-challenger image in CI, pushing it, and then testing against a completely different, older image. Regressions could slip through and only get caught after release.

This PR wires the tests to use the kcrypt-challenger image that CI just built. On a PR run the encryption tests deploy `ghcr.io/kairos-io/kairos/kcrypt-challenger:pr-<N>`; on master they deploy the `master-scratch` tag; on release they deploy the `<tag>-scratch` tag. If nobody sets the image reference (a local misuse or a CI misconfig), the test errors out early instead of silently falling back to the old released tag.

As a small cleanup: the same kustomization was pulling its base from `github.com/kairos-io/kcrypt-challenger`, an archived repo since the monorepo landed. Repointed it at the in-tree copy under `kcrypt/config/default/`.

## Which issue(s) this PR fixes

None (follow-up to #4356).
