### PR TITLE
fix(riscv64): symlink Debian/Ubuntu's monolithic grubriscv64.efi to the path AuroraBoot expects

### DIFF
--- a/kairos-init/pkg/stages/steps_init.go
+++ b/kairos-init/pkg/stages/steps_init.go
@@ -260,6 +260,23 @@ func GetWorkaroundsStage(_ values.System, l logger.KairosLogger) []schema.Stage 
 			},
 		},
 		{
+			// Debian/Ubuntu's grub-efi-riscv64-bin ships its prebuilt EFI
+			// binary under a "monolithic" subdirectory, unlike every other
+			// arch's grub-efi package. AuroraBoot's riscv64 search list
+			// (getEfiGrubFilesForArch) looks for it one level up, at
+			// /usr/lib/grub/riscv64-efi/grubriscv64.efi -- without this link
+			// that search comes up empty inside the rootfs, and AuroraBoot
+			// falls back to whatever grubriscv64.efi happens to exist on the
+			// build host instead of the one this image actually installed.
+			Name:       "Link Debian/Ubuntu riscv64 grub EFI binary to the path AuroraBoot expects",
+			OnlyIfOs:   "Ubuntu.*|Debian.*",
+			OnlyIfArch: "riscv64",
+			If:         "test -f /usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi && ! test -e /usr/lib/grub/riscv64-efi/grubriscv64.efi",
+			Commands: []string{
+				"ln -s monolithic/grubriscv64.efi /usr/lib/grub/riscv64-efi/grubriscv64.efi",
+			},
+		},
+		{
 			Name:     "Fixup sudo perms",
 			OnlyIfOs: "Ubuntu.*|Debian.*",
 			Commands: []string{


### PR DESCRIPTION
## What's broken

Debian/Ubuntu's `grub-efi-riscv64-bin` package (added by [kairos-init#398](https://github.com/kairos-io/kairos-init/pull/398)) ships its prebuilt EFI binary under a `monolithic/` subdirectory:

```
/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi
```

AuroraBoot's riscv64 search list (`getEfiGrubFilesForArch` in `pkg/ops/iso.go`) looks one level up:

```go
"/usr/lib/grub/riscv64-efi/grubriscv64.efi",
```

No symlink bridges the two, so AuroraBoot's search of the rootfs comes up empty and it silently falls back to whatever `grubriscv64.efi` happens to exist on the *build host* instead of the one this image actually installed. Observed live building a Kairos Ubuntu 24.04 riscv64 image in [mauromorales/homelab](https://github.com/mauromorales/homelab): the build host's own file was the only reason the resulting ISO booted at all, which is not something to depend on.

## Fix

A new workaround stage, right next to the existing "Link grub-editenv to grub2-editenv" one it mirrors: check for the monolithic binary, symlink it to the path AuroraBoot expects, no-op if the link already exists. `OnlyIfOs: "Ubuntu.*|Debian.*"`, `OnlyIfArch: "riscv64"`.

This keeps riscv64 self-contained the same way amd64/arm64 already are -- the rootfs kairos-init builds carries its own bootloader, nothing borrowed from whatever happens to be on the machine running AuroraBoot.

## Verification

`gofmt -l` clean. `go build`/`go vet` on `./kairos-init/pkg/stages/...` with `GOARCH=riscv64` (the only arch this stage touches) hits an unrelated pre-existing failure in `pkg/bundled`'s embed pattern (`binaries/kairos` vs. the Makefile's `kairos-installer` output) -- same failure with or without this change, confirmed by reverting it and re-running. Structurally verified against the existing `schema.Stage` fields already used identically elsewhere in this same file.

Co-developed-by: Claude Sonnet 5 <noreply@anthropic.com>