### PR TITLE
Fix encrypted-partition boot flake, alternative to #4404 (#4403)

### DIFF
--- a/agent/internal/phonehome/handlers.go
+++ b/agent/internal/phonehome/handlers.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/kairos-io/kairos/v4/agent/pkg/action"
 	"github.com/kairos-io/kairos/v4/agent/pkg/constants"
+	sdkConstants "github.com/kairos-io/kairos/v4/sdk/constants"
+	"github.com/kairos-io/kairos/v4/sdk/machine"
 	sdkConfig "github.com/kairos-io/kairos/v4/sdk/types/config"
 )
 
@@ -333,8 +335,9 @@ func writeOEMCloudConfig(content string) error {
 	if err := os.MkdirAll("/oem", 0750); err != nil {
 		Logger.Warnf("mkdir /oem: %v", err)
 	}
-	// Best-effort mount — error is expected and ignored when /oem is already mounted.
-	_ = exec.Command("mount", "-L", "COS_OEM", "/oem").Run() //nosec G204 -- fixed label, called on local mountpoint
+	// Best-effort mount. The error is expected and ignored when /oem is
+	// already mounted.
+	_ = machine.Mount(sdkConstants.OEMLabel, "/oem")
 
 	return os.WriteFile("/oem/99_phonehome_remote.yaml", []byte(content), 0600)
 }

--- a/immucore/pkg/state/steps_shared.go
+++ b/immucore/pkg/state/steps_shared.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kairos-io/kairos/v4/immucore/pkg/op"
 	"github.com/kairos-io/kairos/v4/immucore/pkg/schema"
 	"github.com/kairos-io/kairos/v4/sdk/kcrypt"
+	"github.com/kairos-io/kairos/v4/sdk/kcrypt/lookup"
 	"github.com/kairos-io/kairos/v4/sdk/state"
 	"github.com/spectrocloud-labs/herd"
 )
@@ -236,15 +237,24 @@ func (s *State) MountOemDagStep(g *herd.Graph, opts ...herd.OpOption) error {
 					internalUtils.KLog.Logger.Debug().Msg("Livecd mode detected, won't mount OEM")
 					return nil
 				}
-				if internalUtils.GetOemLabel() == "" {
+				oemLabel := internalUtils.GetOemLabel()
+				if oemLabel == "" {
 					internalUtils.KLog.Logger.Debug().Msg("OEM label from cmdline empty, won't mount OEM")
 					return nil
 				}
+				// Resolve to a concrete device path so mount(2) and fstab
+				// bypass /dev/disk/by-label. See kairos-io/kairos#4403.
+				source, err := resolveMountSource(oemLabel)
+				if err != nil {
+					internalUtils.KLog.Logger.Err(err).Str("label", oemLabel).
+						Msg("Could not resolve OEM label to a device")
+					return err
+				}
 				operation := func(_ context.Context) error {
 					fstab, err := op.MountOPWithFstab(
-						fmt.Sprintf("/dev/disk/by-label/%s", internalUtils.GetOemLabel()),
+						source,
 						s.path("/oem"),
-						internalUtils.DiskFSType(fmt.Sprintf("/dev/disk/by-label/%s", internalUtils.GetOemLabel())),
+						internalUtils.DiskFSType(source),
 						[]string{
 							"rw",
 							"suid",
@@ -259,6 +269,38 @@ func (s *State) MountOemDagStep(g *herd.Graph, opts ...herd.OpOption) error {
 				}
 				return operation(ctx)
 			}))...)
+}
+
+// resolveMountSource maps a filesystem label to the concrete device path we
+// want mount(2) and fstab to reference. On pre-fix installs the outer LUKS
+// container shares the label with its inner ext4, so /dev/disk/by-label/<X>
+// resolves ambiguously under udev. See kairos-io/kairos#4403. Using the
+// mapper path (for encrypted setups) or the plain partition path (for
+// unencrypted ones) sidesteps the race entirely. Failures are returned to
+// the caller: falling back to the by-label form would silently reintroduce
+// the race for the same partition that ghw just failed to enumerate.
+func resolveMountSource(label string) (string, error) {
+	dev, err := lookup.MountSourceForLabel(label)
+	if err != nil {
+		return "", fmt.Errorf("resolving mount source for label %q: %w", label, err)
+	}
+	if dev == "" {
+		return "", fmt.Errorf("resolving mount source for label %q: empty result", label)
+	}
+	internalUtils.KLog.Logger.Debug().Str("label", label).Str("resolved", dev).
+		Msg("Resolved label to concrete device path")
+	return dev, nil
+}
+
+// labelFromByLabelPath returns the label component of a /dev/disk/by-label/<X>
+// path, or the empty string if the input is any other shape. Used to unwrap
+// the label form ParseMount produced in cos-layout.env parsing.
+func labelFromByLabelPath(p string) string {
+	const prefix = "/dev/disk/by-label/"
+	if strings.HasPrefix(p, prefix) {
+		return strings.TrimPrefix(p, prefix)
+	}
+	return ""
 }
 
 // MountBaseOverlayDagStep will add mounting /run/overlay as an overlay dir
@@ -347,15 +389,37 @@ func (s *State) MountCustomMountsDagStep(g *herd.Graph, opts ...herd.OpOption) e
 				if strings.Contains(what, "COS_PERSISTENT") {
 					mountOptions = []string{"rw"}
 				}
-				// 30s covers the window between cryptsetup finishing a LUKS
-				// unlock and udev populating /dev/disk/by-label/<label> for
-				// the unlocked mapper. Under IO or CPU pressure that window
-				// can exceed a few seconds, and if the mount gives up first
-				// it fails with "no such device" and boot continues without
-				// /usr/local mounted - so every persistent bind (/home, ...)
-				// silently disappears from the running system.
+				// If `what` is a /dev/disk/by-label/<X> path (the common
+				// case from cos-layout.env's VOLUMES entries), resolve to
+				// the concrete device path first, since the by-label symlink
+				// races with udev on pre-fix installs whose LUKS outer and
+				// inner ext4 share the label (kairos-io/kairos#4403).
+				source := what
+				if label := labelFromByLabelPath(what); label != "" {
+					resolved, resolveErr := resolveMountSource(label)
+					if resolveErr != nil {
+						internalUtils.KLog.Logger.Err(resolveErr).Str("label", label).
+							Msg("Could not resolve custom-mount label to a device")
+						if !strings.Contains(what, "COS_OEM") {
+							err = multierror.Append(err, resolveErr)
+						}
+						continue
+					}
+					source = resolved
+				}
+				// The 30s timeout covers the window between cryptsetup
+				// creating the mapper (kernel side) and udev finishing the
+				// /dev/mapper/<name> node MountOPWithFstab tries to open.
+				// Even with a concrete device path, mount(2) still sees
+				// ENOENT until udev has finished processing the new dm
+				// event; under IO or CPU pressure that can take several
+				// seconds. MountOPWithFstab retries during this window,
+				// and 30s gives boot enough room to succeed before we give
+				// up and log a warning. If resolveMountSource failed above,
+				// we already `continue`d, so this path is only reached with
+				// a resolved concrete source.
 				fstab, err2 := op.MountOPWithFstab(
-					what,
+					source,
 					s.path(where),
 					fstype,
 					mountOptions,

--- a/immucore/pkg/state/steps_shared_label_test.go
+++ b/immucore/pkg/state/steps_shared_label_test.go
@@ -1,0 +1,104 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/kairos-io/kairos/v4/sdk/constants"
+	"github.com/kairos-io/kairos/v4/sdk/ghw/mocks"
+	"github.com/kairos-io/kairos/v4/sdk/types/partitions"
+)
+
+// TestLabelFromByLabelPath pins the small string helper immucore's mount step
+// uses to unwrap a /dev/disk/by-label/<X> path back to its label component.
+// The mount step calls resolveMountSource with that label so the concrete
+// device path (mapper for LUKS, plain partition otherwise) replaces the
+// racy by-label form in both the mount(2) call and the fstab entry.
+func TestLabelFromByLabelPath(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "/dev/disk/by-label/COS_PERSISTENT", want: constants.PersistentLabel},
+		{in: "/dev/disk/by-label/COS_OEM", want: constants.OEMLabel},
+		{in: "/dev/disk/by-label/MYAPP_DATA", want: "MYAPP_DATA"},
+		{in: "/dev/sda2", want: ""},
+		{in: "/dev/mapper/vda5", want: ""},
+		{in: "LABEL=COS_PERSISTENT", want: ""},
+		{in: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := labelFromByLabelPath(tt.in); got != tt.want {
+				t.Fatalf("labelFromByLabelPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveMountSource verifies the resolution path immucore's mount step
+// takes for encrypted mounts on a pre-fix install (LUKS container and its
+// inner ext4 both labelled COS_PERSISTENT). The mount source must be the
+// mapper (see kairos-io/kairos#4403), so udev's by-label race doesn't decide
+// what gets mounted.
+func TestResolveMountSource(t *testing.T) {
+	t.Run("encrypted: resolves to the mapper path", func(t *testing.T) {
+		var ghwMock mocks.GhwMock
+		ghwMock.AddDisk(partitions.Disk{
+			Name: "vda",
+			Partitions: partitions.PartitionList{
+				{
+					Name:            "vda5",
+					PartitionLabel:  "persistent",
+					FilesystemLabel: constants.PersistentLabel,
+					FS:              "crypto_LUKS",
+				},
+			},
+		})
+		ghwMock.CreateDevices()
+		t.Cleanup(ghwMock.Clean)
+
+		got, err := resolveMountSource(constants.PersistentLabel)
+		if err != nil {
+			t.Fatalf("resolveMountSource(COS_PERSISTENT) error = %v", err)
+		}
+		if got != "/dev/mapper/vda5" {
+			t.Fatalf("resolveMountSource(COS_PERSISTENT) = %q, want /dev/mapper/vda5", got)
+		}
+	})
+
+	t.Run("plain: resolves to the partition path", func(t *testing.T) {
+		var ghwMock mocks.GhwMock
+		ghwMock.AddDisk(partitions.Disk{
+			Name: "vda",
+			Partitions: partitions.PartitionList{
+				{
+					Name:            "vda2",
+					FilesystemLabel: constants.OEMLabel,
+					FS:              "ext4",
+				},
+			},
+		})
+		ghwMock.CreateDevices()
+		t.Cleanup(ghwMock.Clean)
+
+		got, err := resolveMountSource(constants.OEMLabel)
+		if err != nil {
+			t.Fatalf("resolveMountSource(COS_OEM) error = %v", err)
+		}
+		if got != "/dev/vda2" {
+			t.Fatalf("resolveMountSource(COS_OEM) = %q, want /dev/vda2", got)
+		}
+	})
+
+	t.Run("unknown label: returns an error", func(t *testing.T) {
+		var ghwMock mocks.GhwMock
+		ghwMock.AddDisk(partitions.Disk{Name: "vda"})
+		ghwMock.CreateDevices()
+		t.Cleanup(ghwMock.Clean)
+
+		got, err := resolveMountSource("MISSING_LABEL")
+		if err == nil {
+			t.Fatalf("resolveMountSource(MISSING_LABEL) = %q, want an error", got)
+		}
+	})
+}

--- a/sdk/kcrypt/lookup/lookup.go
+++ b/sdk/kcrypt/lookup/lookup.go
@@ -1,0 +1,133 @@
+// Package lookup holds the partition-label resolution helpers that the boot
+// and post-install mount paths depend on to disambiguate a LUKS container
+// from its unlocked mapper. Both advertise the same filesystem label on
+// encrypted installs (see kairos-io/kairos#4403), so any caller that resolves
+// a label via /dev/disk/by-label/<X> or a bare blkid -L is racing with udev.
+//
+// The helpers live in this leaf package so both sdk/kcrypt (the encryption
+// flow) and sdk/machine (the post-install mount helpers) can call them
+// without introducing an import cycle through sdk/collector.
+package lookup
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/kairos-io/kairos/v4/sdk/constants"
+	"github.com/kairos-io/kairos/v4/sdk/ghw"
+	sdkLogger "github.com/kairos-io/kairos/v4/sdk/types/logger"
+	"github.com/kairos-io/kairos/v4/sdk/types/partitions"
+)
+
+// LegacyPartitionName maps a Kairos filesystem label back to its GPT
+// PartitionLabel counterpart (COS_PERSISTENT -> persistent, COS_OEM -> oem).
+// The reverse mapping is needed to find a partition whose filesystem label
+// was never set. That is the pre-kairos-sdk#822 install shape where the LUKS
+// container has no FS label at all and only its GPT PARTLABEL identifies it.
+func LegacyPartitionName(filesystemLabel string) string {
+	switch filesystemLabel {
+	case constants.OEMLabel:
+		return constants.OEMPartName
+	case constants.PersistentLabel:
+		return constants.PersistentPartName
+	default:
+		return ""
+	}
+}
+
+// MapperPath returns the device-mapper path for a given LUKS partition.
+// This is where cryptsetup luksOpen places the unlocked mapper, keyed by the
+// underlying LUKS partition's kernel name (e.g. /dev/mapper/vda5).
+func MapperPath(p *partitions.Partition) string {
+	if p == nil {
+		return ""
+	}
+	return filepath.Join("/dev", "mapper", p.Name)
+}
+
+// FindByLabel returns any partition carrying the given filesystem label,
+// without regard to filesystem type. Callers who need a specific FS type
+// must use FindLUKSContainerByLabel or FindMapperByLabel so the by-label
+// ambiguity does not steer them to the wrong device.
+func FindByLabel(partitionLabel string) (*partitions.Partition, error) {
+	return findByLabelFiltered(partitionLabel, nil)
+}
+
+// FindLUKSContainerByLabel returns the crypto_LUKS partition carrying the
+// given filesystem label. Used at unlock time and by mount code paths that
+// need the LUKS device to derive its mapper path.
+func FindLUKSContainerByLabel(partitionLabel string) (*partitions.Partition, error) {
+	return findByLabelFiltered(partitionLabel, func(p *partitions.Partition) bool {
+		return p.FS == "crypto_LUKS"
+	})
+}
+
+// FindMapperByLabel returns the plaintext filesystem carrying the given
+// filesystem label. That is, the ext4/xfs partition, or the unlocked mapper
+// of a crypto_LUKS container. Used to bypass /dev/disk/by-label ambiguity
+// when mounting a label that also exists on a LUKS wrapper.
+func FindMapperByLabel(partitionLabel string) (*partitions.Partition, error) {
+	return findByLabelFiltered(partitionLabel, func(p *partitions.Partition) bool {
+		return p.FS != "crypto_LUKS"
+	})
+}
+
+// MountSourceForLabel returns the concrete device path to hand to mount(2)
+// for the filesystem with the given label, resolving the by-label symlink
+// ambiguity that kairos-io/kairos#4403 relies on. If the label lives on a
+// LUKS container, the returned path is the mapper (/dev/mapper/<name>),
+// which is unambiguous even when the outer and inner filesystems share the
+// same label. If the label lives on a plain partition, the returned path is
+// that partition's device path.
+//
+// This is the value that boot-time mount code AND the fstab entry Spec must
+// use for label-addressed mounts on Kairos systems. Passing
+// /dev/disk/by-label/<X> leaves the caller at the mercy of udev's
+// last-writer-wins resolution.
+func MountSourceForLabel(partitionLabel string) (string, error) {
+	if luks, err := FindLUKSContainerByLabel(partitionLabel); err == nil {
+		return MapperPath(luks), nil
+	}
+	p, err := FindMapperByLabel(partitionLabel)
+	if err != nil {
+		return "", err
+	}
+	if p.Path != "" {
+		return p.Path, nil
+	}
+	return filepath.Join("/dev", p.Name), nil
+}
+
+func findByLabelFiltered(partitionLabel string, filter func(*partitions.Partition) bool) (*partitions.Partition, error) {
+	legacyName := LegacyPartitionName(partitionLabel)
+
+	logger := sdkLogger.NewNullLogger()
+	disks := ghw.GetDisks(ghw.NewPaths(""), &logger)
+	if disks == nil {
+		return nil, fmt.Errorf("failed to scan block devices")
+	}
+
+	labelMatches := func(p *partitions.Partition) bool {
+		return p.FilesystemLabel == partitionLabel ||
+			(legacyName != "" && p.PartitionLabel == legacyName)
+	}
+
+	for _, disk := range disks {
+		for _, p := range disk.Partitions {
+			if !labelMatches(p) {
+				continue
+			}
+			if filter != nil && !filter(p) {
+				continue
+			}
+			if p.Path == "" {
+				p.Path = filepath.Join("/dev", p.Name)
+			}
+			if p.Name == "" {
+				p.Name = filepath.Base(p.Path)
+			}
+			return p, nil
+		}
+	}
+	return nil, fmt.Errorf("partition not found")
+}

--- a/sdk/kcrypt/lookup/lookup_test.go
+++ b/sdk/kcrypt/lookup/lookup_test.go
@@ -1,0 +1,177 @@
+package lookup
+
+import (
+	"testing"
+
+	"github.com/kairos-io/kairos/v4/sdk/constants"
+	"github.com/kairos-io/kairos/v4/sdk/ghw/mocks"
+	"github.com/kairos-io/kairos/v4/sdk/types/partitions"
+)
+
+func TestLegacyPartitionName(t *testing.T) {
+	tests := []struct {
+		label string
+		want  string
+	}{
+		{label: constants.OEMLabel, want: constants.OEMPartName},
+		{label: constants.PersistentLabel, want: constants.PersistentPartName},
+		{label: "CUSTOM_LABEL", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.label, func(t *testing.T) {
+			if got := LegacyPartitionName(tt.label); got != tt.want {
+				t.Fatalf("LegacyPartitionName(%q) = %q, want %q", tt.label, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFindByLabelFallsBackToGPTLabel covers installs with no FS label at all
+// (kairos-sdk#822 / kairos-io/kairos#4276), where the LUKS container is
+// discoverable only via GPT PARTLABEL. The mock intentionally leaves
+// FilesystemLabel empty so only the PARTLABEL branch can satisfy the match.
+func TestFindByLabelFallsBackToGPTLabel(t *testing.T) {
+	var ghwMock mocks.GhwMock
+	ghwMock.AddDisk(partitions.Disk{
+		Name: "disk",
+		Partitions: partitions.PartitionList{
+			{
+				Name:           "disk1",
+				PartitionLabel: constants.OEMPartName,
+				FS:             "crypto_LUKS",
+			},
+		},
+	})
+	ghwMock.CreateDevices()
+	t.Cleanup(ghwMock.Clean)
+
+	partition, err := FindByLabel(constants.OEMLabel)
+	if err != nil {
+		t.Fatalf("FindByLabel error = %v", err)
+	}
+	if partition.Path != "/dev/disk1" {
+		t.Fatalf("FindByLabel path = %q, want /dev/disk1", partition.Path)
+	}
+}
+
+// TestFindByLabelTypeFilters covers the split lookup that lets callers pick
+// the LUKS container or the plaintext filesystem unambiguously even when
+// both sides share the same label. kairos-io/kairos#4403.
+func TestFindByLabelTypeFilters(t *testing.T) {
+	var ghwMock mocks.GhwMock
+	// LUKS container /dev/vda5 and its unlocked mapper /dev/mapper/vda5
+	// both advertise LABEL=COS_PERSISTENT.
+	ghwMock.AddDisk(partitions.Disk{
+		Name: "vda",
+		Partitions: partitions.PartitionList{
+			{
+				Name:            "vda5",
+				PartitionLabel:  constants.PersistentPartName,
+				FilesystemLabel: constants.PersistentLabel,
+				FS:              "crypto_LUKS",
+			},
+		},
+	})
+	ghwMock.AddDisk(partitions.Disk{
+		Name: "dm-0",
+		Partitions: partitions.PartitionList{
+			{
+				Name:            "dm-0",
+				FilesystemLabel: constants.PersistentLabel,
+				FS:              "ext4",
+			},
+		},
+	})
+	ghwMock.CreateDevices()
+	t.Cleanup(ghwMock.Clean)
+
+	t.Run("FindLUKSContainerByLabel returns the crypto_LUKS device", func(t *testing.T) {
+		p, err := FindLUKSContainerByLabel(constants.PersistentLabel)
+		if err != nil {
+			t.Fatalf("FindLUKSContainerByLabel error = %v", err)
+		}
+		if p.FS != "crypto_LUKS" {
+			t.Fatalf("FindLUKSContainerByLabel FS = %q, want crypto_LUKS", p.FS)
+		}
+		if p.Name != "vda5" {
+			t.Fatalf("FindLUKSContainerByLabel Name = %q, want vda5", p.Name)
+		}
+	})
+
+	t.Run("FindMapperByLabel returns the ext4 device, never the LUKS", func(t *testing.T) {
+		p, err := FindMapperByLabel(constants.PersistentLabel)
+		if err != nil {
+			t.Fatalf("FindMapperByLabel error = %v", err)
+		}
+		if p.FS == "crypto_LUKS" {
+			t.Fatalf("FindMapperByLabel returned the LUKS container; must return the plaintext side")
+		}
+		if p.Name != "dm-0" {
+			t.Fatalf("FindMapperByLabel Name = %q, want dm-0", p.Name)
+		}
+	})
+}
+
+// TestMountSourceForLabel pins the resolution that immucore's mount step and
+// sdk/machine.Mount depend on to bypass the by-label symlink race.
+func TestMountSourceForLabel(t *testing.T) {
+	t.Run("prefers the mapper when a LUKS container carries the label", func(t *testing.T) {
+		var ghwMock mocks.GhwMock
+		ghwMock.AddDisk(partitions.Disk{
+			Name: "vda",
+			Partitions: partitions.PartitionList{
+				{
+					Name:            "vda5",
+					PartitionLabel:  constants.PersistentPartName,
+					FilesystemLabel: constants.PersistentLabel,
+					FS:              "crypto_LUKS",
+				},
+			},
+		})
+		ghwMock.CreateDevices()
+		t.Cleanup(ghwMock.Clean)
+
+		got, err := MountSourceForLabel(constants.PersistentLabel)
+		if err != nil {
+			t.Fatalf("MountSourceForLabel error = %v", err)
+		}
+		if got != "/dev/mapper/vda5" {
+			t.Fatalf("MountSourceForLabel = %q, want /dev/mapper/vda5", got)
+		}
+	})
+
+	t.Run("returns the plain partition when the label lives on unencrypted ext4", func(t *testing.T) {
+		var ghwMock mocks.GhwMock
+		ghwMock.AddDisk(partitions.Disk{
+			Name: "vda",
+			Partitions: partitions.PartitionList{
+				{
+					Name:            "vda3",
+					FilesystemLabel: constants.OEMLabel,
+					FS:              "ext4",
+				},
+			},
+		})
+		ghwMock.CreateDevices()
+		t.Cleanup(ghwMock.Clean)
+
+		got, err := MountSourceForLabel(constants.OEMLabel)
+		if err != nil {
+			t.Fatalf("MountSourceForLabel error = %v", err)
+		}
+		if got != "/dev/vda3" {
+			t.Fatalf("MountSourceForLabel = %q, want /dev/vda3", got)
+		}
+	})
+
+	t.Run("returns error when the label is not present", func(t *testing.T) {
+		var ghwMock mocks.GhwMock
+		ghwMock.AddDisk(partitions.Disk{Name: "vda"})
+		ghwMock.CreateDevices()
+		t.Cleanup(ghwMock.Clean)
+
+		if _, err := MountSourceForLabel("NOPE"); err == nil {
+			t.Fatalf("MountSourceForLabel expected an error for missing label, got nil")
+		}
+	})
+}

--- a/sdk/machine/partitions.go
+++ b/sdk/machine/partitions.go
@@ -3,8 +3,8 @@ package machine
 import (
 	"fmt"
 	"os"
-	"strings"
 
+	"github.com/kairos-io/kairos/v4/sdk/kcrypt/lookup"
 	"github.com/kairos-io/kairos/v4/sdk/utils"
 )
 
@@ -24,25 +24,31 @@ func Remount(opt, path string) error {
 	return nil
 }
 
+// Mount resolves the given filesystem label to a concrete device path and
+// mounts it at mountpoint. Post-install callers (agent hooks copying logs,
+// installing bundles, hardening SSH, wiring grub options) previously reached
+// for `blkid -L <label>` directly, which on pre-fix encrypted installs races
+// with udev between the LUKS container and its unlocked mapper
+// (kairos-io/kairos#4403). lookup.MountSourceForLabel bypasses the by-label
+// symlink entirely, returning the mapper path for LUKS-wrapped partitions
+// and the plain partition path otherwise.
 func Mount(label, mountpoint string) error {
-	part, _ := utils.SH(fmt.Sprintf("blkid -L %s", label))
+	part, err := lookup.MountSourceForLabel(label)
+	if err != nil {
+		return fmt.Errorf("resolving mount source for label %q: %w", label, err)
+	}
 	if part == "" {
-		fmt.Printf("%s partition not found\n", label)
-		return fmt.Errorf("partition not found")
+		return fmt.Errorf("resolving mount source for label %q: empty result", label)
 	}
 
-	part = strings.TrimSuffix(part, "\n")
-
 	if !utils.Exists(mountpoint) {
-		err := os.MkdirAll(mountpoint, 0755)
-		if err != nil {
+		if err := os.MkdirAll(mountpoint, 0755); err != nil {
 			return err
 		}
 	}
-	mount, err := utils.SH(fmt.Sprintf("mount %s %s", part, mountpoint))
+	out, err := utils.SH(fmt.Sprintf("mount %s %s", part, mountpoint))
 	if err != nil {
-		fmt.Printf("could not mount: %s\n", mount+err.Error())
-		return err
+		return fmt.Errorf("mounting %s at %s: %w (output: %s)", part, mountpoint, err, out)
 	}
 	return nil
 }

--- a/tests/encryption_advanced_test.go
+++ b/tests/encryption_advanced_test.go
@@ -77,6 +77,24 @@ func verifyEncryptedPartition(vm VM) {
 	Expect(err).ToNot(HaveOccurred(), out)
 	Expect(out).To(MatchRegexp("TYPE=\"crypto_LUKS\" PARTLABEL=\"persistent\""), out)
 	Expect(out).To(MatchRegexp("/dev/mapper.*LABEL=\"COS_PERSISTENT\""), out)
+	verifyPersistentFstabUsesMapper(vm)
+}
+
+// verifyPersistentFstabUsesMapper asserts the persistent mount in /etc/fstab
+// resolves to a concrete /dev/mapper path rather than the by-label symlink
+// that races with udev on pre-fix installs (kairos-io/kairos#4403). The LUKS
+// container and its inner ext4 both carry LABEL=COS_PERSISTENT there, so a
+// fstab entry using /dev/disk/by-label/COS_PERSISTENT (or LABEL=COS_PERSISTENT)
+// leaves systemd racing at mount-unit activation and boot loses /usr/local
+// with "Can't open blockdev". Immucore now writes /dev/mapper/<name>; catching
+// a regression back to the by-label form here is one grep in the guest.
+func verifyPersistentFstabUsesMapper(vm VM) {
+	GinkgoHelper()
+	By("Verifying /etc/fstab uses the mapper path for /usr/local")
+	fstab, err := vm.Sudo("cat /etc/fstab")
+	Expect(err).ToNot(HaveOccurred(), fstab)
+	Expect(fstab).To(MatchRegexp(`/dev/mapper/\S+\s+/usr/local\s+`), fstab)
+	Expect(fstab).ToNot(MatchRegexp(`(?m)^\S*(LABEL=COS_PERSISTENT|/dev/disk/by-label/COS_PERSISTENT)\s+/usr/local`), fstab)
 }
 
 // checkPassphraseRetrieval invokes the discovery CLI in-guest against the
@@ -137,8 +155,8 @@ metadata:
 spec:
   TPMHash: "%s"
   partitions:
-    - label: COS_PERSISTENT
-  quarantined: false`, sealedVolumeName, tpmHash)
+    - label: %s
+  quarantined: false`, sealedVolumeName, tpmHash, "COS_PERSISTENT")
 
 	if attestationConfig != nil {
 		sealedVolumeYaml += "\n  attestation:"
@@ -501,12 +519,12 @@ metadata:
 spec:
   TPMHash: "%s"
   partitions:
-    - label: COS_PERSISTENT
+    - label: %s
       secret:
         name: %s-cos-persistent
         path: passphrase
   attestation: {}
-`, sealedVolumeName, tpmHash, sealedVolumeName))
+`, sealedVolumeName, tpmHash, "COS_PERSISTENT", sealedVolumeName))
 
 			By("Installing Kairos with encryption")
 			config := fmt.Sprintf(`#cloud-config
@@ -602,7 +620,7 @@ metadata:
 spec:
   TPMHash: "%s"
   partitions:
-    - label: COS_PERSISTENT
+    - label: %s
       secret:
         name: %s-cos-persistent
         path: passphrase
@@ -612,7 +630,7 @@ spec:
       pcrs:
         "0": ""
         "7": ""
-`, sealedVolumeName, tpmHash, sealedVolumeName))
+`, sealedVolumeName, tpmHash, "COS_PERSISTENT", sealedVolumeName))
 
 			By("Installing Kairos with encryption")
 			config := fmt.Sprintf(`#cloud-config

--- a/tests/encryption_test.go
+++ b/tests/encryption_test.go
@@ -101,6 +101,7 @@ stages:
 			out, err := vm.Sudo("blkid")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp("TYPE=\"crypto_LUKS\" PARTLABEL=\"persistent\""), out)
+			verifyPersistentFstabUsesMapper(vm)
 		})
 	})
 
@@ -138,6 +139,7 @@ stages:
 			out, err := vm.Sudo("blkid")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp("TYPE=\"crypto_LUKS\" PARTLABEL=\"persistent\""), out)
+			verifyPersistentFstabUsesMapper(vm)
 
 			By("running kairos-agent kcrypt checknv on the default NV index")
 			out, err = vm.Sudo("kairos-agent kcrypt checknv")
@@ -217,6 +219,7 @@ kcrypt:
 			out, err := vm.Sudo("blkid")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp("TYPE=\"crypto_LUKS\" PARTLABEL=\"persistent\""), out)
+			verifyPersistentFstabUsesMapper(vm)
 
 			By("Expecting the secret to be created")
 			// TOFU mode creates secrets with name format: "tofu-{tpmHash[:8]}-{partitionLabel}"
@@ -267,7 +270,7 @@ metadata:
 spec:
   TPMHash: "%[2]s"
   partitions:
-    - label: COS_PERSISTENT
+    - label: %[3]s
       secret:
         name: "%[1]s"
         path: pass
@@ -278,7 +281,7 @@ spec:
         "0": ""
         "7": ""
         "11": ""
-`, shortName, tpmHash))
+`, shortName, tpmHash, "COS_PERSISTENT"))
 
 			config = fmt.Sprintf(`#cloud-config
 
@@ -330,6 +333,7 @@ kcrypt:
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp("TYPE=\"crypto_LUKS\" PARTLABEL=\"persistent\""), out)
 			Expect(out).To(MatchRegexp("/dev/mapper.*LABEL=\"COS_PERSISTENT\""), out)
+			verifyPersistentFstabUsesMapper(vm)
 		})
 	})
 
@@ -388,6 +392,7 @@ install:
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).To(MatchRegexp("TYPE=\"crypto_LUKS\" PARTLABEL=\"persistent\""), out)
 				Expect(out).To(MatchRegexp("/dev/(mapper|dm).*LABEL=\"COS_PERSISTENT\""), out)
+				verifyPersistentFstabUsesMapper(vm)
 			})
 		})
 

--- a/tests/uki_test.go
+++ b/tests/uki_test.go
@@ -187,10 +187,16 @@ func genericTests(vm VM) {
 		Expect(err).ToNot(HaveOccurred(), out)
 	})
 	By("Checking OEM/PERSISTENT are not mounted", func() {
+		// On the livecd nothing should be mounted at /oem or /usr/local
+		// yet. Assert the mountpoints directly rather than a specific
+		// device-path form, since kairos-io/kairos#4403 removed
+		// /dev/disk/by-label from the mount pipeline; a vacuously
+		// passing "does not contain by-label" check would no longer
+		// detect a stray mount.
 		out, err := vm.Sudo("mount")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(out).ToNot(ContainSubstring("/dev/disk/by-label/COS_OEM"))
-		Expect(out).ToNot(ContainSubstring("/dev/disk/by-label/COS_PERSISTENT"))
+		Expect(out).ToNot(MatchRegexp(`\son\s/oem\b`), out)
+		Expect(out).ToNot(MatchRegexp(`\son\s/usr/local\b`), out)
 	})
 	By("installing kairos", func() {
 		// Install has already started, so we can use Eventually here to track the logs
@@ -249,10 +255,16 @@ func genericTests(vm VM) {
 		Expect(err).ToNot(HaveOccurred(), out)
 	})
 	By("Checking OEM/PERSISTENT are mounted", func() {
-		out, err := vm.Sudo("df -h") // Shows the disk by label which is easier to check
+		// Immucore resolves the label to the concrete mapper path
+		// before mounting (kairos-io/kairos#4403), so df reports
+		// /dev/mapper/<name> for both /oem and /usr/local rather
+		// than the racy /dev/disk/by-label form.
+		out, err := vm.Sudo("df -h")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(out).To(ContainSubstring("/dev/disk/by-label/COS_OEM"))
-		Expect(out).To(ContainSubstring("/dev/disk/by-label/COS_PERSISTENT"))
+		Expect(out).To(MatchRegexp(`/dev/mapper/\S+\s.*\s/oem\b`), out)
+		Expect(out).To(MatchRegexp(`/dev/mapper/\S+\s.*\s/usr/local\b`), out)
+		Expect(out).ToNot(ContainSubstring("/dev/disk/by-label/COS_OEM"), out)
+		Expect(out).ToNot(ContainSubstring("/dev/disk/by-label/COS_PERSISTENT"), out)
 	})
 	By("Checking OEM/PERSISTENT are encrypted", func() {
 		out, err := vm.Sudo("blkid /dev/vda2")


### PR DESCRIPTION
Alternative to #4404. Same bug, smaller diff.

## The bug

On encrypted installs, boot sometimes lands broken: `/usr/local` is not mounted, `/home/kairos` is missing, and every SSH login prints `Could not chdir to home directory /home/kairos`. Root cause is that both the LUKS container and the ext4 inside it carry the same filesystem label. `/dev/disk/by-label/COS_PERSISTENT` then races on which one udev picked, and when it lands on the LUKS side, systemd tries to mount an encrypted block device as ext4 and loops on "Can't open blockdev".

## The fix (this PR)

Stop trusting `/dev/disk/by-label` anywhere in the mount path. Immucore now resolves each label to a concrete device (`/dev/mapper/<name>` for encrypted, `/dev/<name>` otherwise) before mounting, and writes that same concrete path into `/etc/fstab`. The udev race becomes irrelevant. Same treatment for `sdk/machine.Mount` (called by agent hooks) and the phonehome handler's `/oem` mount.

Existing encrypted installs are fixed on their next boot after upgrading. No on-disk migration, no wire-protocol change with kcrypt-challenger, no SealedVolume rename.

## How it compares to #4404

Both PRs fix the observed boot failure. This PR is the smaller of the two: it only teaches the mount code to bypass `by-label`. #4404 additionally changes the on-disk label of the LUKS container itself so that `/dev/disk/by-label/COS_PERSISTENT` becomes unambiguous, which requires updates in every place that scans for that label, a rename of the kcrypt-challenger secret naming for new installs, and matching test churn.

**Trade-off:** this PR does not split the label at the LUKS header. Nothing in the Kairos tree depends on `by-label` for encrypted partitions after this change, but a third-party tool that resolved `/dev/disk/by-label/COS_PERSISTENT` on an encrypted host would still race. #4404 closes that hole at the cost of the wider changes above.

## Which one to merge

Up to the maintainers. My take: this branch fixes the reported symptom with the smallest surface. #4404 additionally hardens the on-disk state for hypothetical future consumers, in exchange for a wider blast radius (test churn, wire-label change, all ghw scanners).
