### PR TITLE
cmd/kairos: register "init" as an alias for immucore

### DIFF
--- a/cmd/kairos/register_immucore.go
+++ b/cmd/kairos/register_immucore.go
@@ -5,5 +5,11 @@ import (
 )
 
 func init() {
-	register("immucore", immucore.Run)
+	// "init" alias: on a Kairos UKI, /init is a symlink to /usr/bin/immucore
+	// (created by AuroraBoot's uki builder, see pkg/uki/uki.go). The kernel
+	// exec()s /init as PID 1 with argv[0]="/init", so once immucore itself
+	// is a symlink to the multi-call kairos, argv[0]'s basename is "init"
+	// rather than "immucore". Without this alias PID 1 exits with "unknown
+	// sub-tool" and the kernel panics with "Attempted to kill init".
+	register("immucore", immucore.Run, "init")
 }

--- a/tests/provider_decentralized_test.go
+++ b/tests/provider_decentralized_test.go
@@ -140,15 +140,23 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 			}
 		})
 
+		// The provider-kairos binary lives at /system/providers/agent-provider-kairos
+		// on the installed system. Pre-monorepo it was also symlinked at /usr/bin/kairos,
+		// which is now the multi-call dispatcher for immucore/agent/kcrypt. Whether
+		// `kairos <cmd>` should still route to a provider is an open question tracked
+		// in kairos-io/kairos#3926 (multi-provider composability); the absolute path
+		// here keeps the test neutral while that lands.
+		const providerKairos = "/system/providers/agent-provider-kairos"
+
 		vmForEach("checking if it has a working kubeconfig", vms, func(vm VM) {
 			var out string
 			Eventually(func() string {
-				out, _ = vm.Sudo("kairos get-kubeconfig")
+				out, _ = vm.Sudo(providerKairos + " get-kubeconfig")
 				return out
 			}, 1500*time.Second, 10*time.Second).Should(ContainSubstring("https:"))
 
 			Eventually(func() string {
-				vm.Sudo("kairos get-kubeconfig > kubeconfig")
+				vm.Sudo(providerKairos + " get-kubeconfig > kubeconfig")
 				out, _ = vm.Sudo("KUBECONFIG=kubeconfig kubectl get nodes -o wide")
 				return out
 			}, 900*time.Second, 10*time.Second).Should(ContainSubstring("Ready"))
@@ -160,7 +168,7 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 			Expect(err).ToNot(HaveOccurred(), uuid)
 			Expect(uuid).ToNot(Equal(""))
 			Eventually(func() string {
-				out, _ = vm.Sudo("kairos role list")
+				out, _ = vm.Sudo(providerKairos + " role list")
 				return out
 			}, 900*time.Second, 10*time.Second).Should(And(
 				ContainSubstring(uuid),


### PR DESCRIPTION
Fixes the "Attempted to kill init!" kernel panic that qemu-tests-uki started hitting on master after #4356 (see run 32479749093, both boot-assessment and install-upgrade).

AuroraBoot's UKI builder creates /init as a symlink to /usr/bin/immucore (AuroraBoot/pkg/uki/uki.go:599). Before the multi-call rollout /usr/bin/immucore was a real binary, so the kernel exec'd immucore directly with argv[0]="/init" and the immucore binary happily ignored argv[0]. Post-rollout, /usr/bin/immucore is a symlink to /usr/bin/kairos; the kernel still passes argv[0]="/init", multi-call kairos does
filepath.Base("/init") = "init", finds nothing registered under that name, and exits with status 2. PID 1 dying is a kernel panic.

Register "init" as an alias for the immucore sub-tool so kairos resolves argv[0]="/init" to the immucore entrypoint. Same handling "kairos-agent" already gets as an alias for the agent sub-tool.
