### PR TITLE
ci: add qemu-tests-core-fips coverage

### DIFF
--- a/.github/workflows/_build-iso.yaml
+++ b/.github/workflows/_build-iso.yaml
@@ -172,6 +172,7 @@ permissions:
 
 jobs:
   iso:
+    name: ${{ inputs.name }}
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@1e6159c7e150b3ea63fdded7349be7db1f33066f  # v1.5.0
     secrets:
       # ghcr.io accepts github.actor + GITHUB_TOKEN; the token is

--- a/.github/workflows/_build-iso.yaml
+++ b/.github/workflows/_build-iso.yaml
@@ -105,6 +105,18 @@ on:
         type: boolean
         default: false
 
+      fips:
+        description: |
+          Build the FIPS-flavored image. Passes FIPS=fips to
+          images/Dockerfile so kairos-init installs the FIPS variant of
+          the multi-call kairos binary. Caller must also point base_image
+          at a FIPS-hardened base (e.g. ghcr.io/kairos-io/hadron-fips)
+          for the resulting image to be end-to-end FIPS-capable; passing
+          this flag alone against a non-FIPS base produces a partial-FIPS
+          image and defeats the point.
+        type: boolean
+        default: false
+
       single_efi_cmdline:
         description: |
           Bake an extra single-EFI boot entry into the UKI, in
@@ -178,7 +190,11 @@ jobs:
       # Point images/Dockerfile at the caller-supplied kairos-init.
       # This is what makes PRs / releases exercise the freshly-built
       # kairos-init rather than the ARG default in images/Dockerfile.
-      build_args: KAIROS_INIT_IMAGE=${{ inputs.kairos_init_image }}
+      # When `fips` is true the FIPS=fips build_arg switches
+      # kairos-init to embed the FIPS variant of the multi-call binary.
+      build_args: |
+        KAIROS_INIT_IMAGE=${{ inputs.kairos_init_image }}
+        ${{ inputs.fips && 'FIPS=fips' || '' }}
       base_image: ${{ inputs.base_image }}
       arch: ${{ inputs.arch }}
       model: ${{ inputs.model }}

--- a/.github/workflows/_build-iso.yaml
+++ b/.github/workflows/_build-iso.yaml
@@ -172,7 +172,11 @@ permissions:
 
 jobs:
   iso:
-    name: ${{ inputs.name }}
+    # No `name:` override here on purpose: the caller's matrix job
+    # already includes ${{ matrix.name }} in its own name, so any
+    # override here would repeat it in the check-run identifier.
+    # Defaults to the job_id `iso`, which becomes the middle segment
+    # you see in check names like `build-iso / amd64-core / iso / ...`.
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@1e6159c7e150b3ea63fdded7349be7db1f33066f  # v1.5.0
     secrets:
       # ghcr.io accepts github.actor + GITHUB_TOKEN; the token is

--- a/.github/workflows/_build-iso.yaml
+++ b/.github/workflows/_build-iso.yaml
@@ -172,11 +172,6 @@ permissions:
 
 jobs:
   iso:
-    # No `name:` override here on purpose: the caller's matrix job
-    # already includes ${{ matrix.name }} in its own name, so any
-    # override here would repeat it in the check-run identifier.
-    # Defaults to the job_id `iso`, which becomes the middle segment
-    # you see in check names like `build-iso / amd64-core / iso / ...`.
     uses: kairos-io/kairos-factory-action/.github/workflows/reusable-factory.yaml@1e6159c7e150b3ea63fdded7349be7db1f33066f  # v1.5.0
     secrets:
       # ghcr.io accepts github.actor + GITHUB_TOKEN; the token is

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -129,7 +129,6 @@ jobs:
           # UKI cells feed qemu-tests-uki (see pr.yaml for the shape).
           - {name: 'amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
           - {name: 'amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
-    # See build-iso in pr.yaml for why this override exists.
     name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
@@ -178,7 +177,6 @@ jobs:
             registry_domain: 'quay.io'
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
-    # See build-iso in pr.yaml for why this override exists.
     name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
@@ -217,7 +215,6 @@ jobs:
           - {test: 'bundles'}
           - {test: 'ssh-hardening'}
           - {test: 'upgrade-latest-with-cli', release-matcher: 'kairos-hadron-*-core-amd64-generic-v*.iso'}
-    # See build-iso in pr.yaml for why this override exists.
     name: test-core / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -240,7 +237,6 @@ jobs:
         include:
           - {test: 'install'}
           - {test: 'acceptance'}
-    # See build-iso in pr.yaml for why this override exists.
     name: test-core-fips / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -264,7 +260,6 @@ jobs:
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
           - {test: 'provider-upgrade-latest-k8s-with-kubernetes', release-matcher: 'kairos-hadron-*-standard-amd64-generic-*k3sv*.iso'}
-    # See build-iso in pr.yaml for why this override exists.
     name: test-standard / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -296,7 +291,6 @@ jobs:
           - {test: 'encryption-remote-ek-reenroll'}
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
-    # See build-iso in pr.yaml for why this override exists.
     name: test-standard-encryption / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -318,7 +312,6 @@ jobs:
         include:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
-    # See build-iso in pr.yaml for why this override exists.
     name: test-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -130,7 +130,7 @@ jobs:
           - {name: 'amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
           - {name: 'amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
     # See build-iso in pr.yaml for why this override exists.
-    name: build-iso
+    name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -179,7 +179,7 @@ jobs:
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
     # See build-iso in pr.yaml for why this override exists.
-    name: build-iso-arm
+    name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -218,7 +218,7 @@ jobs:
           - {test: 'ssh-hardening'}
           - {test: 'upgrade-latest-with-cli', release-matcher: 'kairos-hadron-*-core-amd64-generic-v*.iso'}
     # See build-iso in pr.yaml for why this override exists.
-    name: test-core
+    name: test-core / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -241,7 +241,7 @@ jobs:
           - {test: 'install'}
           - {test: 'acceptance'}
     # See build-iso in pr.yaml for why this override exists.
-    name: test-core-fips
+    name: test-core-fips / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -265,7 +265,7 @@ jobs:
           - {test: 'provider-k3s-disabled'}
           - {test: 'provider-upgrade-latest-k8s-with-kubernetes', release-matcher: 'kairos-hadron-*-standard-amd64-generic-*k3sv*.iso'}
     # See build-iso in pr.yaml for why this override exists.
-    name: test-standard
+    name: test-standard / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -297,7 +297,7 @@ jobs:
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
     # See build-iso in pr.yaml for why this override exists.
-    name: test-standard-encryption
+    name: test-standard-encryption / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -319,7 +319,7 @@ jobs:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
     # See build-iso in pr.yaml for why this override exists.
-    name: test-uki
+    name: test-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -129,6 +129,8 @@ jobs:
           # UKI cells feed qemu-tests-uki (see pr.yaml for the shape).
           - {name: 'master-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
           - {name: 'master-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
+    # See build-iso in pr.yaml for why this override exists.
+    name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -176,6 +178,8 @@ jobs:
             registry_domain: 'quay.io'
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
+    # See build-iso in pr.yaml for why this override exists.
+    name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -213,6 +217,8 @@ jobs:
           - {test: 'bundles'}
           - {test: 'ssh-hardening'}
           - {test: 'upgrade-latest-with-cli', release-matcher: 'kairos-hadron-*-core-amd64-generic-v*.iso'}
+    # See build-iso in pr.yaml for why this override exists.
+    name: qemu-tests-core / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -234,6 +240,8 @@ jobs:
         include:
           - {test: 'install'}
           - {test: 'acceptance'}
+    # See build-iso in pr.yaml for why this override exists.
+    name: qemu-tests-core-fips / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -256,6 +264,8 @@ jobs:
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
           - {test: 'provider-upgrade-latest-k8s-with-kubernetes', release-matcher: 'kairos-hadron-*-standard-amd64-generic-*k3sv*.iso'}
+    # See build-iso in pr.yaml for why this override exists.
+    name: qemu-tests-standard / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -286,6 +296,8 @@ jobs:
           - {test: 'encryption-remote-ek-reenroll'}
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
+    # See build-iso in pr.yaml for why this override exists.
+    name: qemu-tests-standard-encryption / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -306,6 +318,8 @@ jobs:
         include:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
+    # See build-iso in pr.yaml for why this override exists.
+    name: qemu-tests-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -130,7 +130,7 @@ jobs:
           - {name: 'master-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
           - {name: 'master-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
     # See build-iso in pr.yaml for why this override exists.
-    name: build-iso / ${{ matrix.name }}
+    name: build-iso
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -179,7 +179,7 @@ jobs:
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
     # See build-iso in pr.yaml for why this override exists.
-    name: build-iso-arm / ${{ matrix.name }}
+    name: build-iso-arm
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -218,7 +218,7 @@ jobs:
           - {test: 'ssh-hardening'}
           - {test: 'upgrade-latest-with-cli', release-matcher: 'kairos-hadron-*-core-amd64-generic-v*.iso'}
     # See build-iso in pr.yaml for why this override exists.
-    name: qemu-tests-core / ${{ matrix.test }}
+    name: test-core
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -241,7 +241,7 @@ jobs:
           - {test: 'install'}
           - {test: 'acceptance'}
     # See build-iso in pr.yaml for why this override exists.
-    name: qemu-tests-core-fips / ${{ matrix.test }}
+    name: test-core-fips
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -265,7 +265,7 @@ jobs:
           - {test: 'provider-k3s-disabled'}
           - {test: 'provider-upgrade-latest-k8s-with-kubernetes', release-matcher: 'kairos-hadron-*-standard-amd64-generic-*k3sv*.iso'}
     # See build-iso in pr.yaml for why this override exists.
-    name: qemu-tests-standard / ${{ matrix.test }}
+    name: test-standard
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -297,7 +297,7 @@ jobs:
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
     # See build-iso in pr.yaml for why this override exists.
-    name: qemu-tests-standard-encryption / ${{ matrix.test }}
+    name: test-standard-encryption
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -319,7 +319,7 @@ jobs:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
     # See build-iso in pr.yaml for why this override exists.
-    name: qemu-tests-uki / ${{ matrix.test }}
+    name: test-uki
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -122,11 +122,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: 'master-amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: ''}
-          - {name: 'master-amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s'}
+          - {name: 'master-amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
+          - {name: 'master-amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
+          # FIPS core cell (see pr.yaml for rationale).
+          - {name: 'master-amd64-core-fips', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: true}
           # UKI cells feed qemu-tests-uki (see pr.yaml for the shape).
-          - {name: 'master-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s'}
-          - {name: 'master-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: ''}
+          - {name: 'master-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
+          - {name: 'master-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -138,6 +140,7 @@ jobs:
       iso: ${{ matrix.iso }}
       trusted_boot: ${{ matrix.trusted_boot }}
       kubernetes_distro: ${{ matrix.kubernetes_distro }}
+      fips: ${{ matrix.fips }}
       registry_domain: 'ghcr.io'
       registry_namespace: 'kairos-io/kairos'
       single_efi_cmdline: 'testentry: nothing'
@@ -220,6 +223,26 @@ jobs:
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       release-matcher: ${{ matrix.release-matcher || '' }}
+    secrets: inherit
+
+  # FIPS smoke coverage (see pr.yaml for rationale).
+  qemu-tests-core-fips:
+    needs: build-iso
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {test: 'install'}
+          - {test: 'acceptance'}
+    uses: ./.github/workflows/reusable-qemu-test.yaml
+    with:
+      test: ${{ matrix.test }}
+      base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1'
+      variant: 'core'
+      arch: 'amd64'
+      model: 'generic'
+      secureboot: false
+      container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
     secrets: inherit
 
   qemu-tests-standard:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -122,13 +122,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: 'master-amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
-          - {name: 'master-amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
+          - {name: 'amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
+          - {name: 'amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
           # FIPS core cell (see pr.yaml for rationale).
-          - {name: 'master-amd64-core-fips', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: true}
+          - {name: 'amd64-core-fips', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: true}
           # UKI cells feed qemu-tests-uki (see pr.yaml for the shape).
-          - {name: 'master-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
-          - {name: 'master-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
+          - {name: 'amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
+          - {name: 'amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
     # See build-iso in pr.yaml for why this override exists.
     name: build-iso
     uses: ./.github/workflows/_build-iso.yaml
@@ -155,10 +155,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: 'master-arm64-core', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: ''}
-          - {name: 'master-arm64-rpi3', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi3', iso: false, trusted_boot: false, kubernetes_distro: ''}
-          - {name: 'master-arm64-rpi4', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi4', iso: false, trusted_boot: false, kubernetes_distro: ''}
-          - name: 'master-arm64-nvidia-agx-orin'
+          - {name: 'arm64-core', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: ''}
+          - {name: 'arm64-rpi3', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi3', iso: false, trusted_boot: false, kubernetes_distro: ''}
+          - {name: 'arm64-rpi4', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi4', iso: false, trusted_boot: false, kubernetes_distro: ''}
+          - name: 'arm64-nvidia-agx-orin'
             arch: 'arm64'
             base_image: 'ubuntu:22.04'
             model: 'nvidia-jetson-agx-orin'
@@ -168,7 +168,7 @@ jobs:
             registry_domain: 'quay.io'
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
-          - name: 'master-arm64-nvidia-orin-nx'
+          - name: 'arm64-nvidia-orin-nx'
             arch: 'arm64'
             base_image: 'ubuntu:22.04'
             model: 'nvidia-jetson-orin-nx'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -192,14 +192,6 @@ jobs:
           # in _build-iso.yaml's custom formats.
           - {name: 'amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
           - {name: 'amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
-    # Explicit name overrides the auto-generated
-    # `build-iso (<every matrix value in parens>)` GitHub Actions
-    # produces by default. Without this, adding or renaming any
-    # matrix key silently changes every existing job's check-run
-    # identifier, which orphans every branch-protection required
-    # check that referenced the old identifier. Deriving the check
-    # name from matrix.name alone keeps it stable across future
-    # matrix edits.
     name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
@@ -263,7 +255,6 @@ jobs:
             registry_domain: 'quay.io'
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
-    # See build-iso above for why this override exists.
     name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
@@ -314,7 +305,6 @@ jobs:
           - {test: 'bundles'}
           - {test: 'ssh-hardening'}
           - {test: 'upgrade-latest-with-cli', release-matcher: 'kairos-hadron-*-core-amd64-generic-v*.iso'}
-    # See build-iso above for why this override exists.
     name: test-core / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -344,7 +334,6 @@ jobs:
         include:
           - {test: 'install'}
           - {test: 'acceptance'}
-    # See build-iso above for why this override exists.
     name: test-core-fips / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -370,7 +359,6 @@ jobs:
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
           - {test: 'provider-upgrade-latest-k8s-with-kubernetes', release-matcher: 'kairos-hadron-*-standard-amd64-generic-*k3sv*.iso'}
-    # See build-iso above for why this override exists.
     name: test-standard / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -407,7 +395,6 @@ jobs:
           - {test: 'encryption-remote-ek-reenroll'}
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
-    # See build-iso above for why this override exists.
     name: test-standard-encryption / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -436,7 +423,6 @@ jobs:
         include:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
-    # See build-iso above for why this override exists.
     name: test-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -192,6 +192,15 @@ jobs:
           # in _build-iso.yaml's custom formats.
           - {name: 'pr-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
           - {name: 'pr-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
+    # Explicit name overrides the auto-generated
+    # `build-iso (<every matrix value in parens>)` GitHub Actions
+    # produces by default. Without this, adding or renaming any
+    # matrix key silently changes every existing job's check-run
+    # identifier, which orphans every branch-protection required
+    # check that referenced the old identifier. Deriving the check
+    # name from matrix.name alone keeps it stable across future
+    # matrix edits.
+    name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -254,6 +263,8 @@ jobs:
             registry_domain: 'quay.io'
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
+    # See build-iso above for why this override exists.
+    name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -303,6 +314,8 @@ jobs:
           - {test: 'bundles'}
           - {test: 'ssh-hardening'}
           - {test: 'upgrade-latest-with-cli', release-matcher: 'kairos-hadron-*-core-amd64-generic-v*.iso'}
+    # See build-iso above for why this override exists.
+    name: qemu-tests-core / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -331,6 +344,8 @@ jobs:
         include:
           - {test: 'install'}
           - {test: 'acceptance'}
+    # See build-iso above for why this override exists.
+    name: qemu-tests-core-fips / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -355,6 +370,8 @@ jobs:
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
           - {test: 'provider-upgrade-latest-k8s-with-kubernetes', release-matcher: 'kairos-hadron-*-standard-amd64-generic-*k3sv*.iso'}
+    # See build-iso above for why this override exists.
+    name: qemu-tests-standard / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -390,6 +407,8 @@ jobs:
           - {test: 'encryption-remote-ek-reenroll'}
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
+    # See build-iso above for why this override exists.
+    name: qemu-tests-standard-encryption / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -417,6 +436,8 @@ jobs:
         include:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
+    # See build-iso above for why this override exists.
+    name: qemu-tests-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -177,21 +177,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: 'pr-amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
-          - {name: 'pr-amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
+          - {name: 'amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
+          - {name: 'amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
           # FIPS core cell. hadron-fips is a distinct base image from
           # hadron (FIPS-hardened kernel + userspace); passing fips:true
           # additionally flips the FIPS=fips build_arg in images/Dockerfile
           # so kairos-init installs the FIPS variant of the multi-call
           # kairos binary. Both switches are required for an
           # end-to-end FIPS image; either alone is a footgun.
-          - {name: 'pr-amd64-core-fips', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: true}
+          - {name: 'amd64-core-fips', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: true}
           # UKI cells feed qemu-tests-uki. hadron-trusted is a distinct
           # base image from hadron (extra tpm/measured-boot bits); the
           # -uki suffix on the artifact/tag comes from the $UKI token
           # in _build-iso.yaml's custom formats.
-          - {name: 'pr-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
-          - {name: 'pr-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
+          - {name: 'amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
+          - {name: 'amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
     # Explicit name overrides the auto-generated
     # `build-iso (<every matrix value in parens>)` GitHub Actions
     # produces by default. Without this, adding or renaming any
@@ -231,10 +231,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: 'pr-arm64-core', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: ''}
+          - {name: 'arm64-core', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: ''}
           # rpi cells: raw disk image, no ISO. Still on hadron base.
-          - {name: 'pr-arm64-rpi3', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi3', iso: false, trusted_boot: false, kubernetes_distro: ''}
-          - {name: 'pr-arm64-rpi4', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi4', iso: false, trusted_boot: false, kubernetes_distro: ''}
+          - {name: 'arm64-rpi3', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi3', iso: false, trusted_boot: false, kubernetes_distro: ''}
+          - {name: 'arm64-rpi4', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi4', iso: false, trusted_boot: false, kubernetes_distro: ''}
           # NVIDIA Jetson cells. base_image=ubuntu:22.04 -- L4T rootfs
           # only builds on that. Model-derived knobs (grype/sbom/
           # cleanup) turn off scans and enable disk cleanup; see
@@ -243,7 +243,7 @@ jobs:
           # ghcr.io/kairos-io/kairos/ubuntu package does not exist yet
           # and needs the same seed dance hadron got; ci-temp-images
           # is already public and existing.
-          - name: 'pr-arm64-nvidia-agx-orin'
+          - name: 'arm64-nvidia-agx-orin'
             arch: 'arm64'
             base_image: 'ubuntu:22.04'
             model: 'nvidia-jetson-agx-orin'
@@ -253,7 +253,7 @@ jobs:
             registry_domain: 'quay.io'
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
-          - name: 'pr-arm64-nvidia-orin-nx'
+          - name: 'arm64-nvidia-orin-nx'
             arch: 'arm64'
             base_image: 'ubuntu:22.04'
             model: 'nvidia-jetson-orin-nx'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -200,7 +200,7 @@ jobs:
     # check that referenced the old identifier. Deriving the check
     # name from matrix.name alone keeps it stable across future
     # matrix edits.
-    name: build-iso / ${{ matrix.name }}
+    name: build-iso
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -264,7 +264,7 @@ jobs:
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
     # See build-iso above for why this override exists.
-    name: build-iso-arm / ${{ matrix.name }}
+    name: build-iso-arm
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -315,7 +315,7 @@ jobs:
           - {test: 'ssh-hardening'}
           - {test: 'upgrade-latest-with-cli', release-matcher: 'kairos-hadron-*-core-amd64-generic-v*.iso'}
     # See build-iso above for why this override exists.
-    name: qemu-tests-core / ${{ matrix.test }}
+    name: test-core
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -345,7 +345,7 @@ jobs:
           - {test: 'install'}
           - {test: 'acceptance'}
     # See build-iso above for why this override exists.
-    name: qemu-tests-core-fips / ${{ matrix.test }}
+    name: test-core-fips
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -371,7 +371,7 @@ jobs:
           - {test: 'provider-k3s-disabled'}
           - {test: 'provider-upgrade-latest-k8s-with-kubernetes', release-matcher: 'kairos-hadron-*-standard-amd64-generic-*k3sv*.iso'}
     # See build-iso above for why this override exists.
-    name: qemu-tests-standard / ${{ matrix.test }}
+    name: test-standard
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -408,7 +408,7 @@ jobs:
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
     # See build-iso above for why this override exists.
-    name: qemu-tests-standard-encryption / ${{ matrix.test }}
+    name: test-standard-encryption
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -437,7 +437,7 @@ jobs:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
     # See build-iso above for why this override exists.
-    name: qemu-tests-uki / ${{ matrix.test }}
+    name: test-uki
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -177,14 +177,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: 'pr-amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: ''}
-          - {name: 'pr-amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s'}
+          - {name: 'pr-amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
+          - {name: 'pr-amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
+          # FIPS core cell. hadron-fips is a distinct base image from
+          # hadron (FIPS-hardened kernel + userspace); passing fips:true
+          # additionally flips the FIPS=fips build_arg in images/Dockerfile
+          # so kairos-init installs the FIPS variant of the multi-call
+          # kairos binary. Both switches are required for an
+          # end-to-end FIPS image; either alone is a footgun.
+          - {name: 'pr-amd64-core-fips', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: true}
           # UKI cells feed qemu-tests-uki. hadron-trusted is a distinct
           # base image from hadron (extra tpm/measured-boot bits); the
           # -uki suffix on the artifact/tag comes from the $UKI token
           # in _build-iso.yaml's custom formats.
-          - {name: 'pr-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s'}
-          - {name: 'pr-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: ''}
+          - {name: 'pr-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
+          - {name: 'pr-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -195,6 +202,7 @@ jobs:
       iso: ${{ matrix.iso }}
       trusted_boot: ${{ matrix.trusted_boot }}
       kubernetes_distro: ${{ matrix.kubernetes_distro }}
+      fips: ${{ matrix.fips }}
       # All cells here are hadron/ghcr; nvidia + ubuntu-based ones
       # live in build-iso-arm below and override the registry there.
       registry_domain: 'ghcr.io'
@@ -305,6 +313,33 @@ jobs:
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       release-matcher: ${{ matrix.release-matcher || '' }}
+      ref: refs/pull/${{ github.event.pull_request.number }}/head
+      caller-vetted-ref: true
+    secrets: inherit
+
+  # FIPS smoke coverage. install + acceptance is the cheapest signal
+  # that the FIPS variant of the multi-call kairos binary boots and
+  # cloud-config installs land the way the default variant does; a
+  # deeper matrix here would double a slow build for no extra signal.
+  # Consumes pr-amd64-core-fips's ISO artifact (base_image = hadron-fips,
+  # variant computed as core because kubernetes_distro is empty).
+  qemu-tests-core-fips:
+    needs: build-iso
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {test: 'install'}
+          - {test: 'acceptance'}
+    uses: ./.github/workflows/reusable-qemu-test.yaml
+    with:
+      test: ${{ matrix.test }}
+      base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1'
+      variant: 'core'
+      arch: 'amd64'
+      model: 'generic'
+      secureboot: false
+      container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       ref: refs/pull/${{ github.event.pull_request.number }}/head
       caller-vetted-ref: true
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -200,7 +200,7 @@ jobs:
     # check that referenced the old identifier. Deriving the check
     # name from matrix.name alone keeps it stable across future
     # matrix edits.
-    name: build-iso
+    name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -264,7 +264,7 @@ jobs:
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
     # See build-iso above for why this override exists.
-    name: build-iso-arm
+    name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -315,7 +315,7 @@ jobs:
           - {test: 'ssh-hardening'}
           - {test: 'upgrade-latest-with-cli', release-matcher: 'kairos-hadron-*-core-amd64-generic-v*.iso'}
     # See build-iso above for why this override exists.
-    name: test-core
+    name: test-core / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -345,7 +345,7 @@ jobs:
           - {test: 'install'}
           - {test: 'acceptance'}
     # See build-iso above for why this override exists.
-    name: test-core-fips
+    name: test-core-fips / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -371,7 +371,7 @@ jobs:
           - {test: 'provider-k3s-disabled'}
           - {test: 'provider-upgrade-latest-k8s-with-kubernetes', release-matcher: 'kairos-hadron-*-standard-amd64-generic-*k3sv*.iso'}
     # See build-iso above for why this override exists.
-    name: test-standard
+    name: test-standard / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -408,7 +408,7 @@ jobs:
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
     # See build-iso above for why this override exists.
-    name: test-standard-encryption
+    name: test-standard-encryption / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -437,7 +437,7 @@ jobs:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
     # See build-iso above for why this override exists.
-    name: test-uki
+    name: test-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -182,6 +182,8 @@ jobs:
           # bootable UKI-iso even with trusted_boot=true.
           - {name: 'release-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
           - {name: 'release-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
+    # See build-iso in pr.yaml for why this override exists.
+    name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -228,6 +230,8 @@ jobs:
             registry_domain: 'quay.io'
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
+    # See build-iso in pr.yaml for why this override exists.
+    name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -322,6 +326,8 @@ jobs:
           - {test: 'upgrade-with-cli'}
           - {test: 'bundles'}
           - {test: 'ssh-hardening'}
+    # See build-iso in pr.yaml for why this override exists.
+    name: qemu-tests-core / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -342,6 +348,8 @@ jobs:
         include:
           - {test: 'install'}
           - {test: 'acceptance'}
+    # See build-iso in pr.yaml for why this override exists.
+    name: qemu-tests-core-fips / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -363,6 +371,8 @@ jobs:
           - {test: 'provider-upgrade-k8s'}
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
+    # See build-iso in pr.yaml for why this override exists.
+    name: qemu-tests-standard / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -392,6 +402,8 @@ jobs:
           - {test: 'encryption-remote-ek-reenroll'}
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
+    # See build-iso in pr.yaml for why this override exists.
+    name: qemu-tests-standard-encryption / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -412,6 +424,8 @@ jobs:
         include:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
+    # See build-iso in pr.yaml for why this override exists.
+    name: qemu-tests-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,16 +172,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: 'release-amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
-          - {name: 'release-amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
+          - {name: 'amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
+          - {name: 'amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
           # FIPS core cell (see pr.yaml for rationale).
-          - {name: 'release-amd64-core-fips', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: true}
+          - {name: 'amd64-core-fips', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: true}
           # UKI cells feed qemu-tests-uki (see pr.yaml for the shape).
           # hadron-trusted is a distinct base image from hadron; both UKI
           # cells set iso:true because factory-action still produces the
           # bootable UKI-iso even with trusted_boot=true.
-          - {name: 'release-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
-          - {name: 'release-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
+          - {name: 'amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
+          - {name: 'amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
     # See build-iso in pr.yaml for why this override exists.
     name: build-iso
     uses: ./.github/workflows/_build-iso.yaml
@@ -207,10 +207,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: 'release-arm64-core', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: ''}
-          - {name: 'release-arm64-rpi3', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi3', iso: false, trusted_boot: false, kubernetes_distro: ''}
-          - {name: 'release-arm64-rpi4', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi4', iso: false, trusted_boot: false, kubernetes_distro: ''}
-          - name: 'release-arm64-nvidia-agx-orin'
+          - {name: 'arm64-core', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: ''}
+          - {name: 'arm64-rpi3', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi3', iso: false, trusted_boot: false, kubernetes_distro: ''}
+          - {name: 'arm64-rpi4', arch: 'arm64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'rpi4', iso: false, trusted_boot: false, kubernetes_distro: ''}
+          - name: 'arm64-nvidia-agx-orin'
             arch: 'arm64'
             base_image: 'ubuntu:22.04'
             model: 'nvidia-jetson-agx-orin'
@@ -220,7 +220,7 @@ jobs:
             registry_domain: 'quay.io'
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
-          - name: 'release-arm64-nvidia-orin-nx'
+          - name: 'arm64-nvidia-orin-nx'
             arch: 'arm64'
             base_image: 'ubuntu:22.04'
             model: 'nvidia-jetson-orin-nx'
@@ -267,7 +267,7 @@ jobs:
         kubernetes_version: ${{ fromJson(needs.get-k3s-versions.outputs.kubernetes_versions) }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
-      name: 'release-amd64-standard-k3s-${{ matrix.kubernetes_version }}'
+      name: 'amd64-standard-k3s-${{ matrix.kubernetes_version }}'
       kairos_init_image: quay.io/kairos/kairos-init:${{ github.ref_name }}-scratch
       arch: 'amd64'
       base_image: 'ghcr.io/kairos-io/hadron:v0.5.1'
@@ -289,7 +289,7 @@ jobs:
         kubernetes_version: ${{ fromJson(needs.get-k0s-versions.outputs.kubernetes_versions) }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
-      name: 'release-amd64-standard-k0s-${{ matrix.kubernetes_version }}'
+      name: 'amd64-standard-k0s-${{ matrix.kubernetes_version }}'
       kairos_init_image: quay.io/kairos/kairos-init:${{ github.ref_name }}-scratch
       arch: 'amd64'
       base_image: 'ghcr.io/kairos-io/hadron:v0.5.1'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,14 +172,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {name: 'release-amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: ''}
-          - {name: 'release-amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s'}
+          - {name: 'release-amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
+          - {name: 'release-amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
+          # FIPS core cell (see pr.yaml for rationale).
+          - {name: 'release-amd64-core-fips', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: true}
           # UKI cells feed qemu-tests-uki (see pr.yaml for the shape).
           # hadron-trusted is a distinct base image from hadron; both UKI
           # cells set iso:true because factory-action still produces the
           # bootable UKI-iso even with trusted_boot=true.
-          - {name: 'release-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s'}
-          - {name: 'release-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: ''}
+          - {name: 'release-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
+          - {name: 'release-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -191,6 +193,7 @@ jobs:
       iso: ${{ matrix.iso }}
       trusted_boot: ${{ matrix.trusted_boot }}
       kubernetes_distro: ${{ matrix.kubernetes_distro }}
+      fips: ${{ matrix.fips }}
       registry_domain: 'quay.io'
       registry_namespace: 'kairos'
       release: true
@@ -323,6 +326,26 @@ jobs:
     with:
       test: ${{ matrix.test }}
       base_image: 'ghcr.io/kairos-io/hadron:v0.5.1'
+      variant: 'core'
+      arch: 'amd64'
+      model: 'generic'
+      secureboot: false
+      container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+    secrets: inherit
+
+  # FIPS smoke coverage (see pr.yaml for rationale).
+  qemu-tests-core-fips:
+    needs: build-iso
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {test: 'install'}
+          - {test: 'acceptance'}
+    uses: ./.github/workflows/reusable-qemu-test.yaml
+    with:
+      test: ${{ matrix.test }}
+      base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1'
       variant: 'core'
       arch: 'amd64'
       model: 'generic'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,7 +183,7 @@ jobs:
           - {name: 'release-amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
           - {name: 'release-amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
     # See build-iso in pr.yaml for why this override exists.
-    name: build-iso / ${{ matrix.name }}
+    name: build-iso
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -231,7 +231,7 @@ jobs:
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
     # See build-iso in pr.yaml for why this override exists.
-    name: build-iso-arm / ${{ matrix.name }}
+    name: build-iso-arm
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -327,7 +327,7 @@ jobs:
           - {test: 'bundles'}
           - {test: 'ssh-hardening'}
     # See build-iso in pr.yaml for why this override exists.
-    name: qemu-tests-core / ${{ matrix.test }}
+    name: test-core
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -349,7 +349,7 @@ jobs:
           - {test: 'install'}
           - {test: 'acceptance'}
     # See build-iso in pr.yaml for why this override exists.
-    name: qemu-tests-core-fips / ${{ matrix.test }}
+    name: test-core-fips
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -372,7 +372,7 @@ jobs:
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
     # See build-iso in pr.yaml for why this override exists.
-    name: qemu-tests-standard / ${{ matrix.test }}
+    name: test-standard
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -403,7 +403,7 @@ jobs:
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
     # See build-iso in pr.yaml for why this override exists.
-    name: qemu-tests-standard-encryption / ${{ matrix.test }}
+    name: test-standard-encryption
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -425,7 +425,7 @@ jobs:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
     # See build-iso in pr.yaml for why this override exists.
-    name: qemu-tests-uki / ${{ matrix.test }}
+    name: test-uki
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -182,7 +182,6 @@ jobs:
           # bootable UKI-iso even with trusted_boot=true.
           - {name: 'amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
           - {name: 'amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
-    # See build-iso in pr.yaml for why this override exists.
     name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
@@ -230,7 +229,6 @@ jobs:
             registry_domain: 'quay.io'
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
-    # See build-iso in pr.yaml for why this override exists.
     name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
@@ -326,7 +324,6 @@ jobs:
           - {test: 'upgrade-with-cli'}
           - {test: 'bundles'}
           - {test: 'ssh-hardening'}
-    # See build-iso in pr.yaml for why this override exists.
     name: test-core / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -348,7 +345,6 @@ jobs:
         include:
           - {test: 'install'}
           - {test: 'acceptance'}
-    # See build-iso in pr.yaml for why this override exists.
     name: test-core-fips / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -371,7 +367,6 @@ jobs:
           - {test: 'provider-upgrade-k8s'}
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
-    # See build-iso in pr.yaml for why this override exists.
     name: test-standard / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -402,7 +397,6 @@ jobs:
           - {test: 'encryption-remote-ek-reenroll'}
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
-    # See build-iso in pr.yaml for why this override exists.
     name: test-standard-encryption / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
@@ -424,7 +418,6 @@ jobs:
         include:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
-    # See build-iso in pr.yaml for why this override exists.
     name: test-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,7 +183,7 @@ jobs:
           - {name: 'amd64-standard-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: 'k3s', fips: false}
           - {name: 'amd64-core-uki', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1', model: 'generic', iso: true, trusted_boot: true, kubernetes_distro: '', fips: false}
     # See build-iso in pr.yaml for why this override exists.
-    name: build-iso
+    name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -231,7 +231,7 @@ jobs:
             registry_namespace: 'kairos'
             registry_repository: 'ci-temp-images'
     # See build-iso in pr.yaml for why this override exists.
-    name: build-iso-arm
+    name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
     with:
       name: ${{ matrix.name }}
@@ -327,7 +327,7 @@ jobs:
           - {test: 'bundles'}
           - {test: 'ssh-hardening'}
     # See build-iso in pr.yaml for why this override exists.
-    name: test-core
+    name: test-core / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -349,7 +349,7 @@ jobs:
           - {test: 'install'}
           - {test: 'acceptance'}
     # See build-iso in pr.yaml for why this override exists.
-    name: test-core-fips
+    name: test-core-fips / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -372,7 +372,7 @@ jobs:
           - {test: 'provider-decentralized-k8s'}
           - {test: 'provider-k3s-disabled'}
     # See build-iso in pr.yaml for why this override exists.
-    name: test-standard
+    name: test-standard / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -403,7 +403,7 @@ jobs:
           - {test: 'encryption-remote-mixed-modes'}
           - {test: 'encryption-kcrypt-cli'}
     # See build-iso in pr.yaml for why this override exists.
-    name: test-standard-encryption
+    name: test-standard-encryption / ${{ matrix.test }}
     uses: ./.github/workflows/reusable-qemu-test.yaml
     with:
       test: ${{ matrix.test }}
@@ -425,7 +425,7 @@ jobs:
           - {test: 'install-upgrade', variant: 'standard'}
           - {test: 'boot-assessment', variant: 'core'}
     # See build-iso in pr.yaml for why this override exists.
-    name: test-uki
+    name: test-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -109,6 +109,7 @@ on:
 jobs:
   test:  # decentralized k8s needs to run in github hosted workers for network stuff to work
     runs-on: ${{ inputs.test == 'provider-decentralized-k8s' && 'ubuntu-24.04' || 'fast' }}
+    name: ${{ inputs.test }}${{ inputs.secureboot == true && ' - SecureBoot' || '' }}
     steps:
       - name: Split base image
         id: split

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -109,14 +109,6 @@ on:
 jobs:
   test:  # decentralized k8s needs to run in github hosted workers for network stuff to work
     runs-on: ${{ inputs.test == 'provider-decentralized-k8s' && 'ubuntu-24.04' || 'fast' }}
-    # No `name:` override here on purpose: the caller's matrix job
-    # already includes the test label in its own name, so any override
-    # here would repeat it in the check-run identifier. Defaults to
-    # the job_id `test`, which is the trailing segment you see in
-    # check names like `test-core / acceptance / test`.
-    #
-    # SecureBoot was previously appended here; it is still identifiable
-    # from the workflow file (input value + test label).
     steps:
       - name: Split base image
         id: split

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -109,7 +109,14 @@ on:
 jobs:
   test:  # decentralized k8s needs to run in github hosted workers for network stuff to work
     runs-on: ${{ inputs.test == 'provider-decentralized-k8s' && 'ubuntu-24.04' || 'fast' }}
-    name: ${{ inputs.test }}${{ inputs.secureboot == true && ' - SecureBoot' || '' }}
+    # No `name:` override here on purpose: the caller's matrix job
+    # already includes the test label in its own name, so any override
+    # here would repeat it in the check-run identifier. Defaults to
+    # the job_id `test`, which is the trailing segment you see in
+    # check names like `test-core / acceptance / test`.
+    #
+    # SecureBoot was previously appended here; it is still identifiable
+    # from the workflow file (input value + test label).
     steps:
       - name: Split base image
         id: split


### PR DESCRIPTION
Today the qemu suites only exercise the default variant, so any regression in the FIPS install path would ship to release users silently. Adds the cheapest signal that closes the gap: a `qemu-tests-core-fips` matrix cell in pr.yaml, master.yaml, and release.yaml running `install` + `acceptance` against a FIPS ISO.

Two switches are needed for an end-to-end FIPS image, and both are now wired:

  * base_image: ghcr.io/kairos-io/hadron-fips:v0.5.1 (published by the hadron repo already) rather than the default hadron. This is a FIPS-hardened kernel + userspace.
  * FIPS=fips build arg into images/Dockerfile so kairos-init installs the FIPS variant of the multi-call kairos binary (the multi-call binary always embeds both variants in the kairos-init image; the build arg selects which one gets deployed).

Concretely:

  * _build-iso.yaml gains a `fips: boolean` input (default false). When true, appends `FIPS=fips` to build_args. Base image choice stays the caller's responsibility -- passing fips:true against a non-FIPS base produces a partial-FIPS image and defeats the point, so a comment on the input flags that footgun.
  * pr.yaml / master.yaml / release.yaml add one new build-iso cell (name suffix -fips, base_image hadron-fips, fips: true) and thread the fips input through the with: block. All existing cells get `fips: false` explicitly so the matrix stays uniform.
  * pr.yaml / master.yaml / release.yaml each get a new qemu-tests-core-fips job that consumes the fips ISO with `install` + `acceptance` labels. base_image on the qemu job is the same hadron-fips so reusable-qemu-test.yaml derives the matching flavor for the artifact download.

Not touched intentionally:
  * build-iso-arm: arm64 FIPS ISO smoke is a distinct scope.
  * qemu-tests-standard-*: standard variants add k8s + edgevpn + more labels; the ticket asks only for the cheapest install-path guard, which is the core variant. Deeper FIPS matrix belongs in a follow-up if it earns its runtime.

Refs kairos-io/kairos#4367 (item 24c).