### PR TITLE
ci: pull request jobs push to ci-temp-images with the scoped robot

### DIFF
--- a/.github/workflows/_build-iso.yaml
+++ b/.github/workflows/_build-iso.yaml
@@ -150,11 +150,26 @@ on:
         required: false
         default: false
 
-# No `secrets:` block on workflow_call: registry credentials are
-# derived from inputs.registry_domain inside the job (ghcr.io ->
-# github.actor + GITHUB_TOKEN, quay.io -> QUAY_USERNAME + QUAY_PASSWORD),
-# which only works when the caller uses `secrets: inherit` so this
-# reusable can see the org-level QUAY_* secrets.
+    # Registry credentials are derived from inputs.registry_domain
+    # inside the job: ghcr.io -> github.actor + GITHUB_TOKEN,
+    # quay.io -> these two.
+    #
+    # These are DECLARED rather than left to `secrets: inherit` so a
+    # caller can decide which quay account to hand over. `inherit`
+    # still satisfies a declared secret, so master.yaml and
+    # release.yaml keep working unchanged, while pr.yaml passes the
+    # scoped ci-temp-images robot instead of the production account.
+    secrets:
+      QUAY_USERNAME:
+        description: |
+          Registry user, used only when inputs.registry_domain is
+          quay.io. On the pull request path this must be the
+          ci-temp-images-scoped robot, never the account that
+          publishes permanent images.
+        required: false
+      QUAY_PASSWORD:
+        description: "Registry token matching QUAY_USERNAME."
+        required: false
 
 permissions:
   # packages: write is required for factory-action's push to ghcr:

--- a/.github/workflows/_uki-test.yaml
+++ b/.github/workflows/_uki-test.yaml
@@ -83,6 +83,20 @@ on:
         required: false
         default: false
 
+    # Declared rather than inherited, so the caller chooses the quay
+    # account. Only the install-upgrade cell logs in at all: it pushes
+    # the freshly built UKI upgrade image to ci-temp-images.
+    secrets:
+      QUAY_USERNAME:
+        description: |
+          Registry user with WRITE on quay.io/kairos/ci-temp-images.
+          On the pull request path this must be the scoped robot,
+          never the account that publishes permanent images.
+        required: false
+      QUAY_PASSWORD:
+        description: "Registry token matching QUAY_USERNAME."
+        required: false
+
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -260,7 +260,13 @@ jobs:
       release: false
       ref: refs/pull/${{ github.event.pull_request.number }}/head
       caller-vetted-ref: true
-    secrets: inherit
+    # ci-temp-images pushes on the pull request path use the
+    # scoped `kairos+prci` robot, never the account release.yaml
+    # publishes permanent images with. Restores what #4323 and
+    # #4327 established before the monorepo pipeline landed.
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_PR_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PR_PASSWORD }}
 
   # QEMU test suites. Matrix at THIS level (caller side) calling
   # reusable-qemu-test.yaml directly, because matrix + uses on a
@@ -302,7 +308,13 @@ jobs:
       release-matcher: ${{ matrix.release-matcher || '' }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head
       caller-vetted-ref: true
-    secrets: inherit
+    # ci-temp-images pushes on the pull request path use the
+    # scoped `kairos+prci` robot, never the account release.yaml
+    # publishes permanent images with. Restores what #4323 and
+    # #4327 established before the monorepo pipeline landed.
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_PR_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PR_PASSWORD }}
 
   # FIPS smoke coverage. install + acceptance is the cheapest signal
   # that the FIPS variant of the multi-call kairos binary boots and
@@ -330,7 +342,13 @@ jobs:
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       ref: refs/pull/${{ github.event.pull_request.number }}/head
       caller-vetted-ref: true
-    secrets: inherit
+    # ci-temp-images pushes on the pull request path use the
+    # scoped `kairos+prci` robot, never the account release.yaml
+    # publishes permanent images with. Restores what #4323 and
+    # #4327 established before the monorepo pipeline landed.
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_PR_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PR_PASSWORD }}
 
   qemu-tests-standard:
     needs: build-iso
@@ -356,7 +374,13 @@ jobs:
       release-matcher: ${{ matrix.release-matcher || '' }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head
       caller-vetted-ref: true
-    secrets: inherit
+    # ci-temp-images pushes on the pull request path use the
+    # scoped `kairos+prci` robot, never the account release.yaml
+    # publishes permanent images with. Restores what #4323 and
+    # #4327 established before the monorepo pipeline landed.
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_PR_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PR_PASSWORD }}
 
   # encryption-* tests spin up a k3s cluster with a kcrypt-challenger
   # Deployment, and that deployment now runs the image this PR just
@@ -392,7 +416,13 @@ jobs:
       kcrypt_challenger_image: ghcr.io/kairos-io/kairos/kcrypt-challenger:pr-${{ github.event.pull_request.number }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head
       caller-vetted-ref: true
-    secrets: inherit
+    # ci-temp-images pushes on the pull request path use the
+    # scoped `kairos+prci` robot, never the account release.yaml
+    # publishes permanent images with. Restores what #4323 and
+    # #4327 established before the monorepo pipeline landed.
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_PR_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PR_PASSWORD }}
 
   # UKI qemu tests. `generic` needs the standard (k3s) UKI ISO plus a
   # dynamically-built upgrade image; `boot-assessment` runs against
@@ -418,4 +448,10 @@ jobs:
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
       ref: refs/pull/${{ github.event.pull_request.number }}/head
       caller-vetted-ref: true
-    secrets: inherit
+    # ci-temp-images pushes on the pull request path use the
+    # scoped `kairos+prci` robot, never the account release.yaml
+    # publishes permanent images with. Restores what #4323 and
+    # #4327 established before the monorepo pipeline landed.
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_PR_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PR_PASSWORD }}


### PR DESCRIPTION
## What

Every pull request job that writes to `quay.io/kairos/ci-temp-images` authenticates today as `QUAY_USERNAME` / `QUAY_PASSWORD`, the account `release.yaml` uses to publish permanent images. This puts those writes back on `QUAY_PR_USERNAME` / `QUAY_PR_PASSWORD`, the `kairos+prci` robot scoped to `ci-temp-images` and nothing else.

## Why

#4323 and #4327 established exactly this, on 18 August. `ae314796` ("ci: retire pre-monorepo workflows, ship canonical pipeline") removed the three workflow files that carried the scoping, and the replacement pipeline reaches quay through `secrets: inherit`, so the production credential came back with it. There are zero references to `QUAY_PR_*` on `master` today. Both secrets still exist on the repository, so this works without any secret being created.

It reads as collateral from the pipeline migration rather than a decision. The commit subject is about retiring old workflows and says nothing about credentials.

## Three paths reach quay from `pr.yaml`

| Job | Reusable | What it pushes |
|---|---|---|
| `build-iso-arm`, the two `nvidia-jetson` cells | `_build-iso.yaml` | raw images, `registry_repository: ci-temp-images` |
| `qemu-tests-core`, the `bundles` cell | `reusable-qemu-test.yaml` | `ci-temp-images:bundles-test` |
| `qemu-tests-uki`, the `install-upgrade` cell | `_uki-test.yaml` | the freshly built UKI upgrade image |

Each one is switched on by an `if:` that matches exactly what `pr.yaml` sends, so all three run on an ordinary pull request.

## How

`reusable-qemu-test.yaml` already declared `QUAY_USERNAME` and `QUAY_PASSWORD`. `_build-iso.yaml` and `_uki-test.yaml` now declare them too, rather than reading them through `secrets: inherit`, so the caller chooses which account to hand over.

**`secrets: inherit` still satisfies a declared secret**, so `master.yaml` and `release.yaml` keep working with no change.

`pr.yaml` then passes the scoped robot to the six jobs that can reach quay: `build-iso-arm`, `qemu-tests-core`, `qemu-tests-core-fips`, `qemu-tests-standard`, `qemu-tests-standard-encryption`, and `qemu-tests-uki`.

## What this does not change

- **The `authorize` gate is untouched.** A fork pull request still goes through the `fork-pr-builds` environment with maintainer review.
- **`quay.expires-after=6h` is untouched.**
- **The remaining `secrets: inherit` callers in `pr.yaml`** are the jobs that never talk to quay: unit tests, lint, the kairos and kairos-init builds, the kcrypt-challenger builds, and the ghcr-only `build-iso`. They still receive the production credential and never use it. Removing that too is a bigger change and a separate decision. Say the word and I will extend this.

## Worth a reviewer's eye

`reusable-qemu-test.yaml` uses this credential to pull as well as push. Its own description says WRITE is required because it pulls the image under test from `ci-temp-images` and pushes the bundles image back. The scoped robot has write on that repository, so both work. If any test also pulls from a **different** private quay repository, that pull would start failing, and I could not find one by reading. Please confirm.

## Testing

`pr.yaml` runs on `pull_request_target`, so GitHub uses the base branch's copy. This pull request cannot exercise its own change. It needs a merge, or a manual run on a branch, to be validated for real.

YAML parses on all three files, and the `secrets` blocks are structurally under `on.workflow_call` in both reusables.

## Related

- #4310 is still open and untouched here: the bundles image is pushed to the fixed tag `ci-temp-images:bundles-test` with no pull request number or SHA, so concurrent pull requests overwrite each other and `tests/assets/bundles.yaml` pulls that exact tag.