### PR TITLE
:art: immucore: replace containerd mount helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/containerd/containerd v1.7.34
 	github.com/containerd/containerd/v2 v2.3.4
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/deniswernert/go-fstab v0.0.0-20141204152952-eb4090f26517

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,6 @@ github.com/containerd/cgroups/v3 v3.1.3/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
-github.com/containerd/containerd v1.7.34 h1:Q35B4FUECxcoaMz9QrOlqp+0s72w8/0NWawVMhVdf5g=
-github.com/containerd/containerd v1.7.34/go.mod h1:ozI//0TomTCLPhQREnx0IXDIQMg+Fk7yTtg9fNvU8EQ=
 github.com/containerd/containerd/api v1.11.1 h1:h8nfoDW9+fNsC/9TwiAHj8B1GzXKtR4eFtkhi/X5RLU=
 github.com/containerd/containerd/api v1.11.1/go.mod h1:CaQFRu+N1MtbgL6JDOJLUB1hCKESU1lD6MuTJhgtdlw=
 github.com/containerd/containerd/v2 v2.3.4 h1:c2PJo/9UGVdiiw8SwrxuLxWGY+9b3jQ6Xp9zntneIvI=

--- a/immucore/internal/mount/mount.go
+++ b/immucore/internal/mount/mount.go
@@ -1,0 +1,84 @@
+// Package mount provides the Linux mount operation used by immucore.
+package mount
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// Mount describes a filesystem mount.
+type Mount struct {
+	Type    string
+	Source  string
+	Options []string
+}
+
+var mountSyscall = unix.Mount
+
+type mountFlag struct {
+	clear bool
+	value uintptr
+}
+
+var mountFlags = map[string]mountFlag{
+	"async":         {clear: true, value: unix.MS_SYNCHRONOUS},
+	"atime":         {clear: true, value: unix.MS_NOATIME},
+	"bind":          {value: unix.MS_BIND},
+	"defaults":      {},
+	"dev":           {clear: true, value: unix.MS_NODEV},
+	"diratime":      {clear: true, value: unix.MS_NODIRATIME},
+	"dirsync":       {value: unix.MS_DIRSYNC},
+	"exec":          {clear: true, value: unix.MS_NOEXEC},
+	"mand":          {value: unix.MS_MANDLOCK},
+	"noatime":       {value: unix.MS_NOATIME},
+	"nodev":         {value: unix.MS_NODEV},
+	"nodiratime":    {value: unix.MS_NODIRATIME},
+	"noexec":        {value: unix.MS_NOEXEC},
+	"nomand":        {clear: true, value: unix.MS_MANDLOCK},
+	"norelatime":    {clear: true, value: unix.MS_RELATIME},
+	"nostrictatime": {clear: true, value: unix.MS_STRICTATIME},
+	"nosuid":        {value: unix.MS_NOSUID},
+	"rbind":         {value: unix.MS_BIND | unix.MS_REC},
+	"relatime":      {value: unix.MS_RELATIME},
+	"remount":       {value: unix.MS_REMOUNT},
+	"ro":            {value: unix.MS_RDONLY},
+	"rw":            {clear: true, value: unix.MS_RDONLY},
+	"strictatime":   {value: unix.MS_STRICTATIME},
+	"suid":          {clear: true, value: unix.MS_NOSUID},
+	"sync":          {value: unix.MS_SYNCHRONOUS},
+}
+
+// Mount invokes the mount syscall for this mount at target.
+func (m Mount) Mount(target string) error {
+	flags, data := parseOptions(m.Options)
+	mountData := strings.Join(data, ",")
+	if len(mountData) >= os.Getpagesize() {
+		return fmt.Errorf("mount data is too long: %d bytes", len(mountData))
+	}
+
+	if err := mountSyscall(m.Source, target, m.Type, flags, mountData); err != nil {
+		return fmt.Errorf("mount %q at %q: %w", m.Source, target, err)
+	}
+	return nil
+}
+
+func parseOptions(options []string) (uintptr, []string) {
+	var flags uintptr
+	var data []string
+	for _, option := range options {
+		flag, ok := mountFlags[option]
+		if !ok {
+			data = append(data, option)
+			continue
+		}
+		if flag.clear {
+			flags &^= flag.value
+		} else {
+			flags |= flag.value
+		}
+	}
+	return flags, data
+}

--- a/immucore/internal/mount/mount_test.go
+++ b/immucore/internal/mount/mount_test.go
@@ -1,0 +1,109 @@
+package mount
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestMountParsesFlagsAndPreservesDataOrder(t *testing.T) {
+	originalMount := mountSyscall
+	t.Cleanup(func() { mountSyscall = originalMount })
+
+	var gotSource, gotTarget, gotType, gotData string
+	var gotFlags uintptr
+	mountSyscall = func(source, target, fsType string, flags uintptr, data string) error {
+		gotSource, gotTarget, gotType = source, target, fsType
+		gotFlags, gotData = flags, data
+		return nil
+	}
+
+	m := Mount{
+		Type:   "ext4",
+		Source: "/dev/test",
+		Options: []string{
+			"ro", "nodev", "noexec", "nosuid", "sync", "dirsync",
+			"noatime", "nodiratime", "relatime", "strictatime",
+			"bind", "rbind", "remount", "unknown", "key=value",
+		},
+	}
+	if err := m.Mount("/target"); err != nil {
+		t.Fatalf("Mount() error = %v", err)
+	}
+
+	wantFlags := uintptr(unix.MS_RDONLY | unix.MS_NODEV | unix.MS_NOEXEC |
+		unix.MS_NOSUID | unix.MS_SYNCHRONOUS | unix.MS_DIRSYNC |
+		unix.MS_NOATIME | unix.MS_NODIRATIME | unix.MS_RELATIME |
+		unix.MS_STRICTATIME | unix.MS_BIND | unix.MS_REC | unix.MS_REMOUNT)
+	if gotSource != m.Source || gotTarget != "/target" || gotType != m.Type {
+		t.Fatalf("mount arguments = (%q, %q, %q), want (%q, %q, %q)",
+			gotSource, gotTarget, gotType, m.Source, "/target", m.Type)
+	}
+	if gotFlags != wantFlags {
+		t.Errorf("mount flags = %#x, want %#x", gotFlags, wantFlags)
+	}
+	if gotData != "unknown,key=value" {
+		t.Errorf("mount data = %q, want %q", gotData, "unknown,key=value")
+	}
+}
+
+func TestMountClearsFlags(t *testing.T) {
+	originalMount := mountSyscall
+	t.Cleanup(func() { mountSyscall = originalMount })
+
+	var gotFlags uintptr
+	mountSyscall = func(_, _, _ string, flags uintptr, _ string) error {
+		gotFlags = flags
+		return nil
+	}
+
+	m := Mount{Options: []string{
+		"ro", "rw", "nodev", "dev", "noexec", "exec", "nosuid", "suid",
+		"sync", "async", "noatime", "atime", "nodiratime", "diratime",
+		"relatime", "norelatime", "strictatime", "nostrictatime",
+		"mand", "nomand", "defaults",
+	}}
+	if err := m.Mount("/target"); err != nil {
+		t.Fatalf("Mount() error = %v", err)
+	}
+	if gotFlags != 0 {
+		t.Errorf("mount flags = %#x, want 0", gotFlags)
+	}
+}
+
+func TestMountRejectsPageSizedData(t *testing.T) {
+	originalMount := mountSyscall
+	t.Cleanup(func() { mountSyscall = originalMount })
+
+	called := false
+	mountSyscall = func(_, _, _ string, _ uintptr, _ string) error {
+		called = true
+		return nil
+	}
+
+	m := Mount{Options: []string{strings.Repeat("x", os.Getpagesize())}}
+	err := m.Mount("/target")
+	if err == nil {
+		t.Fatal("Mount() error = nil, want mount data size error")
+	}
+	if called {
+		t.Fatal("mount syscall called for page-sized data")
+	}
+}
+
+func TestMountWrapsSyscallError(t *testing.T) {
+	originalMount := mountSyscall
+	t.Cleanup(func() { mountSyscall = originalMount })
+
+	mountSyscall = func(_, _, _ string, _ uintptr, _ string) error {
+		return unix.EPERM
+	}
+
+	err := (&Mount{Source: "/dev/test"}).Mount("/target")
+	if !errors.Is(err, unix.EPERM) {
+		t.Fatalf("Mount() error = %v, want wrapped EPERM", err)
+	}
+}

--- a/immucore/internal/utils/mounts.go
+++ b/immucore/internal/utils/mounts.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/containerd/containerd/mount"
 	"github.com/deniswernert/go-fstab"
+	"github.com/kairos-io/kairos/v4/immucore/internal/mount"
 	"github.com/kairos-io/kairos/v4/sdk/constants"
 	"github.com/kairos-io/kairos/v4/sdk/ghw"
 )

--- a/immucore/internal/utils/utils_test.go
+++ b/immucore/internal/utils/utils_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/containerd/mount"
 	"github.com/jaypipes/ghw/pkg/block"
+	"github.com/kairos-io/kairos/v4/immucore/internal/mount"
 	"github.com/kairos-io/kairos/v4/immucore/internal/utils"
 	"github.com/kairos-io/kairos/v4/immucore/tests/mocks"
 	. "github.com/onsi/ginkgo/v2"

--- a/immucore/pkg/op/fs.go
+++ b/immucore/pkg/op/fs.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/mount"
 	"github.com/kairos-io/kairos/v4/immucore/internal/constants"
+	"github.com/kairos-io/kairos/v4/immucore/internal/mount"
 	internalUtils "github.com/kairos-io/kairos/v4/immucore/internal/utils"
 	"github.com/kairos-io/kairos/v4/immucore/pkg/schema"
 )

--- a/immucore/pkg/op/mount.go
+++ b/immucore/pkg/op/mount.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containerd/containerd/mount"
 	"github.com/kairos-io/kairos/v4/immucore/internal/constants"
+	"github.com/kairos-io/kairos/v4/immucore/internal/mount"
 	internalUtils "github.com/kairos-io/kairos/v4/immucore/internal/utils"
 	"github.com/kairos-io/kairos/v4/immucore/pkg/schema"
 )

--- a/immucore/pkg/op/operation.go
+++ b/immucore/pkg/op/operation.go
@@ -1,9 +1,9 @@
 package op
 
 import (
-	"github.com/containerd/containerd/mount"
 	"github.com/deniswernert/go-fstab"
 	"github.com/kairos-io/kairos/v4/immucore/internal/constants"
+	"github.com/kairos-io/kairos/v4/immucore/internal/mount"
 	internalUtils "github.com/kairos-io/kairos/v4/immucore/internal/utils"
 	"github.com/moby/sys/mountinfo"
 )
@@ -42,5 +42,5 @@ func (m MountOperation) Run() error {
 		return constants.ErrAlreadyMounted
 	}
 	l.Debug().Msg("mount ready")
-	return mount.All([]mount.Mount{m.MountOption}, m.Target)
+	return m.MountOption.Mount(m.Target)
 }


### PR DESCRIPTION
## What changed

- add a focused immucore mount type backed by `unix.Mount`
- parse standard mount flags and preserve filesystem options in order
- keep syscall errors compatible with `errors.Is`
- migrate immucore mount operations and fstab conversion
- remove the unused containerd v1 dependency

## Why

Immucore uses only a small part of containerd mount behavior. A local package keeps that required behavior without pulling in containerd v1 and its unrelated helpers.

## Verification

- `go test -count=1 ./immucore/...`
- `go mod tidy` followed by a clean `git diff --exit-code go.mod go.sum`
- confirmed no `github.com/containerd/containerd/mount` imports remain under `immucore`

Repository-wide tests require generated embedded binaries, rsync, Docker, and CGO TPM support that are unavailable in this runner. The changed immucore suite passes independently.

Closes #1697