### PR TITLE
fix: let the p2p provider choose the edgevpn API address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,19 @@ image-kairos-init: kairos-init
 .PHONY: images
 images: image-kcrypt-challenger image-kairos-init
 
+# --- bootable artifacts ---
+#
+# Everything above stops at container images. `make iso` carries on to a
+# bootable ISO by running the two remaining steps CI does in
+# .github/workflows/reusable-factory.yaml: bake the OS image with
+# images/Dockerfile, then hand it to auroraboot. Defaults reproduce the
+# amd64-standard cell, which is what the provider and standard qemu suites
+# test against. Needs docker with a usable socket; see the script header for
+# the environment variables it honours.
+.PHONY: iso
+iso:
+	scripts/build-iso.sh
+
 .PHONY: clean
 clean:
 	rm -rf $(DIST_DIR)

--- a/agent/pkg/cmd/root.go
+++ b/agent/pkg/cmd/root.go
@@ -277,8 +277,28 @@ Starts the kairos agent which automatically bootstrap and advertize to the kairo
 				Name: "force",
 			},
 			&cli.StringFlag{
-				Name:  "api",
-				Value: "http://127.0.0.1:8080",
+				Name: "api",
+				Usage: "Address of the edgevpn API the p2p provider co-ordinates over. " +
+					"Leave unset to let the provider choose, which is what keeps the edgevpn " +
+					"daemon's listen address and the provider CLI's client address in agreement. " +
+					"Setting it moves the daemon only, so the provider CLI needs the same " +
+					"address in EDGEVPN_API to keep working.",
+				// Deliberately no default. The address is the p2p provider's to
+				// decide: it both writes APILISTEN for the edgevpn daemon and
+				// defaults its own CLI client to the same place. A default here
+				// would win over the provider's and desynchronise the two ends.
+				//
+				// Note that an explicitly set value desynchronises them just the
+				// same. Whatever arrives here reaches the daemon's APILISTEN and
+				// the provider's in-process coordination client, but not the
+				// provider's command line client, which has no way to learn it
+				// and keeps its own default. Operators who set this must also
+				// export EDGEVPN_API for `get-kubeconfig` and `role list`. The
+				// real fix is for the provider CLI to derive its default from
+				// the APILISTEN the provider already writes to
+				// /etc/systemd/system.conf.d/edgevpn-kairos.env, which belongs
+				// in kairos-io/provider-kairos.
+				Value: "",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/agent/pkg/cmd/root_test.go
+++ b/agent/pkg/cmd/root_test.go
@@ -108,3 +108,39 @@ func TestCatalogDownloadFailureDoesNotLeaveTemporaryFile(t *testing.T) {
 		t.Fatalf("temporary catalog was not removed: %v", statErr)
 	}
 }
+
+// The edgevpn API address is chosen by the p2p provider, not by the agent.
+// The agent only forwards whatever the operator passed on the command line,
+// so an unset --api must reach the provider as an empty string. If the agent
+// substitutes a default of its own, that default silently overrides the
+// provider's and the two ends of the API disagree: the provider writes the
+// agent's address into the edgevpn daemon's APILISTEN while its own CLI keeps
+// defaulting to the provider's socket, so `get-kubeconfig` and `role list`
+// talk to an address nothing is listening on and print empty output.
+func TestStartAPIFlagHasNoDefault(t *testing.T) {
+	var start *cli.Command
+	for _, c := range cmds {
+		if c.Name == "start" {
+			start = c
+			break
+		}
+	}
+	if start == nil {
+		t.Fatal("no start command registered")
+	}
+
+	var api *cli.StringFlag
+	for _, f := range start.Flags {
+		if sf, ok := f.(*cli.StringFlag); ok && sf.Name == "api" {
+			api = sf
+			break
+		}
+	}
+	if api == nil {
+		t.Fatal("start command has no --api flag")
+	}
+
+	if api.Value != "" {
+		t.Fatalf("start --api default = %q, want %q so the provider picks the address", api.Value, "")
+	}
+}

--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -51,7 +51,29 @@ fi
 : "${IMAGE_TAG:=dev}"
 KAIROS_INIT_IMAGE="$IMAGE_REGISTRY/kairos-init:$IMAGE_TAG"
 : "${OS_IMAGE:=$IMAGE_REGISTRY/kairos-os:$IMAGE_TAG}"
-: "${AURORABOOT_IMAGE:=quay.io/kairos/auroraboot:latest}"
+# The auroraboot version is pinned in .github/workflows/_build-iso.yaml, which
+# passes auroraboot_version to the factory workflow rather than taking the
+# factory's own "latest" default. Read it from there instead of repeating it,
+# so a local ISO stays comparable to a CI one and there is only one place to
+# bump. scripts/kairos-diff.sh parses pinned versions out of tracked files the
+# same way. Failing loudly beats silently falling back to a different version
+# than CI uses, which is the whole point of tracking the pin.
+if [[ -z "${AURORABOOT_IMAGE:-}" ]]; then
+    iso_workflow=".github/workflows/_build-iso.yaml"
+    # No `| head -1`: under pipefail, head closing the pipe early can fail the
+    # script on sed's SIGPIPE. Take the first match by expansion instead.
+    aurora_matches="$(sed -n \
+        "s/^[[:space:]]*auroraboot_version:[[:space:]]*['\"]\{0,1\}\([^'\"[:space:]]*\)['\"]\{0,1\}[[:space:]]*$/\1/p" \
+        "$iso_workflow")"
+    aurora_version="${aurora_matches%%$'\n'*}"
+    if [[ -z "$aurora_version" ]]; then
+        echo "error: no auroraboot_version found in $iso_workflow" >&2
+        echo "       The pin moved or changed shape. Fix the parse above, or set" >&2
+        echo "       AURORABOOT_IMAGE to pick the image explicitly." >&2
+        exit 1
+    fi
+    AURORABOOT_IMAGE="quay.io/kairos/auroraboot:$aurora_version"
+fi
 : "${OUTPUT_DIR:=$REPO_ROOT/build/iso}"
 
 for cmd in docker go; do

--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Build a bootable Kairos ISO from this working tree, the same way CI does.
+#
+# `make binaries` stops at the kairos-init container image. The two steps
+# that turn that into something you can boot live only in
+# .github/workflows/reusable-factory.yaml, so reproducing a CI ISO locally
+# used to mean reading the workflow and reassembling the docker commands by
+# hand. This script is those steps, in order:
+#
+#   1. make binaries        -- the multi-call kairos (default + FIPS), the
+#                              installer, and kairos-init with them embedded
+#   2. make image-kairos-init -- kairos-init as a container image
+#   3. docker build         -- run kairos-init over the base image to produce
+#                              the Kairos OS image (images/Dockerfile)
+#   4. auroraboot build-iso -- turn that OS image into an ISO
+#
+# Defaults reproduce the `amd64-standard` cell from master.yaml, which is the
+# image the provider and standard qemu test suites run against. Everything is
+# overridable by environment variable; nothing takes a flag yet.
+#
+# Requires docker (with a working socket) and go.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Build inputs -----------------------------------------------------------
+# These mirror the amd64-standard matrix cell in .github/workflows/master.yaml.
+: "${ARCH:=amd64}"
+: "${BASE_IMAGE:=ghcr.io/kairos-io/hadron:v0.5.1}"
+: "${MODEL:=generic}"
+: "${KUBERNETES_DISTRO:=k3s}"
+: "${TRUSTED_BOOT:=false}"
+
+# Same derivation the factory workflow uses for version: "auto". A bare SHA
+# means the tree has no tags reachable, which kairos-init rejects as a
+# version, so it gets a v0.0.0- prefix.
+if [[ -z "${VERSION:-}" ]]; then
+    VERSION="$(git describe --tags --dirty --always 2>/dev/null || echo dev)"
+    if [[ "$VERSION" =~ ^[a-f0-9]+$ ]]; then
+        VERSION="v0.0.0-$VERSION"
+    fi
+fi
+
+# kairos-init is consumed by images/Dockerfile as a FROM, so it only has to
+# exist in the local docker daemon. Nothing here pushes. The registry and tag
+# are separate because `make image-kairos-init` composes the name itself, as
+# <registry>/kairos-init:<tag>.
+: "${IMAGE_REGISTRY:=kairos-local}"
+: "${IMAGE_TAG:=dev}"
+KAIROS_INIT_IMAGE="$IMAGE_REGISTRY/kairos-init:$IMAGE_TAG"
+: "${OS_IMAGE:=$IMAGE_REGISTRY/kairos-os:$IMAGE_TAG}"
+: "${AURORABOOT_IMAGE:=quay.io/kairos/auroraboot:latest}"
+: "${OUTPUT_DIR:=$REPO_ROOT/build/iso}"
+
+for cmd in docker go; do
+    command -v "$cmd" >/dev/null 2>&1 || {
+        echo "error: $cmd is required but not on PATH" >&2
+        exit 1
+    }
+done
+
+echo "==> Building ISO"
+echo "    arch:       $ARCH"
+echo "    base image: $BASE_IMAGE"
+echo "    model:      $MODEL"
+echo "    k8s:        ${KUBERNETES_DISTRO:-<none>}"
+echo "    version:    $VERSION"
+echo "    output:     $OUTPUT_DIR"
+echo
+
+# --- 1 + 2: binaries, then kairos-init as an image --------------------------
+# `binaries` also fetches the external provider-kairos and edgevpn releases
+# pinned in scripts/prepare-kairos-init-binaries.sh, so the ISO carries the
+# same provider versions CI ships.
+echo "==> [1/4] make binaries"
+make binaries ARCH="$ARCH"
+
+echo "==> [2/4] make image-kairos-init -> $KAIROS_INIT_IMAGE"
+make image-kairos-init \
+    ARCH="$ARCH" \
+    IMAGE_REGISTRY="$IMAGE_REGISTRY" \
+    IMAGE_TAG="$IMAGE_TAG"
+
+# --- 3: OS image ------------------------------------------------------------
+echo "==> [3/4] docker build (images/Dockerfile) -> $OS_IMAGE"
+docker build -f images/Dockerfile . \
+    --build-arg BASE_IMAGE="$BASE_IMAGE" \
+    --build-arg KAIROS_INIT_IMAGE="$KAIROS_INIT_IMAGE" \
+    --build-arg MODEL="$MODEL" \
+    --build-arg TRUSTED_BOOT="$TRUSTED_BOOT" \
+    --build-arg KUBERNETES_DISTRO="$KUBERNETES_DISTRO" \
+    --build-arg VERSION="$VERSION" \
+    -t "$OS_IMAGE"
+
+# --- 4: ISO -----------------------------------------------------------------
+# auroraboot reads the OS image straight out of the local docker daemon, which
+# is why it needs the socket bind-mounted. It writes into /output.
+echo "==> [4/4] auroraboot build-iso -> $OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$OUTPUT_DIR:/output" \
+    "$AURORABOOT_IMAGE" --debug \
+    build-iso --output /output/ "docker:$OS_IMAGE"
+
+# auroraboot runs as root inside its container, so everything it wrote to the
+# bind mount is owned by root and the invoking user cannot delete or move it
+# without sudo. Hand it back using a throwaway container from the same image,
+# which already has the root privileges needed to chown. Doing it in a
+# container rather than on the host keeps this script sudo-free.
+docker run --rm \
+    -v "$OUTPUT_DIR:/output" \
+    --entrypoint chown \
+    "$AURORABOOT_IMAGE" -R "$(id -u):$(id -g)" /output
+
+# OUTPUT_DIR is reused across runs, so pick the newest ISO rather than the
+# first one the filesystem happens to hand back. Taking the first line with a
+# parameter expansion rather than `| head -1` keeps `head` from closing the
+# pipe early, which under `pipefail` would fail the script on sort's SIGPIPE.
+isos="$(find "$OUTPUT_DIR" -maxdepth 1 -name '*.iso' -printf '%T@ %p\n' | sort -rn)"
+iso="${isos%%$'\n'*}"
+iso="${iso#* }"
+if [[ -z "$iso" ]]; then
+    echo "error: auroraboot reported success but no ISO landed in $OUTPUT_DIR" >&2
+    exit 1
+fi
+
+echo
+echo "ISO: $iso"
+echo
+echo "Run a qemu test against it with, for example:"
+echo "  export ISO=$iso MEMORY=5000 CPUS=4 DRIVE_SIZE=50000"
+echo "  cd tests && go run github.com/onsi/ginkgo/v2/ginkgo -v \\"
+echo "    --label-filter \"provider-decentralized-k8s\" --fail-fast -r ./..."

--- a/tests/provider_decentralized_test.go
+++ b/tests/provider_decentralized_test.go
@@ -189,7 +189,17 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 		vmForEach("checking if it has machines with different IPs", vms, func(vm VM) {
 			var out string
 			Eventually(func() string {
-				out, _ = vm.Sudo(`curl --unix-socket ` + edgevpnAPISocket + ` http://localhost/api/machines`)
+				var err error
+				out, err = vm.Sudo(`curl -sSf --unix-socket ` + edgevpnAPISocket + ` http://localhost/api/machines`)
+				if err != nil {
+					// Without this, an unreachable socket or an API error is
+					// indistinguishable from a reachable API that has not
+					// listed both nodes yet, and the spec burns the full 900s
+					// with an empty string to show for it. vm.Sudo returns
+					// stdout and stderr together, so curl's -sS message is
+					// already in out; err adds the exit status.
+					return fmt.Sprintf("querying the machines API failed: %v: %s", err, out)
+				}
 				return out
 			}, 900*time.Second, 10*time.Second).Should(And(
 				ContainSubstring("10.1.0.1"),
@@ -214,7 +224,14 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 			var err error
 			Eventually(func() string {
 				// Set up the DNS record via the API (use simple regex, not escaped)
-				_, _ = vm.Sudo(`curl --unix-socket ` + edgevpnAPISocket + ` -X POST http://localhost/api/dns --header "Content-Type: application/json" -d '{ "Regex": "foo.bar", "Records": { "A": "2.2.2.2" } }'`)
+				postOut, postErr := vm.Sudo(`curl -sSf --unix-socket ` + edgevpnAPISocket + ` -X POST http://localhost/api/dns --header "Content-Type: application/json" -d '{ "Regex": "foo.bar", "Records": { "A": "2.2.2.2" } }'`)
+				if postErr != nil {
+					// Announcing the record is what makes the lookups below
+					// resolve. If the POST failed there is nothing to resolve,
+					// so report that rather than letting the spec fail 240s
+					// later on a lookup that was never going to succeed.
+					return fmt.Sprintf("announcing the DNS record failed: %v: %s", postErr, postOut)
+				}
 
 				// Check if DNS resolution works using resolvectl (more reliable than curl)
 				out, err = vm.Sudo("resolvectl query foo.bar 2>&1")

--- a/tests/provider_decentralized_test.go
+++ b/tests/provider_decentralized_test.go
@@ -15,6 +15,13 @@ import (
 	. "github.com/spectrocloud/peg/matcher"
 )
 
+// The p2p provider serves the edgevpn API on a unix socket, not on a TCP port.
+// This is provider-kairos' DefaultEdgeVPNAPIAddress with the "unix://" scheme
+// stripped, which is the form curl's --unix-socket wants. The URLs below still
+// need a host to be well formed, so they use "localhost" as a placeholder that
+// --unix-socket overrides.
+const edgevpnAPISocket = "/run/edgevpn-kairos.sock"
+
 var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-decentralized-k8s"), func() {
 	var vms []VM
 	var configPath string
@@ -182,7 +189,7 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 		vmForEach("checking if it has machines with different IPs", vms, func(vm VM) {
 			var out string
 			Eventually(func() string {
-				out, _ = vm.Sudo(`curl http://localhost:8080/api/machines`)
+				out, _ = vm.Sudo(`curl --unix-socket ` + edgevpnAPISocket + ` http://localhost/api/machines`)
 				return out
 			}, 900*time.Second, 10*time.Second).Should(And(
 				ContainSubstring("10.1.0.1"),
@@ -207,7 +214,7 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 			var err error
 			Eventually(func() string {
 				// Set up the DNS record via the API (use simple regex, not escaped)
-				_, _ = vm.Sudo(`curl -X POST http://localhost:8080/api/dns --header "Content-Type: application/json" -d '{ "Regex": "foo.bar", "Records": { "A": "2.2.2.2" } }'`)
+				_, _ = vm.Sudo(`curl --unix-socket ` + edgevpnAPISocket + ` -X POST http://localhost/api/dns --header "Content-Type: application/json" -d '{ "Regex": "foo.bar", "Records": { "A": "2.2.2.2" } }'`)
 
 				// Check if DNS resolution works using resolvectl (more reliable than curl)
 				out, err = vm.Sudo("resolvectl query foo.bar 2>&1")
@@ -220,7 +227,7 @@ var _ = Describe("kairos decentralized k8s test", Label("provider", "provider-de
 				return strings.TrimSpace(out)
 			}, 240*time.Second, 10*time.Second).Should(MatchRegexp("2\\.2\\.2\\.2"), func() string {
 				// On failure, print diagnostics
-				dnsRecords, _ := vm.Sudo("curl -s http://localhost:8080/api/dns")
+				dnsRecords, _ := vm.Sudo("curl -s --unix-socket " + edgevpnAPISocket + " http://localhost/api/dns")
 				resolv, _ := vm.Sudo("cat /etc/resolv.conf")
 				svcStatus, _ := vm.Sudo("systemctl status edgevpn@kairos --no-pager 2>&1 | head -20")
 				resolvectl, _ := vm.Sudo("resolvectl status 2>&1 | head -30")


### PR DESCRIPTION
**What this PR does / why we need it**:

On a Kairos node built with the `standard` variant, asking for the cluster's kubeconfig printed nothing at all:

```
# /system/providers/agent-provider-kairos get-kubeconfig

# echo $?
0
```

An empty line and a success exit code. Listing the node roles behaved the same way, printing its table header and no rows:

```
# /system/providers/agent-provider-kairos role list
Node                                             Role                            IP
-----------------------------------------------  ------------------------------  ---------------
```

The cluster itself was healthy throughout. Both nodes found each other, roles were assigned, the master published its address and join token, and the worker joined k3s.

### Cause

Kairos nodes run edgevpn, a peer to peer daemon that lets the nodes discover each other and share the kubeconfig and the k3s join token. It exposes a small HTTP API. Both the address the daemon listens on and the address its command line client dials are decided by the p2p provider, provider-kairos.

The provider defaults both ends to a unix socket at `/run/edgevpn-kairos.sock`.

`kairos-agent start` had a default of its own, `http://127.0.0.1:8080`, which it published on the plugin bus as `BootstrapPayload.APIAddress`. The provider prefers whatever the agent sends it, so the daemon was told to listen on TCP port 8080 while the provider's own client kept dialing the socket. Nothing listened on the socket. The client discards its error (`str, _ := cc.Get(...)`), so the commands printed empty output and exited 0.

Confirmed from the CI logs of the failing job. The edgevpn daemon reported:

```
edgevpn[1460]: ⇨ http server started on 127.0.0.1:8080
```

while the provider binary shipped in the same image reported:

```
--api value  ... (default: "unix:///run/edgevpn-kairos.sock")
```

### Fix

The agent has no business choosing this address. It now sends an empty string when the operator did not pass `--api`, which is the case the provider already handles by falling back to its own default. One component decides, so both ends agree.

Minimal pair, taken from the `kairos-agent` binary extracted out of each ISO:

```
--- ISO built from master (2026-08-24) ---
   --api value  (default: "http://127.0.0.1:8080")
--- ISO built from this branch ---
   --api value  Address of the edgevpn API the p2p provider co-ordinates over. ...
```

The qemu test `provider-decentralized-k8s` reached that API by curling port 8080 in three places, so those move to the socket.

This also adds `make iso`, which builds a bootable ISO from a checkout. The Makefile previously stopped at container images; the two steps that turn those into something you can boot existed only inside `.github/workflows/reusable-factory.yaml`. That is how the verification below was done.

### Verification

`provider-decentralized-k8s` has failed on every master run since 2026-08-24, always timing out at `tests/provider_decentralized_test.go:156` waiting 25 minutes for a kubeconfig that could never arrive. Most recently [run 33155499457](https://github.com/kairos-io/kairos/actions/runs/33155499457/job/98800113379).

Run locally against an ISO built from this branch with `make iso`:

| Step | CI, before | Local, after |
|---|---|---|
| checking if it has a working kubeconfig | 1500s, then failed | 1.4s |
| checking roles | 900s | 0.2s |
| checking if it has machines with different IPs | 900s | 0.1s |
| checking if it can propagate dns | not reached cleanly | passed |
| suite total | 45m53s, FAIL | 4m1s, `1 Passed \| 0 Failed` |

The DNS step passing matters on its own, because it exercises the rewritten `curl --unix-socket` POST path rather than just compiling it.

---

## Reminder: this needs a release note

**The edgevpn API on standard nodes moves from `127.0.0.1:8080` to a unix socket at `/run/edgevpn-kairos.sock`.** Suggested text:

> On a node built with the `standard` variant, the peer to peer coordination API that edgevpn serves used to listen on TCP port `8080`. It now listens on a unix socket instead. Anything that reached it over TCP needs to change:
>
> ```
> # before
> curl http://localhost:8080/api/machines
> # after
> curl --unix-socket /run/edgevpn-kairos.sock http://localhost/api/machines
> ```
>
> If you need the TCP listener back, both ends have to be told, not just one:
>
> ```
> kairos-agent start --api http://127.0.0.1:8080
> EDGEVPN_API=http://127.0.0.1:8080 /system/providers/agent-provider-kairos get-kubeconfig
> ```
>
> The flag moves the edgevpn daemon and the provider's in-process coordination client. It does not reach the provider's command line client, which has no way to learn it and keeps defaulting to the unix socket, so `get-kubeconfig` and `role list` need `EDGEVPN_API` set to the same address.
>
> This only affects the API running on a Kairos node. The `kairosctl bridge` API, which runs on your own machine and is the one the documentation describes, still listens on `127.0.0.1:8080` and is unchanged.

The TCP listener was never documented for nodes. Every `localhost:8080` in the docs refers to `kairosctl bridge`, which has its own separate `--api` flag and is unaffected: `docs/installation/p2p.md` lines 171, 177 and 299 all sit under a `kairosctl bridge` heading, and `docs/reference/kairosctl.md:154` is the `bridge` command reference. So no documentation change is required, only the release note.

## Follow up work, not in this PR

Both in `kairos-io/provider-kairos`:

1. Derive the client's `--api` default from the `APILISTEN` the provider itself writes to `/etc/systemd/system.conf.d/edgevpn-kairos.env`, so the two ends stay in agreement even when someone does pass `--api` to the agent. This PR removes the disagreement; that change would make it structurally impossible.
2. Stop discarding the client error in `internal/cli/get_kubeconfig.go` and `internal/cli/role.go`. That swallowed error is the reason a connection failure cost 45 minutes of CI time instead of printing one line.

**Which issue(s) this PR fixes**:
