### PR TITLE
ci: make yamllint strict for the OpenSSF warnings_strict criterion

### DIFF
--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -17,13 +17,13 @@ jobs:
           - "ubuntu-non-hwe"
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
         with:
           driver-opts: network=host
       - name: Build Dockerfile
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           file: examples/builds/${{ matrix.example-dir }}/Dockerfile
           context: examples/builds/${{ matrix.example-dir }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -468,11 +468,11 @@ jobs:
       # behind the authorize gate, so pulling the PR ref here is the same
       # vetted-ref deal the rest of the workflow makes.
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/head
       - name: Download PR ISOs
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: "kairos-hadron-*-amd64-generic.iso.zip"
           path: candidate

--- a/.github/workflows/release-notes-diff.yaml
+++ b/.github/workflows/release-notes-diff.yaml
@@ -25,7 +25,7 @@ jobs:
       CURRENT_TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Check for CVEs in standard k3s/k0s images
         id: cve-check

--- a/.github/workflows/reusable-factory.yaml
+++ b/.github/workflows/reusable-factory.yaml
@@ -123,7 +123,11 @@ on:
       allow_insecure_registries:
         type: boolean
         default: false
-        description: "Allow auroraboot to pull container images from registries over plain HTTP or with untrusted/self-signed TLS certificates when generating artifacts (ISO/UKI/RAW). Useful on self-hosted runners that pull from a local or in-cluster registry (e.g. localhost:5000/...). Passed to auroraboot as --allow-insecure-registries, and as --set allow-insecure-registries=true for the RAW flow."
+        description: "Allow auroraboot to pull container images from registries over plain HTTP or
+          with untrusted/self-signed TLS certificates when generating artifacts (ISO/UKI/RAW).
+          Useful on self-hosted runners that pull from a local or in-cluster registry (e.g.
+          localhost:5000/...). Passed to auroraboot as --allow-insecure-registries, and as --set
+          allow-insecure-registries=true for the RAW flow."
 
       # Individual artifact types
       iso:
@@ -333,7 +337,9 @@ jobs:
       # of what next-*.yaml / _next-build-iso.yaml grant, and ghcr
       # returns "installation not allowed to Write organization package".
       packages: write
-    name: ${{ inputs.custom_job_name_format != '' && inputs.custom_job_name_format || format('{0}-{1}-{2}-{3}{4}{5}', inputs.base_image, (inputs.kubernetes_distro != '' && 'standard' || 'core'), inputs.arch, inputs.model, (inputs.kubernetes_distro != '' && format('-{0}', inputs.kubernetes_distro) || ''), (inputs.trusted_boot && '-uki' || '')) }}
+    name: "${{ inputs.custom_job_name_format != '' && inputs.custom_job_name_format || format('{0}-{1}-{2}-{3}{4}{5}',
+      inputs.base_image, (inputs.kubernetes_distro != '' && 'standard' || 'core'), inputs.arch, inputs.model,
+      (inputs.kubernetes_distro != '' && format('-{0}', inputs.kubernetes_distro) || ''), (inputs.trusted_boot && '-uki' || '')) }}"
     runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     steps:
       - name: Release space from worker
@@ -378,7 +384,7 @@ jobs:
           sudo rm -rfv build || true
           df -h
       - name: Checkout source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: '0'
           # Empty is actions/checkout's own default, so unset behaves exactly as
@@ -752,7 +758,7 @@ jobs:
       - name: Run Grype security scan
         if: inputs.grype
         id: grype
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         with:
           image: ${{ steps.setup.outputs.image_tag }}
           output-format: json
@@ -793,7 +799,7 @@ jobs:
       - name: Run Trivy security scan
         if: inputs.trivy
         id: trivy-scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ${{ steps.setup.outputs.image_tag }}
           format: json
@@ -902,7 +908,7 @@ jobs:
 
       - name: Run Trivy SARIF scan
         if: inputs.trivy_sarif
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           image-ref: ${{ steps.setup.outputs.image_tag }}
           format: sarif
@@ -913,7 +919,7 @@ jobs:
 
       - name: Generate Grype SARIF
         if: inputs.grype_sarif
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
         with:
           image: ${{ steps.setup.outputs.image_tag }}
           output-format: sarif
@@ -926,7 +932,7 @@ jobs:
 
       - name: Filter Grype SARIF to critical
         if: inputs.grype_sarif
-        uses: itxaka/sarif-filter@e5315c19bd49c5a4ad76310a2640b2586247d433 # v1
+        uses: itxaka/sarif-filter@e5315c19bd49c5a4ad76310a2640b2586247d433  # v1
         with:
           input: grype.sarif
           output: grype.sarif
@@ -934,7 +940,7 @@ jobs:
 
       - name: Filter Trivy SARIF to critical
         if: inputs.trivy_sarif
-        uses: itxaka/sarif-filter@e5315c19bd49c5a4ad76310a2640b2586247d433 # v1
+        uses: itxaka/sarif-filter@e5315c19bd49c5a4ad76310a2640b2586247d433  # v1
         with:
           input: trivy.sarif
           output: trivy.sarif
@@ -942,14 +948,14 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: inputs.trivy_sarif
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4
         with:
           sarif_file: 'trivy.sarif'
           category: ${{ steps.setup.outputs.flavor }}-${{ steps.setup.outputs.flavor_release }}-${{ steps.setup.outputs.variant }}-${{ inputs.arch }}-${{ inputs.model }}${{ inputs.trusted_boot && '-uki' || '' }}
 
       - name: Upload Grype scan results to GitHub Security tab
         if: inputs.grype_sarif
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4
         with:
           sarif_file: 'grype.sarif'
           category: ${{ steps.setup.outputs.flavor }}-${{ steps.setup.outputs.flavor_release }}-${{ steps.setup.outputs.variant }}-${{ inputs.arch }}-${{ inputs.model }}${{ inputs.trusted_boot && '-uki' || '' }}

--- a/.github/workflows/reusable-linting.yaml
+++ b/.github/workflows/reusable-linting.yaml
@@ -108,4 +108,4 @@ jobs:
           allow-unsafe-pr-checkout: ${{ inputs.caller-vetted-ref }}
       - name: yamllint
         shell: bash
-        run: find ${{ inputs.yamldirs }} -path "./examples" -prune -o -name "*.yml" -or -name "*.yaml" -print  | xargs -r -n1 docker run -v "$PWD":/work -w /work cytopia/yamllint
+        run: find ${{ inputs.yamldirs }} -path "./examples" -prune -o -name "*.yml" -or -name "*.yaml" -print  | xargs -r -n1 docker run -v "$PWD":/work -w /work cytopia/yamllint --strict

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -158,13 +158,13 @@ jobs:
           echo "Flavor Release: $FLAVOR_RELEASE"
           echo "Flavor Release Latest: $FLAVOR_RELEASE_LATEST"
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
           allow-unsafe-pr-checkout: ${{ inputs.caller-vetted-ref }}
       - name: Install Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         timeout-minutes: 5
         with:
           go-version-file: tests/go.mod
@@ -172,12 +172,12 @@ jobs:
           cache: ${{ runner.environment == 'self-hosted' && 'false' || 'true' }}
       - name: Set up Docker Buildx for public runners
         if: runner.environment == 'github-hosted'
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
         with:
           driver-opts: network=host
       - name: Set up Docker Buildx for custom runners
         if: runner.environment == 'self-hosted'
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
         with:
           driver-opts: network=host
           buildkitd-config-inline: |
@@ -197,7 +197,7 @@ jobs:
         # not at ci-temp-images, so IMAGE_NAME pulls from ghcr
         # inside the VM and needs no CI-level quay creds either.
         if: inputs.test == 'bundles'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -271,18 +271,20 @@ jobs:
           echo "IMAGE_NAME=${PREFIX}:${FLAVOR}-${FLAVOR_RELEASE}-${VARIANT}-${ARCH}-${MODEL}-${SHA}" >> "$GITHUB_ENV"
       - name: Download artifacts
         if: ${{ inputs.test != 'upgrade-latest-with-cli' && inputs.test != 'provider-upgrade-latest-k8s-with-kubernetes' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: kairos-${{ steps.split.outputs.flavor }}-${{ steps.split.outputs.flavor_release }}-${{ inputs.variant }}-${{ inputs.arch }}-${{ inputs.model }}.iso.zip
       - name: Download latest release
-        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
+        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
         if: ${{ (inputs.test == 'upgrade-latest-with-cli' || inputs.test == 'provider-upgrade-latest-k8s-with-kubernetes') && inputs.release-matcher == '' }}
         with:
           latest: true
-          fileName: kairos-${{ steps.split.outputs.flavor }}-${{ steps.split.outputs.flavor_release_latest }}-${{ inputs.test == 'provider-upgrade-latest-k8s-with-kubernetes' && 'standard' || 'core'}}-${{ inputs.arch }}-${{ inputs.model }}-*${{ inputs.test == 'provider-upgrade-latest-k8s-with-kubernetes' && 'k3sv*' || ''}}.iso
+          fileName: "kairos-${{ steps.split.outputs.flavor }}-${{ steps.split.outputs.flavor_release_latest }}-${{
+            inputs.test == 'provider-upgrade-latest-k8s-with-kubernetes' && 'standard' || 'core'}}-${{ inputs.arch }}-${{
+            inputs.model }}-*${{ inputs.test == 'provider-upgrade-latest-k8s-with-kubernetes' && 'k3sv*' || ''}}.iso"
           out-file-path: ""
       - name: Download latest release with release matcher
-        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f # v1.13
+        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
         if: ${{ (inputs.test == 'upgrade-latest-with-cli' || inputs.test == 'provider-upgrade-latest-k8s-with-kubernetes') && inputs.release-matcher != '' }}
         with:
           latest: true
@@ -290,7 +292,7 @@ jobs:
           out-file-path: ""
       - name: Prepare test bundle
         if: ${{ inputs.test == 'bundles' }}
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           file: examples/bundle/Dockerfile
@@ -332,7 +334,7 @@ jobs:
           # Pick a k3s image
           export ISO=$PWD/$(ls *.iso|grep -v ipxe | grep k3s | head -1 )
           .github/encryption-tests.sh
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: failure()
         with:
           name: ${{ steps.split.outputs.flavor }}-${{ steps.split.outputs.flavor_release }}-${{ inputs.variant }}-${{ inputs.test }}.logs.zip

--- a/.github/workflows/scorecards.yaml
+++ b/.github/workflows/scorecards.yaml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc  # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -42,7 +42,7 @@ jobs:
       # uploads of run results in SARIF format to the repository Actions tab.
       # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
       - name: "Upload artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93  # v11.0.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 10 days.'

--- a/.github/workflows/upload-cloud-images.yaml
+++ b/.github/workflows/upload-cloud-images.yaml
@@ -33,7 +33,7 @@ jobs:
       id-token: write
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           # workflow_run's default checkout context is this repo's default
@@ -46,13 +46,13 @@ jobs:
       # https://github.com/google-github-actions/auth/blob/main/docs/EXAMPLES.md#service-account-key-json
       - id: "auth"
         name: "Authenticate to GCP"
-        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # v3
+        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093'  # v3
         with:
           create_credentials_file: true
           workload_identity_provider: 'projects/908384205599/locations/global/workloadIdentityPools/github/providers/kairos'
           service_account: 'github-service-account@palette-kairos.iam.gserviceaccount.com'
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db' # v3
+        uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db'  # v3
       - name: Install deps
         run: |
           sudo apt update && sudo apt install -y qemu-utils gdisk
@@ -130,7 +130,7 @@ jobs:
       id-token: write
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
@@ -138,7 +138,7 @@ jobs:
           git fetch --prune --unshallow
       # https://github.com/aws-actions/configure-aws-credentials?tab=readme-ov-file#assumerole-with-static-iam-credentials-in-repository-secrets
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6
         with:
           audience: sts.amazonaws.com
           aws-region: eu-central-1
@@ -202,7 +202,7 @@ jobs:
       shouldBuild: ${{ steps.checkPushed.outputs.shouldBuild }}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
@@ -210,7 +210,7 @@ jobs:
           git fetch --prune --unshallow
       # https://github.com/Azure/login?tab=readme-ov-file#azure-login-action
       - name: Azure login
-        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca  # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -267,7 +267,7 @@ jobs:
               --set "state_dir=/aurora"
 
       - name: Azure CLI script
-        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52  # v3
         if: ${{ steps.checkPushed.outputs.shouldBuild == 'true' }}
         env:
           GCP_PROJECT: palette-kairos


### PR DESCRIPTION
🤖 Opened by `mauro-agent`, an AI agent operated by `@mauromorales`, continuing work he directed on kairos-io/kairos#4243. He has not reviewed this specific text yet. If you want a human, feel free to ping him directly.

kairos-io/kairos#4243 (OpenSSF Best Practices badge): `warnings_strict` is SUGGESTED, and the honest answer as things stood was Unmet, because yamllint's line-length rule is downgraded to warning in `.yamllint` and CI never passed `--strict`, so yamllint's own warnings never failed the build (unlike golangci-lint, hadolint, and shellcheck, which already fail on every finding).

Fixed the ~37 comment-spacing warnings and 3 over-length lines this surfaces in `.github/workflows/` (the only directory yamllint actually lints), then added `--strict` to the yamllint step. Each over-length line was folded at an existing space inside the value, verified to reproduce the exact original string byte for byte, not rewritten.

Verified clean: running the exact CI command locally exits 0 with `--strict` on.