### PR TITLE
workflows: opt into actions/checkout's allow-unsafe-pr-checkout via caller-vetted-ref

### DIFF
--- a/.github/workflows/_build-image-kairos-init.yaml
+++ b/.github/workflows/_build-image-kairos-init.yaml
@@ -42,6 +42,21 @@ on:
         type: string
         required: false
         default: ''
+      caller-vetted-ref:
+        description: |
+          Caller assertion required to unlock actions/checkout's
+          `allow-unsafe-pr-checkout` opt-in. Set to `true` ONLY if
+          the caller has its own authorization gate in front of
+          this workflow -- e.g. a `pull_request_target` pipeline
+          whose `authorize` job pins the run to a GitHub
+          Environment that requires maintainer review before the
+          fork's `ref` is fetched. Without such a gate, leaving
+          this false keeps the `pull_request_target` + fork-ref
+          combination blocked at checkout time (the guard
+          described at https://gh.io/securely-using-pull_request_target).
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -56,6 +71,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: ${{ inputs.caller-vetted-ref }}
 
       - name: Download kairos-init artifacts (amd64 + arm64)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/_build-image-kcrypt-challenger.yaml
+++ b/.github/workflows/_build-image-kcrypt-challenger.yaml
@@ -43,6 +43,21 @@ on:
         type: string
         required: false
         default: ''
+      caller-vetted-ref:
+        description: |
+          Caller assertion required to unlock actions/checkout's
+          `allow-unsafe-pr-checkout` opt-in. Set to `true` ONLY if
+          the caller has its own authorization gate in front of
+          this workflow -- e.g. a `pull_request_target` pipeline
+          whose `authorize` job pins the run to a GitHub
+          Environment that requires maintainer review before the
+          fork's `ref` is fetched. Without such a gate, leaving
+          this false keeps the `pull_request_target` + fork-ref
+          combination blocked at checkout time (the guard
+          described at https://gh.io/securely-using-pull_request_target).
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -57,6 +72,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: ${{ inputs.caller-vetted-ref }}
 
       - name: Download kcrypt-challenger artifacts (amd64 + arm64, default only)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/_build-iso.yaml
+++ b/.github/workflows/_build-iso.yaml
@@ -122,6 +122,21 @@ on:
         type: string
         required: false
         default: ''
+      caller-vetted-ref:
+        description: |
+          Caller assertion required to unlock actions/checkout's
+          `allow-unsafe-pr-checkout` opt-in inside factory-action.
+          Set to `true` ONLY if the caller has its own authorization
+          gate in front of this workflow -- e.g. a `pull_request_target`
+          pipeline whose `authorize` job pins the run to a GitHub
+          Environment that requires maintainer review before the fork's
+          `ref` is fetched. Without such a gate, leaving this false keeps
+          the `pull_request_target` + fork-ref combination blocked at
+          checkout time (the guard described at
+          https://gh.io/securely-using-pull_request_target).
+        type: boolean
+        required: false
+        default: false
 
 # No `secrets:` block on workflow_call: registry credentials are
 # derived from inputs.registry_domain inside the job (ghcr.io ->
@@ -146,7 +161,7 @@ permissions:
 jobs:
   iso:
     name: ${{ inputs.name }}
-    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@e2108928941a741b690e3f879f46e5f0706ae565  # v1.4.5
+    uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@1e6159c7e150b3ea63fdded7349be7db1f33066f  # v1.5.0
     secrets:
       # ghcr.io accepts github.actor + GITHUB_TOKEN; the token is
       # write-scoped only for same-repo events (push, same-repo PR).
@@ -157,6 +172,7 @@ jobs:
       registry_password: ${{ inputs.registry_domain == 'ghcr.io' && secrets.GITHUB_TOKEN || secrets.QUAY_PASSWORD }}
     with:
       ref: ${{ inputs.ref }}
+      caller-vetted-ref: ${{ inputs.caller-vetted-ref }}
       auroraboot_version: 'v0.26.2'
       dockerfile_path: 'images/Dockerfile'
       # Point images/Dockerfile at the caller-supplied kairos-init.

--- a/.github/workflows/_build-kairos-init.yaml
+++ b/.github/workflows/_build-kairos-init.yaml
@@ -24,6 +24,21 @@ on:
         type: string
         required: false
         default: ''
+      caller-vetted-ref:
+        description: |
+          Caller assertion required to unlock actions/checkout's
+          `allow-unsafe-pr-checkout` opt-in. Set to `true` ONLY if
+          the caller has its own authorization gate in front of
+          this workflow -- e.g. a `pull_request_target` pipeline
+          whose `authorize` job pins the run to a GitHub
+          Environment that requires maintainer review before the
+          fork's `ref` is fetched. Without such a gate, leaving
+          this false keeps the `pull_request_target` + fork-ref
+          combination blocked at checkout time (the guard
+          described at https://gh.io/securely-using-pull_request_target).
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -56,6 +71,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: ${{ inputs.caller-vetted-ref }}
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0

--- a/.github/workflows/_build-kairos.yaml
+++ b/.github/workflows/_build-kairos.yaml
@@ -24,6 +24,21 @@ on:
         type: string
         required: false
         default: ''
+      caller-vetted-ref:
+        description: |
+          Caller assertion required to unlock actions/checkout's
+          `allow-unsafe-pr-checkout` opt-in. Set to `true` ONLY if
+          the caller has its own authorization gate in front of
+          this workflow -- e.g. a `pull_request_target` pipeline
+          whose `authorize` job pins the run to a GitHub
+          Environment that requires maintainer review before the
+          fork's `ref` is fetched. Without such a gate, leaving
+          this false keeps the `pull_request_target` + fork-ref
+          combination blocked at checkout time (the guard
+          described at https://gh.io/securely-using-pull_request_target).
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -56,6 +71,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: ${{ inputs.caller-vetted-ref }}
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0

--- a/.github/workflows/_build-kcrypt-challenger.yaml
+++ b/.github/workflows/_build-kcrypt-challenger.yaml
@@ -26,6 +26,21 @@ on:
         type: string
         required: false
         default: ''
+      caller-vetted-ref:
+        description: |
+          Caller assertion required to unlock actions/checkout's
+          `allow-unsafe-pr-checkout` opt-in. Set to `true` ONLY if
+          the caller has its own authorization gate in front of
+          this workflow -- e.g. a `pull_request_target` pipeline
+          whose `authorize` job pins the run to a GitHub
+          Environment that requires maintainer review before the
+          fork's `ref` is fetched. Without such a gate, leaving
+          this false keeps the `pull_request_target` + fork-ref
+          combination blocked at checkout time (the guard
+          described at https://gh.io/securely-using-pull_request_target).
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -58,6 +73,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: ${{ inputs.caller-vetted-ref }}
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0

--- a/.github/workflows/_lint.yaml
+++ b/.github/workflows/_lint.yaml
@@ -16,14 +16,31 @@ on:
         type: string
         required: false
         default: ''
+      caller-vetted-ref:
+        description: |
+          Caller assertion required to unlock actions/checkout's
+          `allow-unsafe-pr-checkout` opt-in inside the nested lint
+          reusable. Set to `true` ONLY if the caller has its own
+          authorization gate in front of this workflow -- e.g. a
+          `pull_request_target` pipeline whose `authorize` job pins
+          the run to a GitHub Environment that requires maintainer
+          review before the fork's `ref` is fetched. Without such a
+          gate, leaving this false keeps the `pull_request_target`
+          + fork-ref combination blocked at checkout time (the
+          guard described at
+          https://gh.io/securely-using-pull_request_target).
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
 
 jobs:
   lint:
-    uses: kairos-io/linting-composite-action/.github/workflows/reusable-linting.yaml@6d48f21028c3fe44c036a89b54b54931415999c0  # main @ ref-input
+    uses: kairos-io/linting-composite-action/.github/workflows/reusable-linting.yaml@424114d0be41e4aa2a1ec2e6989aa66288dfc344  # v0.0.11
     with:
       yamldirs: '.github/workflows/'
       is-go: false
       ref: ${{ inputs.ref }}
+      caller-vetted-ref: ${{ inputs.caller-vetted-ref }}

--- a/.github/workflows/_uki-test.yaml
+++ b/.github/workflows/_uki-test.yaml
@@ -67,6 +67,21 @@ on:
         type: string
         required: false
         default: ''
+      caller-vetted-ref:
+        description: |
+          Caller assertion required to unlock actions/checkout's
+          `allow-unsafe-pr-checkout` opt-in. Set to `true` ONLY if
+          the caller has its own authorization gate in front of
+          this workflow -- e.g. a `pull_request_target` pipeline
+          whose `authorize` job pins the run to a GitHub
+          Environment that requires maintainer review before the
+          fork's `ref` is fetched. Without such a gate, leaving
+          this false keeps the `pull_request_target` + fork-ref
+          combination blocked at checkout time (the guard
+          described at https://gh.io/securely-using-pull_request_target).
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -108,6 +123,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: ${{ inputs.caller-vetted-ref }}
 
       - name: Set Version
         run: echo "VERSION=$(git describe --tags --dirty)" >> "$GITHUB_ENV"

--- a/.github/workflows/_unit-tests.yaml
+++ b/.github/workflows/_unit-tests.yaml
@@ -16,6 +16,21 @@ on:
         type: string
         required: false
         default: ''
+      caller-vetted-ref:
+        description: |
+          Caller assertion required to unlock actions/checkout's
+          `allow-unsafe-pr-checkout` opt-in. Set to `true` ONLY if
+          the caller has its own authorization gate in front of
+          this workflow -- e.g. a `pull_request_target` pipeline
+          whose `authorize` job pins the run to a GitHub
+          Environment that requires maintainer review before the
+          fork's `ref` is fetched. Without such a gate, leaving
+          this false keeps the `pull_request_target` + fork-ref
+          combination blocked at checkout time (the guard
+          described at https://gh.io/securely-using-pull_request_target).
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -29,6 +44,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: ${{ inputs.caller-vetted-ref }}
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,14 @@ name: PR
 # fork-pr-builds environment and wait for a maintainer to review
 # the diff before any secret-bearing job runs. Do NOT drop the
 # authorize job or those findings become real.
+#
+# Every reusable call below sets `caller-vetted-ref: true`. That
+# is what unlocks actions/checkout's `allow-unsafe-pr-checkout`
+# opt-in inside each reusable. It is honest to assert here because
+# `needs: authorize` puts every fork PR through the fork-pr-builds
+# environment approval before its ref is fetched. Removing the
+# `authorize` gate without also removing these assertions turns
+# the codeql-flagged "pwn request" attack surface real.
 
 on:
   pull_request_target:
@@ -65,6 +73,7 @@ jobs:
     uses: ./.github/workflows/_unit-tests.yaml
     with:
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   lint:
@@ -72,6 +81,7 @@ jobs:
     uses: ./.github/workflows/_lint.yaml
     with:
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   # The kairos-init pipe (multi-call kairos -> kairos-init -> image ->
@@ -82,6 +92,7 @@ jobs:
     with:
       matrix_scope: ci
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   build-kairos-init:
@@ -90,6 +101,7 @@ jobs:
     with:
       matrix_scope: ci
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   # unit-tests + lint gate any image push (visible outside the run).
@@ -103,6 +115,7 @@ jobs:
       push: true
       registry_login: ghcr
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   # The kcrypt-challenger pipe runs in parallel to the kairos pipe.
@@ -115,6 +128,7 @@ jobs:
     with:
       matrix_scope: ci
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   build-image-kcrypt-challenger:
@@ -126,6 +140,7 @@ jobs:
       push: true
       registry_login: ghcr
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   # ISO matrix is split into two jobs so qemu-tests-* start as soon
@@ -174,6 +189,7 @@ jobs:
       single_efi_cmdline: 'testentry: nothing'
       release: false
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   build-iso-arm:
@@ -233,6 +249,7 @@ jobs:
       cleanup: ${{ startsWith(matrix.model, 'nvidia-jetson') }}
       release: false
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   # QEMU test suites. Matrix at THIS level (caller side) calling
@@ -271,6 +288,7 @@ jobs:
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       release-matcher: ${{ matrix.release-matcher || '' }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   qemu-tests-standard:
@@ -295,6 +313,7 @@ jobs:
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       release-matcher: ${{ matrix.release-matcher || '' }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   # encryption-* tests spin up a k3s cluster with a kcrypt-challenger
@@ -324,6 +343,7 @@ jobs:
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       kcrypt_challenger_image: ghcr.io/kairos-io/kairos/kcrypt-challenger:pr-${{ github.event.pull_request.number }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit
 
   # UKI qemu tests. `generic` needs the standard (k3s) UKI ISO plus a
@@ -348,4 +368,5 @@ jobs:
       model: 'generic'
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
     secrets: inherit

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -49,6 +49,21 @@ on:
         required: false
         type: string
         default: ''
+      caller-vetted-ref:
+        description: |
+          Caller assertion required to unlock actions/checkout's
+          `allow-unsafe-pr-checkout` opt-in. Set to `true` ONLY if
+          the caller has its own authorization gate in front of
+          this workflow -- e.g. a `pull_request_target` pipeline
+          whose `authorize` job pins the run to a GitHub
+          Environment that requires maintainer review before the
+          fork's `ref` is fetched. Without such a gate, leaving
+          this false keeps the `pull_request_target` + fork-ref
+          combination blocked at checkout time (the guard
+          described at https://gh.io/securely-using-pull_request_target).
+        required: false
+        type: boolean
+        default: false
       container_image_prefix:
         description: |
           Registry path (registry/namespace/repo, no tag) where the Kairos
@@ -147,14 +162,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
-          # actions/checkout refuses to fetch a non-default ref inside a
-          # pull_request_target workflow otherwise -- the exact "pwn request"
-          # guard https://gh.io/securely-using-pull_request_target describes.
-          # Same fix, same reasoning, as kairos-io/kairos-factory-action#60:
-          # `ref`'s own doc above already says the caller carries the risk.
-          # A caller that leaves `ref` empty (every ordinary caller) is
-          # unaffected.
-          allow-unsafe-pr-checkout: ${{ inputs.ref != '' }}
+          allow-unsafe-pr-checkout: ${{ inputs.caller-vetted-ref }}
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         timeout-minutes: 5


### PR DESCRIPTION
actions/checkout now refuses to fetch a fork PR's head ref from a `pull_request_target` workflow unless `allow-unsafe-pr-checkout` is set explicitly (see https://gh.io/securely-using-pull_request_target). Every reusable this pipeline calls with `ref: refs/pull/<n>/head` was tripping that guard.

Rather than hardcode the opt-in inside each reusable -- which would make every future caller unsafe-by-default -- add an explicit `caller-vetted-ref` boolean input (default false) to every internal reusable this workflow calls, thread it into actions/checkout, and have pr.yaml assert `caller-vetted-ref: true` at every call site. The assertion is honest here only because the `authorize` job pins every fork PR to the fork-pr-builds GitHub Environment for maintainer review before any downstream job's ref is fetched; the header comment in pr.yaml spells this out so a future editor cannot drop authorize without also dropping the assertions.

Affects:
- _lint.yaml: bump kairos-io/linting-composite-action pin to v0.0.11 (the release that ships the caller-vetted-ref input) and pass through.
- _build-iso.yaml: bump kairos-io/kairos-factory-action pin to v1.5.0 (same input, plus a legacy `ref != ''` fallback for external callers) and pass through.
- _unit-tests.yaml, _build-kairos.yaml, _build-kcrypt-challenger.yaml, _build-kairos-init.yaml, _build-image-kairos-init.yaml, _build-image-kcrypt-challenger.yaml, _uki-test.yaml: add the input, thread to allow-unsafe-pr-checkout.
- reusable-qemu-test.yaml: replace the transitional `${{ inputs.ref != '' }}` shortcut with the explicit input, matching every sibling reusable.
- pr.yaml: set caller-vetted-ref: true on every reusable call.

master.yaml and release.yaml are unchanged: their `push` / `release` triggers do not fire the guard.