### PR TITLE
ci: add a Security fixes section to generated release notes

### DIFF
--- a/.github/workflows/release-notes-diff.yaml
+++ b/.github/workflows/release-notes-diff.yaml
@@ -173,6 +173,52 @@ jobs:
           ./scripts/kairos-diff.sh "${{ steps.prev.outputs.tag }}" "$CURRENT_TAG" --output "$output_file"
           echo "output_file=$output_file" >> "$GITHUB_ENV"
 
+      - name: Generate security fixes section
+        # OpenSSF Best Practices `release_notes_vulns`: release notes must
+        # explicitly list the publicly known vulnerabilities (CVEs) fixed in
+        # each release, or say plainly that there are none. This scans the
+        # diff already generated above for CVE identifiers in PR titles and
+        # commit subjects across kairos, kairos-init, and every tracked
+        # component, so a security-fix PR is picked up automatically as long
+        # as its title names the CVE it fixes.
+        if: ${{ steps.prev.outputs.skip == 'false' }}
+        id: security
+        run: |
+          security_file="SECURITY_FIXES_${CURRENT_TAG}.md"
+          cve_lines="$(grep -oE '^- .*CVE-[0-9]{4}-[0-9]+.*$' "${output_file}" | sort -u || true)"
+
+          {
+            echo "## Security fixes"
+            echo
+            if [ -n "$cve_lines" ]; then
+              printf '%s\n' "$cve_lines"
+            else
+              echo "No security fixes in this release."
+            fi
+          } > "$security_file"
+
+          echo "security_file=$security_file" >> "$GITHUB_OUTPUT"
+
+      - name: Prepend security fixes section to release description
+        if: ${{ steps.prev.outputs.skip == 'false' }}
+        run: |
+          security_header="## Security fixes"
+
+          gh release view "$CURRENT_TAG" --repo "${{ github.repository }}" --json body --jq '.body // ""' > current_body.md
+
+          if grep -Fq "$security_header" current_body.md; then
+            echo "Security fixes section already present in release body. Skipping."
+            exit 0
+          fi
+
+          {
+            cat current_body.md
+            echo
+            cat "${{ steps.security.outputs.security_file }}"
+          } > with_security_body.md
+
+          gh release edit "$CURRENT_TAG" --repo "${{ github.repository }}" --notes-file with_security_body.md
+
       - name: Append diff to release description
         if: ${{ steps.prev.outputs.skip == 'false' }}
         id: append


### PR DESCRIPTION
## What this does

Adds a "Security fixes" section to generated release notes, listing the CVEs fixed in that release, or stating plainly there were none.

## Why

OpenSSF Best Practices' `release_notes_vulns` criterion (part of #4243, tracked under #4242) requires release notes to explicitly list the publicly known vulnerabilities fixed in each release. The existing "Security Notice" warning in this workflow only covers known, unpatched upstream CVEs in the standard k3s/k0s images. It says nothing about CVEs actually fixed in kairos or its tracked components.

## How

Scans the diff already generated by `scripts/kairos-diff.sh` for this release (kairos, kairos-init, and every tracked dependency) for CVE identifiers in PR titles and commit subjects, and prepends a "## Security fixes" section to the release description listing each match, or "No security fixes in this release." if none are found. Same idempotency guard as the existing diff-append step: if the section header is already present, it's skipped.

This depends on a security-fix PR's title or commit message naming the CVE it fixes, which is already common practice but worth calling out as the convention this now relies on going forward.

Refs #4243, #4242.
