### PR TITLE
Fix/kubevip provider issues

### DIFF
--- a/provider/internal/role/p2p/kubevip.go
+++ b/provider/internal/role/p2p/kubevip.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/kairos-io/kairos/v4/provider/internal/assets"
 	providerConfig "github.com/kairos-io/kairos/v4/provider/internal/provider/config"
@@ -153,12 +154,20 @@ func downloadFromURL(url, where string) error {
 	}
 	defer output.Close()
 
-	response, err := http.Get(url)
+	// http.DefaultClient has no timeout: a server that accepts the TCP
+	// connection and then stalls would keep this call blocked and
+	// prevent the node from finishing its bootstrap. Same shape as the
+	// fix in sdk/collector's MergeConfigURL (see #4389).
+	client := &http.Client{Timeout: 15 * time.Second}
+	response, err := client.Get(url)
 	if err != nil {
 		return err
-
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d fetching %s", response.StatusCode, url)
+	}
 
 	_, err = io.Copy(output, response.Body)
 	return err

--- a/provider/internal/role/p2p/kubevip.go
+++ b/provider/internal/role/p2p/kubevip.go
@@ -211,11 +211,11 @@ func deployKubeVIP(iface, ip string, pconfig *providerConfig.Config) error {
 
 	f, err := os.Create(targetFile)
 	if err != nil {
-		return fmt.Errorf("could not open %s: %w", f.Name(), err)
+		return fmt.Errorf("could not open %s: %w", targetFile, err)
 	}
 	defer f.Close()
 	if _, err := f.WriteString(content); err != nil {
-		return fmt.Errorf("could not write to %s: %w", f.Name(), err)
+		return fmt.Errorf("could not write to %s: %w", targetFile, err)
 	}
 
 	return nil

--- a/provider/internal/role/p2p/kubevip.go
+++ b/provider/internal/role/p2p/kubevip.go
@@ -186,7 +186,7 @@ func deployKubeVIP(iface, ip string, pconfig *providerConfig.Config) error {
 		manifestDirectory = "/var/lib/rancher/k3s/agent/pod-manifests/"
 	}
 	if err := os.MkdirAll(manifestDirectory, 0750); err != nil {
-		return fmt.Errorf("could not create manifest dir")
+		return fmt.Errorf("could not create manifest dir %s: %w", manifestDirectory, err)
 	}
 
 	targetFile := manifestDirectory + "kubevip.yaml"

--- a/provider/internal/role/p2p/kubevip.go
+++ b/provider/internal/role/p2p/kubevip.go
@@ -169,7 +169,7 @@ func deployKubeVIP(iface, ip string, pconfig *providerConfig.Config) error {
 	if pconfig.K3sAgent.IsEnabled() {
 		manifestDirectory = "/var/lib/rancher/k3s/agent/pod-manifests/"
 	}
-	if err := os.MkdirAll(manifestDirectory, 0650); err != nil {
+	if err := os.MkdirAll(manifestDirectory, 0750); err != nil {
 		return fmt.Errorf("could not create manifest dir")
 	}
 

--- a/provider/internal/role/p2p/kubevip.go
+++ b/provider/internal/role/p2p/kubevip.go
@@ -148,12 +148,6 @@ func applyKConfigToInitConfig(kConfig providerConfig.KubeVIP, initConfig *kubevi
 }
 
 func downloadFromURL(url, where string) error {
-	output, err := os.Create(where)
-	if err != nil {
-		return err
-	}
-	defer output.Close()
-
 	// http.DefaultClient has no timeout: a server that accepts the TCP
 	// connection and then stalls would keep this call blocked and
 	// prevent the node from finishing its bootstrap. Same shape as the
@@ -169,8 +163,21 @@ func downloadFromURL(url, where string) error {
 		return fmt.Errorf("unexpected status %d fetching %s", response.StatusCode, url)
 	}
 
-	_, err = io.Copy(output, response.Body)
-	return err
+	// The destination lives in the k3s manifest directory, which the
+	// kubelet watches. Only create the file once we know the response
+	// is usable, and remove any partial write if the copy fails, so a
+	// half-written or empty manifest never lands at the final path.
+	output, err := os.Create(where)
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+
+	if _, err := io.Copy(output, response.Body); err != nil {
+		_ = os.Remove(where)
+		return err
+	}
+	return nil
 }
 
 func deployKubeVIP(iface, ip string, pconfig *providerConfig.Config) error {

--- a/provider/internal/role/p2p/kubevip_test.go
+++ b/provider/internal/role/p2p/kubevip_test.go
@@ -1,6 +1,12 @@
 package role
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"time"
+
 	providerConfig "github.com/kairos-io/kairos/v4/provider/internal/provider/config"
 	"github.com/kube-vip/kube-vip/pkg/kubevip"
 	. "github.com/onsi/ginkgo/v2"
@@ -46,5 +52,76 @@ var _ = Describe("generateKubeVIP image", func() {
 		out, err := generateKubeVIP("pod", "eth0", "192.168.1.1", cfg)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(ContainSubstring("my-registry.example.com/kube-vip/kube-vip:v1.0.0"))
+	})
+})
+
+var _ = Describe("downloadFromURL", func() {
+	var dir string
+
+	BeforeEach(func() {
+		var err error
+		dir, err = os.MkdirTemp("", "kubevip-download-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(dir)).To(Succeed())
+	})
+
+	It("writes the response body to the destination on 200", func() {
+		body := "apiVersion: v1\nkind: ConfigMap\n"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+		}))
+		defer srv.Close()
+
+		dst := filepath.Join(dir, "out.yaml")
+		Expect(downloadFromURL(srv.URL, dst)).To(Succeed())
+
+		got, err := os.ReadFile(dst)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(got)).To(Equal(body))
+	})
+
+	It("returns an error on non-2xx responses instead of writing the error page", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "not found", http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		dst := filepath.Join(dir, "out.yaml")
+		Expect(downloadFromURL(srv.URL, dst)).To(MatchError(ContainSubstring("404")))
+
+		got, err := os.ReadFile(dst)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(BeEmpty(), "the HTTP error page must not be persisted to the manifest path")
+	})
+
+	It("times out instead of hanging forever when the server stalls", func() {
+		block := make(chan struct{})
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-block
+		}))
+		// Release the blocked handler before Close(): httptest.Server.Close
+		// waits for outstanding handlers to return, so ordering here matters.
+		defer srv.Close()
+		defer close(block)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- downloadFromURL(srv.URL, filepath.Join(dir, "stall.yaml"))
+		}()
+
+		select {
+		case err := <-done:
+			// net/http surfaces client-side timeouts as errors whose
+			// message contains "Client.Timeout"; pin on that so a
+			// different failure mode (e.g. connection refused) does
+			// not silently satisfy the assertion.
+			Expect(err).To(MatchError(ContainSubstring("Client.Timeout")))
+		case <-time.After(30 * time.Second):
+			Fail("downloadFromURL did not honor a request timeout within 30s")
+		}
 	})
 })

--- a/provider/internal/role/p2p/kubevip_test.go
+++ b/provider/internal/role/p2p/kubevip_test.go
@@ -84,7 +84,7 @@ var _ = Describe("downloadFromURL", func() {
 		Expect(string(got)).To(Equal(body))
 	})
 
-	It("returns an error on non-2xx responses instead of writing the error page", func() {
+	It("returns an error on non-2xx responses without creating the destination file", func() {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "not found", http.StatusNotFound)
 		}))
@@ -93,9 +93,11 @@ var _ = Describe("downloadFromURL", func() {
 		dst := filepath.Join(dir, "out.yaml")
 		Expect(downloadFromURL(srv.URL, dst)).To(MatchError(ContainSubstring("404")))
 
-		got, err := os.ReadFile(dst)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(got).To(BeEmpty(), "the HTTP error page must not be persisted to the manifest path")
+		// The kubelet watches this directory; even an empty file at the
+		// final path could be picked up. Assert nothing was created.
+		_, err := os.Stat(dst)
+		Expect(err).To(HaveOccurred())
+		Expect(os.IsNotExist(err)).To(BeTrue(), "the HTTP error page must not leave a file at the manifest path")
 	})
 
 	It("times out instead of hanging forever when the server stalls", func() {

--- a/provider/internal/role/schedule.go
+++ b/provider/internal/role/schedule.go
@@ -28,7 +28,7 @@ func scheduleRoles(nodes []string, c *service.RoleConfig, cc *sdkConfig.Config, 
 		advertizing, _ := c.Client.AdvertizingNodes()
 		for u, r := range currentRoles {
 			if !lo.Contains(advertizing, u) {
-				c.Logger.Infof("Role '%s' assigned to unreachable node '%s'. Unassigning.", u, r)
+				c.Logger.Infof("Role '%s' assigned to unreachable node '%s'. Unassigning.", r, u)
 				if err := c.Client.Delete("role", u); err != nil {
 					c.Logger.Warnf("Error announcing deletion %+v", err)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

Four small, independent fixes to the p2p/kube-vip provider code that moved over in the recent absorption. Each is on its own commit.

- **#4427**: The kube-vip manifest directory was being created with a mode that forgot the execute bit on a directory, so no non-root process could ever enter it. Root ignores that check, so nothing was actually broken at runtime, but the mode was semantically wrong for a directory; switched it to the intended `0750`.
- **#4428**: If creating the kube-vip manifest file failed, the code that built the error message tried to read the name off the file object that was never opened, which would crash the process while trying to report the failure. Now the error uses the target path directly.
- **#4429**: When a user pointed the provider at their own kube-vip manifest URL, the download had no timeout (a stalled server would hang the node forever during bootstrap) and did not check the HTTP status (a 404 page would be saved verbatim into the k3s manifest directory). Both are now handled, matching the same fix already applied elsewhere in the tree (#4389).
- **#4430**: When dynamic role scheduling pruned an unreachable node, the log message had the UUID and the role in each other's slots, so it read as though a node named `master` was being pruned. Purely a log-message fix, no behaviour change.

**Which issue(s) this PR fixes**:
Fixes #4427
Fixes #4428
Fixes #4429
Fixes #4430