### PR TITLE
ci: run ginkgo from tests/ instead of copying tests/go.* to repo root

### DIFF
--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -315,9 +315,10 @@ jobs:
           fi
           export ISO=$PWD/$(ls *.iso|grep -v ipxe | head -1 )
           echo "ISO is: $ISO"
-          cp tests/go.* .
+          pushd tests
           go mod download
-          go run github.com/onsi/ginkgo/v2/ginkgo -v --label-filter "${{ inputs.test }}" --fail-fast -r ./tests/
+          go run github.com/onsi/ginkgo/v2/ginkgo -v --label-filter "${{ inputs.test }}" --fail-fast -r ./...
+          popd
       - name: Run encryption tests
         if: ${{ startsWith(inputs.test, 'encryption-') }}
         env:


### PR DESCRIPTION
The reusable QEMU test step used to shim the multi-module setup by copying tests/go.mod and tests/go.sum up to the repo root, then running `go run github.com/onsi/ginkgo/v2/ginkgo ... -r ./tests/` from there. That works only as long as tests/go.mod is self-contained.

The moment tests/go.mod adds a `replace github.com/kairos-io/kairos/v4 => ../` directive, the copy breaks: the moved file resolves `../` to one level above the repo root, where no `go.mod` exists, and go blows up with

  reading ../go.mod: open /runner/_work/kairos/go.mod: no such file
  or directory

Fixed by running ginkgo from tests/ directly with a pushd/popd, which is what .github/encryption-tests.sh already does. tests/go.mod stays in place, its replace directive points at ../ correctly, and the go.sum is used as-is instead of being copied.

Unblocks the follow-up work that needs the tests module to reference sdk/constants directly (kairos-io/kairos#4404).
