### PR TITLE
🐛 kairos-init: order immucore before switch-root

### DIFF
--- a/kairos-init/pkg/bundled/bundled.go
+++ b/kairos-init/pkg/bundled/bundled.go
@@ -180,6 +180,7 @@ DefaultDependencies=no
 After=systemd-udev-settle.service
 Requires=systemd-udev-settle.service
 Before=initrd-fs.target
+Before=initrd-switch-root.target
 Conflicts=initrd-switch-root.target
 
 [Service]

--- a/kairos-init/pkg/bundled/immucore_service_test.go
+++ b/kairos-init/pkg/bundled/immucore_service_test.go
@@ -1,0 +1,18 @@
+package bundled_test
+
+import (
+	"strings"
+
+	"github.com/kairos-io/kairos/v4/kairos-init/pkg/bundled"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Immucore dracut service", func() {
+	It("finishes before switch-root can stop it", func() {
+		lines := strings.Split(bundled.ImmucoreServiceDracut, "\n")
+
+		Expect(lines).To(ContainElement("Before=initrd-switch-root.target"))
+		Expect(lines).To(ContainElement("Conflicts=initrd-switch-root.target"))
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a direct `Before=initrd-switch-root.target` ordering edge to the bundled `immucore.service`. The existing `Conflicts=` relationship could otherwise stop the running oneshot before its mount DAG completed, while the system continued into a root filesystem without persistent binds or overlays.

A regression test preserves both the direct ordering edge and the conflict relationship.

**Verification**:

- `go test ./kairos-init/...`
- `git diff --check`

The repository-wide `make test` reached unrelated environment-dependent failures because this worker has no `rsync`, CGO TPM simulator support, or Docker socket.

**Which issue(s) this PR fixes**:

Fixes #4399