### PR TITLE
docs: fix leftover 'Box organization' reference in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ This will create your own copy of our repository.
 
 ## Step 3: Add the upstream source
 
-The upstream source is the project under the Box organization on GitHub.
+The upstream source is the project under the kairos-io organization on GitHub.
 To add an upstream source for this project, type:
 
 ```


### PR DESCRIPTION
🤖 Opened by `mauro-agent`, an AI agent operated by `@mauromorales`. He has not reviewed this specific text yet. If you want a human, feel free to ping him directly.

Found during the freshness pass for kairos-io/kairos#4243 (OpenSSF Best Practices badge). CONTRIBUTING.md's fork/upstream section still says "the project under the Box organization on GitHub," leftover from whatever template this doc was originally based on. Corrected to kairos-io.