### PR TITLE
ci(master): build riscv64 on every master push, not release-only

### DIFF
--- a/.github/workflows/_build-kairos-init.yaml
+++ b/.github/workflows/_build-kairos-init.yaml
@@ -15,9 +15,7 @@ on:
       matrix_scope:
         description: |
           "ci" -> amd64 + arm64 (PR only).
-          "full" -> amd64 + arm64 + riscv64. Used by both master and
-          release -- the set of architectures to build, not a statement
-          about whether this run is a release.
+          "full" -> amd64 + arm64 + riscv64. Used by both master and release
         type: string
         required: true
 

--- a/.github/workflows/_build-kairos-init.yaml
+++ b/.github/workflows/_build-kairos-init.yaml
@@ -14,8 +14,10 @@ on:
     inputs:
       matrix_scope:
         description: |
-          "ci" -> amd64 + arm64 (PR + master).
-          "release" -> amd64 + arm64 + riscv64.
+          "ci" -> amd64 + arm64 (PR only).
+          "full" -> amd64 + arm64 + riscv64. Used by both master and
+          release -- the set of architectures to build, not a statement
+          about whether this run is a release.
         type: string
         required: true
 
@@ -38,7 +40,7 @@ jobs:
         env:
           SCOPE: ${{ inputs.matrix_scope }}
         run: |
-          if [[ "$SCOPE" == "release" ]]; then
+          if [[ "$SCOPE" == "full" ]]; then
             echo 'matrix={"include":[{"arch":"amd64"},{"arch":"arm64"},{"arch":"riscv64"}]}' >> "$GITHUB_OUTPUT"
           else
             echo 'matrix={"include":[{"arch":"amd64"},{"arch":"arm64"}]}' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_build-kairos.yaml
+++ b/.github/workflows/_build-kairos.yaml
@@ -15,9 +15,7 @@ on:
         description: |
           "ci" -> amd64 + arm64, both default and FIPS (PR only).
           "full" -> full 5-cell matrix (amd64+arm64+riscv64 default plus
-          amd64+arm64 FIPS). Used by both master and release -- it's the
-          set of architectures to build, not a statement about whether
-          this run is a release. Don't read "full" as "release-only".
+          amd64+arm64 FIPS). Used by both master and release.
         type: string
         required: true
 

--- a/.github/workflows/_build-kairos.yaml
+++ b/.github/workflows/_build-kairos.yaml
@@ -13,9 +13,11 @@ on:
     inputs:
       matrix_scope:
         description: |
-          "ci" -> amd64 + arm64, both default and FIPS (PR + master).
-          "release" -> full 5-cell matrix (amd64+arm64+riscv64 default
-          plus amd64+arm64 FIPS).
+          "ci" -> amd64 + arm64, both default and FIPS (PR only).
+          "full" -> full 5-cell matrix (amd64+arm64+riscv64 default plus
+          amd64+arm64 FIPS). Used by both master and release -- it's the
+          set of architectures to build, not a statement about whether
+          this run is a release. Don't read "full" as "release-only".
         type: string
         required: true
 
@@ -38,7 +40,7 @@ jobs:
         env:
           SCOPE: ${{ inputs.matrix_scope }}
         run: |
-          if [[ "$SCOPE" == "release" ]]; then
+          if [[ "$SCOPE" == "full" ]]; then
             echo 'matrix={"include":[{"arch":"amd64","variant":"default"},{"arch":"arm64","variant":"default"},{"arch":"riscv64","variant":"default"},{"arch":"amd64","variant":"fips"},{"arch":"arm64","variant":"fips"}]}' >> "$GITHUB_OUTPUT"
           else
             echo 'matrix={"include":[{"arch":"amd64","variant":"default"},{"arch":"arm64","variant":"default"},{"arch":"amd64","variant":"fips"},{"arch":"arm64","variant":"fips"}]}' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -48,15 +48,20 @@ jobs:
 
   # kairos-init pipe: gates build-iso + qemu-tests.
   #
-  # matrix_scope: release, not ci -- deliberately, even though this is
-  # the master pipeline. "release" is exactly "ci" (amd64+arm64,
-  # default+FIPS) plus one more cell, riscv64 default -- confirmed from
-  # _build-kairos.yaml/_build-kairos-init.yaml's own matrix-computation
-  # step, they're not two independently-defined matrices that happen to
-  # overlap. Since the monorepo CI reshape (ae314796, ea046bc3), riscv64
-  # only builds on a v* release tag, so a riscv64-breaking change to
-  # images/Dockerfile or kairos-init reaches a release before anything
-  # catches it -- the exact code path hadron's build depends on directly
+  # matrix_scope: full -- the same value release.yaml passes, renamed
+  # from "release" (what this was first written as) specifically
+  # because that name was confusing here: master.yaml doesn't cut a
+  # release, and reading "matrix_scope: release" in this file invites
+  # exactly that misreading. "full" names what it actually controls --
+  # the set of architectures built (amd64+arm64, default+FIPS, plus
+  # riscv64 default) -- with no claim about what kind of run this is.
+  # See _build-kairos.yaml/_build-kairos-init.yaml for the actual
+  # matrix each value produces.
+  #
+  # Since the monorepo CI reshape (ae314796, ea046bc3), riscv64 only
+  # built on a v* release tag, so a riscv64-breaking change to
+  # images/Dockerfile or kairos-init reached a release before anything
+  # caught it -- the exact code path hadron's build depends on directly
   # (curl's images/Dockerfile and docker build --platform=linux/riscv64
   # against it; see kairos-io/hadron's Makefile KAIROS_DOCKERFILE_REF).
   # This restores that regression check on every master push, the
@@ -71,14 +76,14 @@ jobs:
   build-kairos:
     uses: ./.github/workflows/_build-kairos.yaml
     with:
-      matrix_scope: release
+      matrix_scope: full
     secrets: inherit
 
   build-kairos-init:
     needs: build-kairos
     uses: ./.github/workflows/_build-kairos-init.yaml
     with:
-      matrix_scope: release
+      matrix_scope: full
     secrets: inherit
 
   build-image-kairos-init:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -48,15 +48,10 @@ jobs:
 
   # kairos-init pipe: gates build-iso + qemu-tests.
   #
-  # matrix_scope: full -- the same value release.yaml passes, renamed
-  # from "release" (what this was first written as) specifically
-  # because that name was confusing here: master.yaml doesn't cut a
-  # release, and reading "matrix_scope: release" in this file invites
-  # exactly that misreading. "full" names what it actually controls --
-  # the set of architectures built (amd64+arm64, default+FIPS, plus
-  # riscv64 default) -- with no claim about what kind of run this is.
-  # See _build-kairos.yaml/_build-kairos-init.yaml for the actual
-  # matrix each value produces.
+  # matrix_scope: full -- the same value release.yaml passes. Names
+  # the architecture set this builds (amd64+arm64, default+FIPS, plus
+  # riscv64 default), not what kind of run this is. See
+  # _build-kairos.yaml/_build-kairos-init.yaml for the actual matrix.
   #
   # Since the monorepo CI reshape (ae314796, ea046bc3), riscv64 only
   # built on a v* release tag, so a riscv64-breaking change to

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -47,17 +47,38 @@ jobs:
     secrets: inherit
 
   # kairos-init pipe: gates build-iso + qemu-tests.
+  #
+  # matrix_scope: release, not ci -- deliberately, even though this is
+  # the master pipeline. "release" is exactly "ci" (amd64+arm64,
+  # default+FIPS) plus one more cell, riscv64 default -- confirmed from
+  # _build-kairos.yaml/_build-kairos-init.yaml's own matrix-computation
+  # step, they're not two independently-defined matrices that happen to
+  # overlap. Since the monorepo CI reshape (ae314796, ea046bc3), riscv64
+  # only builds on a v* release tag, so a riscv64-breaking change to
+  # images/Dockerfile or kairos-init reaches a release before anything
+  # catches it -- the exact code path hadron's build depends on directly
+  # (curl's images/Dockerfile and docker build --platform=linux/riscv64
+  # against it; see kairos-io/hadron's Makefile KAIROS_DOCKERFILE_REF).
+  # This restores that regression check on every master push, the
+  # earliest point it can be caught, without touching pr.yaml -- every
+  # contributor's PR stays exactly as fast as it is today.
+  #
+  # Known cost, not hidden: riscv64 under QEMU is slow (observed ~2h+
+  # for a from-scratch riscv64 build elsewhere in the org). This adds
+  # that to every master push, not just releases. Left as a draft for
+  # a maintainer to weigh against the regression-safety gap above --
+  # not something to wave through unreviewed.
   build-kairos:
     uses: ./.github/workflows/_build-kairos.yaml
     with:
-      matrix_scope: ci
+      matrix_scope: release
     secrets: inherit
 
   build-kairos-init:
     needs: build-kairos
     uses: ./.github/workflows/_build-kairos-init.yaml
     with:
-      matrix_scope: ci
+      matrix_scope: release
     secrets: inherit
 
   build-image-kairos-init:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,17 +111,22 @@ jobs:
           echo "kubernetes_versions=$kubernetes_versions" >> "$GITHUB_OUTPUT"
 
   # kairos-init pipe: gates build-iso + qemu-tests.
+  #
+  # matrix_scope: full, renamed from "release" -- master.yaml now calls
+  # these same two reusable workflows with the same value, since master
+  # builds riscv64 too (see master.yaml's own comment). "full" names
+  # the architecture set this produces, not which workflow calls it.
   build-kairos:
     uses: ./.github/workflows/_build-kairos.yaml
     with:
-      matrix_scope: release
+      matrix_scope: full
     secrets: inherit
 
   build-kairos-init:
     needs: build-kairos
     uses: ./.github/workflows/_build-kairos-init.yaml
     with:
-      matrix_scope: release
+      matrix_scope: full
     secrets: inherit
 
   build-image-kairos-init:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,10 +112,10 @@ jobs:
 
   # kairos-init pipe: gates build-iso + qemu-tests.
   #
-  # matrix_scope: full, renamed from "release" -- master.yaml now calls
-  # these same two reusable workflows with the same value, since master
-  # builds riscv64 too (see master.yaml's own comment). "full" names
-  # the architecture set this produces, not which workflow calls it.
+  # matrix_scope: full -- master.yaml calls these same two reusable
+  # workflows with the same value, since master builds riscv64 too
+  # (see master.yaml's own comment). "full" names the architecture set
+  # this produces, not which workflow calls it.
   build-kairos:
     uses: ./.github/workflows/_build-kairos.yaml
     with:


### PR DESCRIPTION
## Summary

Follow-up to the monorepo CI reshape (ae314796, ea046bc3). `pr.yaml` and `master.yaml` both moved `build-kairos`/`build-kairos-init` to `matrix_scope: ci`, which excludes riscv64 — it now only builds on a `v*` release tag. A riscv64-breaking change to `images/Dockerfile` or `kairos-init` reaches a release before any CI catches it.

That's not hypothetical for us: [kairos-io/hadron](https://github.com/kairos-io/hadron)'s build depends on exactly that path directly — its `Makefile` curls `images/Dockerfile` at a pinned ref and runs `docker build --platform=linux/riscv64` against it (`KAIROS_DOCKERFILE_REF`, currently pinned pre-monorepo for an unrelated reason, with a comment already anticipating this).

## What this does

`master.yaml`'s `build-kairos`/`build-kairos-init` jobs switch from `matrix_scope: ci` to `matrix_scope: release`. Confirmed from `_build-kairos.yaml`/`_build-kairos-init.yaml`'s own matrix-computation step: `release` isn't a separately-defined matrix, it's exactly `ci` (amd64+arm64, default+FIPS) plus one more cell, riscv64 default. The riscv64-has-no-FIPS guards this exercises (`if: matrix.arch != 'riscv64'`) already run today via `release.yaml`, so this isn't a new, untested code path on master — just an earlier point it also runs.

**`pr.yaml` is untouched.** Every contributor's PR stays exactly as fast as it is today. This only adds cost to `master`, post-merge.

## What this doesn't do

`_build-image-kairos-init.yaml` (the published `kairos-init` container image) has a separately hardcoded `linux/amd64,linux/arm64` platform list and doesn't pick up the riscv64 binary this adds — that's an existing gap on `release.yaml` too, not something this PR touches. hadron's build doesn't go through that image anyway (it builds from `images/Dockerfile` directly), so it's out of scope here, flagging it since it's adjacent.

## Known cost, not hidden

riscv64 under QEMU is slow — multi-hour builds observed elsewhere in the org for a from-scratch riscv64 pipeline. This adds that to every master push, not just releases. **Draft, deliberately** — this is a real tradeoff (regression-safety gap vs. CI cost/time) that should get a maintainer's judgment, not land on the strength of this PR's own reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)