### PR TITLE
fix: make kairos-diff.sh aware of the monorepo migration

### DIFF
--- a/scripts/kairos-diff.sh
+++ b/scripts/kairos-diff.sh
@@ -3,7 +3,24 @@
 set -euo pipefail
 
 KAIROS_SLUG="kairos-io/kairos"
+# Archived, frozen at the monorepo migration (2026-08-19/21). Not queried
+# for changes any more (see MONOREPO_PATHS) -- kept only as a read-only
+# fallback for load_makefile_versions/load_gomod_versions when OLD_REF
+# predates the migration and neither kairos-init/Makefile nor go.mod exist
+# yet at that ref in kairos-io/kairos itself.
 KAIROS_INIT_SLUG="kairos-io/kairos-init"
+
+# Components whose source now lives inside kairos-io/kairos itself (the
+# 2026-08-19/21 monorepo migration). They have no version of their own
+# anymore -- diffed by path against the same OLD_REF/NEW_REF as "Kairos
+# changes" itself, not against a separate repo or version pin.
+declare -A MONOREPO_PATHS=(
+  [kairos-init]="kairos-init/"
+  [kairos-agent]="agent/"
+  [immucore]="immucore/"
+  [kairos-sdk]="sdk/"
+  [kcrypt-discovery-challenger]="kcrypt/discovery/"
+)
 
 declare -A COMPONENT_SLUG_HINT=()
 
@@ -44,12 +61,7 @@ component_to_slug() {
   local component="$1"
   case "$component" in
     kairos) printf '%s\n' "$KAIROS_SLUG" ;;
-    kairos-init) printf '%s\n' "$KAIROS_INIT_SLUG" ;;
-    kairos-agent) printf 'kairos-io/kairos-agent\n' ;;
-    immucore) printf 'kairos-io/immucore\n' ;;
-    kcrypt-discovery-challenger) printf 'kairos-io/kcrypt-discovery-challenger\n' ;;
     provider-kairos) printf 'kairos-io/provider-kairos\n' ;;
-    kairos-sdk) printf 'kairos-io/kairos-sdk\n' ;;
     edgevpn) printf 'mudler/edgevpn\n' ;;
     entities) printf 'mudler/entities\n' ;;
     go-pluggable) printf 'mudler/go-pluggable\n' ;;
@@ -115,45 +127,84 @@ normalize_ref_gh() {
   return 1
 }
 
-extract_kairos_init_version() {
+# Pre-migration fallback only: kairos-init/Makefile and go.mod did not
+# exist in kairos-io/kairos before the 2026-08-19/21 merge, so a ref from
+# before it has to read them from the archived kairos-io/kairos-init repo
+# instead, the same way this script always did pre-migration. Resolves via
+# the Dockerfile's KAIROS_INIT= pin, which is the one thing that was
+# already accurate for pre-migration refs and still is.
+resolve_pre_migration_init_ref() {
   local kairos_ref="$1"
-  local dockerfile
+  local dockerfile init_version
   dockerfile="$(get_file_content "$KAIROS_SLUG" "$kairos_ref" "images/Dockerfile")" || return 1
 
   local line
   while IFS= read -r line; do
     if [[ "$line" =~ ^ARG[[:space:]]+KAIROS_INIT=([^[:space:]]+) ]]; then
-      printf '%s\n' "${BASH_REMATCH[1]}"
-      return 0
+      init_version="${BASH_REMATCH[1]}"
+      break
     fi
   done <<<"$dockerfile"
+  [[ -n "${init_version:-}" ]] || return 1
 
-  return 1
+  ensure_ref_exists_gh "$KAIROS_INIT_SLUG" "$init_version" || return 1
+  printf '%s\n' "$init_version"
 }
 
 load_makefile_versions() {
-  local init_ref="$1"
+  # kairos-init/Makefile still pins provider-kairos post-migration, but
+  # AGENT_VERSION/IMMUCORE_VERSION/KCRYPT_DISCOVERY_CHALLENGER_VERSION are
+  # vestigial there now: those components are monorepo paths (see
+  # MONOREPO_PATHS), not external repos with a version to bump.
+  #
+  # EDGEVPN_VERSION is a special case: pre-migration, edgevpn's pin lived
+  # ONLY in this Makefile, never in kairos-init's go.mod, so the fallback
+  # branch below still needs it. Post-migration, edgevpn genuinely is a
+  # go.mod dependency of the root module, and this Makefile variable has
+  # already been observed drifted from it (v0.35.4 here vs. v0.35.3 in
+  # go.mod) -- so it's deliberately NOT captured from the primary,
+  # post-migration branch, only from the pre-migration fallback, letting
+  # load_gomod_versions's root-go.mod read be authoritative post-migration.
+  local kairos_ref="$1"
   local map_name="$2"
   local content
-  content="$(get_file_content "$KAIROS_INIT_SLUG" "$init_ref" "Makefile")" || return 1
+  local pre_migration=0
+  content="$(get_file_content "$KAIROS_SLUG" "$kairos_ref" "kairos-init/Makefile")" || {
+    local init_ref
+    init_ref="$(resolve_pre_migration_init_ref "$kairos_ref")" || return 1
+    content="$(get_file_content "$KAIROS_INIT_SLUG" "$init_ref" "Makefile")" || return 1
+    pre_migration=1
+  }
 
   local line value
   while IFS= read -r line; do
     case "$line" in
-      "AGENT_VERSION :="*) value="${line#AGENT_VERSION := }"; set_assoc_entry "$map_name" "kairos-agent" "$value" ;;
-      "IMMUCORE_VERSION :="*) value="${line#IMMUCORE_VERSION := }"; set_assoc_entry "$map_name" "immucore" "$value" ;;
-      "KCRYPT_DISCOVERY_CHALLENGER_VERSION :="*) value="${line#KCRYPT_DISCOVERY_CHALLENGER_VERSION := }"; set_assoc_entry "$map_name" "kcrypt-discovery-challenger" "$value" ;;
       "PROVIDER_KAIROS_VERSION :="*) value="${line#PROVIDER_KAIROS_VERSION := }"; set_assoc_entry "$map_name" "provider-kairos" "$value" ;;
-      "EDGEVPN_VERSION :="*) value="${line#EDGEVPN_VERSION := }"; set_assoc_entry "$map_name" "edgevpn" "$value" ;;
+      "EDGEVPN_VERSION :="*)
+        if [[ "$pre_migration" -eq 1 ]]; then
+          value="${line#EDGEVPN_VERSION := }"; set_assoc_entry "$map_name" "edgevpn" "$value"
+        fi
+        ;;
     esac
   done <<<"$content"
 }
 
 load_gomod_versions() {
-  local init_ref="$1"
+  # Reads the monorepo's own root go.mod post-migration (there is no more
+  # separate kairos-init go.mod -- it was folded into this one module).
+  # This is also now the live source for edgevpn's pin, which used to be
+  # read from kairos-init's Makefile and had already drifted from go.mod's
+  # actual resolved version by the time this was fixed. Falls back to the
+  # archived kairos-init repo's go.mod for a pre-migration ref, same as
+  # load_makefile_versions above.
+  local kairos_ref="$1"
   local map_name="$2"
   local content
-  content="$(get_file_content "$KAIROS_INIT_SLUG" "$init_ref" "go.mod")" || return 1
+  content="$(get_file_content "$KAIROS_SLUG" "$kairos_ref" "go.mod")" || {
+    local init_ref
+    init_ref="$(resolve_pre_migration_init_ref "$kairos_ref")" || return 1
+    content="$(get_file_content "$KAIROS_INIT_SLUG" "$init_ref" "go.mod")" || return 1
+  }
 
   local line module owner version rest component
   while IFS= read -r line; do
@@ -228,6 +279,85 @@ section_title_for_component() {
     immucore) printf 'Immucore' ;;
     *) printf '%s' "$component" ;;
   esac
+}
+
+# Same shape as collect_changes_gh, but for a component whose source is a
+# path within a monorepo rather than its own repository: every commit in
+# the range is inspected (via its PR's file list, or the commit's own file
+# list when it has no PR) and kept only if it actually touched path_prefix.
+collect_changes_gh_path() {
+  local slug="$1"
+  local from_ref="$2"
+  local to_ref="$3"
+  local path_prefix="$4"
+
+  local commit_lines
+  commit_lines="$(gh api "repos/${slug}/compare/${from_ref}...${to_ref}" --paginate --jq '.commits[]? | "\(.sha)|\(.commit.message|split("\n")[0])|\(.commit.author.name // "")|\(.author.login // "")|\(.commit.author.email // "")"' 2>/dev/null || true)"
+  [[ -z "$commit_lines" ]] && return 0
+
+  declare -A seen_pr=()
+  declare -A pr_touches=()
+  local line sha subject author_name author_login author_email
+  local pr_line pr_number pr_title pr_author commit_author short_sha pr_ref touched
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    IFS='|' read -r sha subject author_name author_login author_email <<<"$line"
+
+    pr_line="$(gh api -H 'Accept: application/vnd.github+json' "repos/${slug}/commits/${sha}/pulls" --jq '.[0] | select(.) | "\(.number)|\(.title)|\(.user.login)"' 2>/dev/null || true)"
+    if [[ -n "$pr_line" ]]; then
+      IFS='|' read -r pr_number pr_title pr_author <<<"$pr_line"
+      if is_filtered_author "$pr_author"; then
+        continue
+      fi
+      if [[ -z "$pr_number" || -n "${seen_pr[$pr_number]:-}" ]]; then
+        continue
+      fi
+      seen_pr["$pr_number"]=1
+
+      if [[ -z "${pr_touches[$pr_number]:-}" ]]; then
+        touched="$(gh api "repos/${slug}/pulls/${pr_number}/files" --paginate --jq '.[].filename' 2>/dev/null | grep -c "^${path_prefix}" || true)"
+        pr_touches["$pr_number"]="${touched:-0}"
+      fi
+      [[ "${pr_touches[$pr_number]}" -gt 0 ]] || continue
+
+      pr_ref="[#${pr_number}](https://github.com/${slug}/pull/${pr_number})"
+      printf -- '- %s by @%s in %s\n' "$pr_title" "$pr_author" "$pr_ref"
+      continue
+    fi
+
+    touched="$(gh api "repos/${slug}/commits/${sha}" --jq '.files[]?.filename' 2>/dev/null | grep -c "^${path_prefix}" || true)"
+    [[ "${touched:-0}" -gt 0 ]] || continue
+
+    commit_author="$author_login"
+    if [[ -z "$commit_author" || "$commit_author" == "null" ]]; then
+      if [[ "$author_email" =~ ^([0-9]+\+)?([^@]+)@users\.noreply\.github\.com$ ]]; then
+        commit_author="${BASH_REMATCH[2]}"
+      else
+        commit_author="$(sanitize_author "$author_name")"
+      fi
+    fi
+
+    if is_filtered_author "$commit_author"; then
+      continue
+    fi
+
+    short_sha="${sha:0:7}"
+    printf -- '- %s by @%s in %s\n' "$subject" "$commit_author" "$short_sha"
+  done <<<"$commit_lines"
+}
+
+append_path_diff_section() {
+  local out_file="$1"
+  local component="$2"
+  local path_prefix="$3"
+
+  local heading
+  heading="$(section_title_for_component "$component") changes"
+
+  local changes
+  changes="$(collect_changes_gh_path "$KAIROS_SLUG" "$OLD_REF" "$NEW_REF" "$path_prefix")"
+  append_section_changes "$out_file" "$heading" "$changes"
 }
 
 append_section_changes() {
@@ -336,27 +466,15 @@ gh_ready || die "gh CLI is required and must be authenticated"
 ensure_ref_exists_gh "$KAIROS_SLUG" "$OLD_REF" || die "Ref not found in ${KAIROS_SLUG}: $OLD_REF"
 ensure_ref_exists_gh "$KAIROS_SLUG" "$NEW_REF" || die "Ref not found in ${KAIROS_SLUG}: $NEW_REF"
 
-OLD_INIT="$(extract_kairos_init_version "$OLD_REF" || true)"
-NEW_INIT="$(extract_kairos_init_version "$NEW_REF" || true)"
-[[ -n "$OLD_INIT" ]] || die "Could not determine KAIROS_INIT for $OLD_REF"
-[[ -n "$NEW_INIT" ]] || die "Could not determine KAIROS_INIT for $NEW_REF"
-
-ensure_ref_exists_gh "$KAIROS_INIT_SLUG" "$OLD_INIT" || die "kairos-init ref not found on GitHub: $OLD_INIT"
-ensure_ref_exists_gh "$KAIROS_INIT_SLUG" "$NEW_INIT" || die "kairos-init ref not found on GitHub: $NEW_INIT"
-
 declare -A old_deps=()
 declare -A new_deps=()
 
-load_makefile_versions "$OLD_INIT" old_deps || die "Unable to read Makefile at kairos-init ref $OLD_INIT"
-load_makefile_versions "$NEW_INIT" new_deps || die "Unable to read Makefile at kairos-init ref $NEW_INIT"
-load_gomod_versions "$OLD_INIT" old_deps || die "Unable to read go.mod at kairos-init ref $OLD_INIT"
-load_gomod_versions "$NEW_INIT" new_deps || die "Unable to read go.mod at kairos-init ref $NEW_INIT"
+load_makefile_versions "$OLD_REF" old_deps || die "Unable to read kairos-init/Makefile (post- or pre-migration) for ${KAIROS_SLUG}@${OLD_REF}"
+load_makefile_versions "$NEW_REF" new_deps || die "Unable to read kairos-init/Makefile (post- or pre-migration) for ${KAIROS_SLUG}@${NEW_REF}"
+load_gomod_versions "$OLD_REF" old_deps || die "Unable to read go.mod (post- or pre-migration) for ${KAIROS_SLUG}@${OLD_REF}"
+load_gomod_versions "$NEW_REF" new_deps || die "Unable to read go.mod (post- or pre-migration) for ${KAIROS_SLUG}@${NEW_REF}"
 
 declare -a fixed_components=(
-  immucore
-  kairos-agent
-  kairos-sdk
-  kcrypt-discovery-challenger
   provider-kairos
   edgevpn
   entities
@@ -373,6 +491,15 @@ for c in "${fixed_components[@]}"; do
   component_seen["$c"]=1
 done
 
+# Already handled by the path-diff loop above. The pre-migration go.mod
+# fallback in load_gomod_versions can still populate these into old_deps
+# when OLD_REF pre-dates the migration (that go.mod listed them as real
+# dependencies back then) -- excluded here so they don't also get a second,
+# stale, version-based section on top of their real path-diffed one.
+for c in "${!MONOREPO_PATHS[@]}"; do
+  component_seen["$c"]=1
+done
+
 for c in "${!old_deps[@]}" "${!new_deps[@]}"; do
   if [[ -z "${component_seen[$c]:-}" ]]; then
     all_components+=("$c")
@@ -384,16 +511,14 @@ output_tmp="$(mktemp)"
 trap 'rm -f "$output_tmp"' EXIT
 
 append_section_changes "$output_tmp" "Kairos changes" "$(collect_changes_gh "$KAIROS_SLUG" "$OLD_REF" "$NEW_REF")"
-init_changes="$(collect_changes_gh "$KAIROS_INIT_SLUG" "$OLD_INIT" "$NEW_INIT")"
 
-init_body="- Version: ${OLD_INIT} -> ${NEW_INIT}"
-if [[ -n "$init_changes" ]]; then
-  init_body+=$'\n'
-  init_body+="$init_changes"
-else
-  init_body+=$'\n- No changes'
-fi
-append_section_changes "$output_tmp" "kairos-init changes" "$init_body"
+# kairos-init, kairos-agent, immucore, kairos-sdk and kcrypt-discovery-challenger
+# are monorepo paths post-migration, diffed the same way "Kairos changes"
+# itself is (same repo, same OLD_REF/NEW_REF), not a separate version+repo.
+# Order matches the pre-migration output: kairos-init first, same as before.
+for component in kairos-init kairos-agent immucore kairos-sdk kcrypt-discovery-challenger; do
+  append_path_diff_section "$output_tmp" "$component" "${MONOREPO_PATHS[$component]}"
+done
 
 for component in "${all_components[@]}"; do
   append_component_section "$output_tmp" "$component" "${old_deps[$component]:-}" "${new_deps[$component]:-}"
@@ -403,7 +528,6 @@ if [[ -n "$OUTPUT_FILE" ]]; then
   cp "$output_tmp" "$OUTPUT_FILE"
   printf 'Release notes written to %s\n' "$OUTPUT_FILE"
   printf 'Compared Kairos: %s -> %s\n' "$OLD_REF" "$NEW_REF"
-  printf 'Resolved kairos-init: %s -> %s\n' "$OLD_INIT" "$NEW_INIT"
 else
   cat "$output_tmp"
 fi


### PR DESCRIPTION
🤖 Opened by `mauro-agent`, an AI agent operated by `@mauromorales`. He asked for this directly, after noticing the components below moved into this repo. He has not reviewed this specific text yet. If you want a human, feel free to ping him directly.

## What this fixes

`scripts/kairos-diff.sh` (which `.github/workflows/release-notes-diff.yaml` runs on every release, most recently extended by #4436) generates the per-component changelog sections in release notes. Five components it treats as separate external repos with their own version to diff were archived and merged into this monorepo on 2026-08-19/21: kairos-init, kairos-agent, immucore, kairos-sdk, kcrypt-discovery-challenger.

Concretely, the script read their pinned versions from kairos-init's own Makefile/go.mod, both of which are now frozen at their pre-archival state, since kairos-init stopped being tagged once its source moved in-tree. Left unfixed, every release from here on would have shown "No changes" for all five components, even as real development kept happening in their monorepo paths.

## What changed

- kairos-init, kairos-agent, immucore, kairos-sdk and kcrypt-discovery-challenger are now diffed by path within this repo itself (same two refs as the "Kairos changes" section), not against a separate repo or a frozen version pin.
- provider-kairos and edgevpn (still real external/go.mod dependencies) are now read from this repo's own kairos-init/Makefile and root go.mod post-migration, falling back to the archived kairos-init repo only for a ref that pre-dates the migration, needed for the one release that straddles it (the next one).
- Real drift caught along the way: kairos-init's Makefile pinned EDGEVPN_VERSION at v0.35.4 while the resolved go.mod dependency was already v0.35.3. go.mod is now authoritative post-migration; the Makefile value is used only as the pre-migration fallback, where it was the only place that version ever lived (it was never in kairos-init's go.mod).

## Testing

Verified directly against the real repo: version resolution for both the post-migration and pre-migration-fallback code paths, and path-based commit attribution against the real 2026-08-19/21 migration commit (correctly attributed, and correctly returned nothing for an unrelated path). The full v4.2.0..master range is too large to run end-to-end in a reasonable time from here; recommend a workflow_dispatch dry run against a recent tag pair before the next real release depends on this.

Refs #4242, #4243. A separate issue explains the underlying problem for anyone who hits it from a different angle.

## Review round (itxaka-agent)

Addressed all 7 inline findings (3 blocking, 4 non-blocking), see the thread replies for detail per finding. Two worth calling out here:

- provider-kairos was missing from the monorepo-path treatment above (same absorption, same frozen-pin bug) -- moved it in alongside the other five.
- A release range that straddles the migration (the very next one) was silently dropping every pre-migration change for these components. Fixed, and verified live: `v4.2.0 -> v4.3.0` now correctly surfaces a real kairos-agent v2.31.3 -> v2.31.4 change that the unfixed script dropped.
- Widening the go.mod read (to make provider-kairos/edgevpn resolution work) also pulled in every transitive ("// indirect") dependency as its own section. Filtered those out, but two genuinely new direct dependencies will still appear the first time this runs against a real release: `go-nodepair` and `tpm-helpers`.

Also restructured the path-diff walk into a single pass instead of one per component, to stay well inside the workflow's GitHub API rate limit on a large release range.


## Rebased on master (#4512)

Master picked up an independent, more thorough fix for this same file while this PR was open ([#4512](https://github.com/kairos-io/kairos/pull/4512)): per-component migration-regime detection plus git-log reads instead of API calls, which supersedes this branch's fix for the review's three blocking findings. Took master's version as the base and kept only the two things it didn't already cover: kcrypt-discovery-challenger's subpath was widened back down to exclude kcrypt-challenger (a separate component sharing the `kcrypt/` tree), and the go.mod read still needed the `// indirect` filter to avoid reporting transitive dependencies as new sections.
