### PR TITLE
:bug: fix blank post-install action after Customize Further

### DIFF
--- a/installer/internal/tui/TUIinstallOptionsPage.go
+++ b/installer/internal/tui/TUIinstallOptionsPage.go
@@ -59,11 +59,12 @@ func (p *installOptionsPage) Update(msg tea.Msg) (Page, tea.Cmd) {
 				p.afterInstallIdx++
 			}
 		case "enter":
+			// Save the selected after-install action for either path, so it
+			// survives a detour through the customization page.
+			mainModel.finishAction = p.afterInstallOpts[p.afterInstallIdx]
 			if p.cursor == 0 {
 				// Start Install - store after install action in Model.extraFields
 				return p, func() tea.Msg {
-					// Set the finish action in the main model
-					mainModel.finishAction = p.afterInstallOpts[p.afterInstallIdx]
 					return GoToPageMsg{PageID: "summary"}
 				}
 			} else {

--- a/installer/internal/tui/TUIinstallOptionsPage_internal_test.go
+++ b/installer/internal/tui/TUIinstallOptionsPage_internal_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	sdkLogger "github.com/kairos-io/kairos/v4/sdk/types/logger"
+)
+
+// TestIssue4412_CustomizeFurtherKeepsDefaultFinishAction reproduces the
+// reported bug: choosing "Customize Further" with the default after-install
+// action selected used to leave mainModel.finishAction empty because only
+// the "Start Install" branch set it. See kairos-io/kairos#4412.
+func TestIssue4412_CustomizeFurtherKeepsDefaultFinishAction(t *testing.T) {
+	logger := sdkLogger.NewKairosLogger("installer-test", "info", true)
+	mainModel = InitialModel(&logger, "")
+
+	p := newInstallOptionsPage()
+	p.cursor = 1 // "Customize Further"
+	if _, cmd := p.Update(tea.KeyMsg{Type: tea.KeyEnter}); cmd != nil {
+		cmd()
+	}
+	if mainModel.finishAction != "nothing" {
+		t.Fatalf("expected finishAction to default to %q, got %q", "nothing", mainModel.finishAction)
+	}
+}
+
+// TestIssue4412_CustomizeFurtherPreservesSelectedFinishAction ensures a
+// reboot/poweroff choice made before "Customize Further" survives the detour
+// through the customization pages.
+func TestIssue4412_CustomizeFurtherPreservesSelectedFinishAction(t *testing.T) {
+	logger := sdkLogger.NewKairosLogger("installer-test", "info", true)
+	mainModel = InitialModel(&logger, "")
+
+	p := newInstallOptionsPage()
+	p.afterInstallIdx = 1 // "reboot"
+	p.cursor = 1          // "Customize Further"
+	if _, cmd := p.Update(tea.KeyMsg{Type: tea.KeyEnter}); cmd != nil {
+		cmd()
+	}
+	if mainModel.finishAction != "reboot" {
+		t.Fatalf("expected finishAction to remain %q, got %q", "reboot", mainModel.finishAction)
+	}
+}
+
+// TestIssue4412_CompletedInstallHelpNeverBlank guarantees the completed
+// install page never renders the blank "System will  shortly" message that
+// resulted from an empty finishAction reaching the page, and that a key
+// press still exits in that case.
+func TestIssue4412_CompletedInstallHelpNeverBlank(t *testing.T) {
+	for _, finishAction := range []string{"nothing", "", "bogus"} {
+		t.Run(finishAction, func(t *testing.T) {
+			logger := sdkLogger.NewKairosLogger("installer-test", "info", true)
+			mainModel = InitialModel(&logger, "")
+			mainModel.finishAction = finishAction
+			mainModel.currentPageID = "install_process"
+
+			ip := findInstallProcessPage(t)
+			ip.progress = len(ip.steps) - 1
+
+			help := ip.Help()
+			if strings.Contains(help, "System will  ") || strings.TrimSpace(help) == "System will" {
+				t.Fatalf("Help() rendered a blank action for finishAction=%q: %q", finishAction, help)
+			}
+			if help != "Press any key to exit" {
+				t.Fatalf("expected the safe-fallback exit prompt for finishAction=%q, got %q", finishAction, help)
+			}
+
+			_, cmd := mainModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+			if cmd == nil {
+				t.Fatalf("expected a key press to quit for finishAction=%q", finishAction)
+			}
+			if _, ok := cmd().(tea.QuitMsg); !ok {
+				t.Fatalf("expected tea.QuitMsg for finishAction=%q", finishAction)
+			}
+		})
+	}
+}
+
+// TestIssue4412_CompletedInstallBlocksKeysForRebootPoweroff keeps the
+// existing behavior intact: once the install completes with a real
+// reboot/poweroff action selected, key presses must not exit the TUI early
+// (the agent process handles the reboot/poweroff itself).
+func TestIssue4412_CompletedInstallBlocksKeysForRebootPoweroff(t *testing.T) {
+	logger := sdkLogger.NewKairosLogger("installer-test", "info", true)
+	mainModel = InitialModel(&logger, "")
+	mainModel.finishAction = "reboot"
+	mainModel.currentPageID = "install_process"
+
+	ip := findInstallProcessPage(t)
+	ip.progress = len(ip.steps) - 1
+
+	if help := ip.Help(); help != "System will reboot shortly" {
+		t.Fatalf("expected reboot help text, got %q", help)
+	}
+
+	_, cmd := mainModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd != nil {
+		t.Fatalf("expected no cmd (keys blocked) while reboot is pending, got one")
+	}
+}
+
+func findInstallProcessPage(t *testing.T) *installProcessPage {
+	t.Helper()
+	for _, p := range mainModel.pages {
+		if ip, ok := p.(*installProcessPage); ok {
+			return ip
+		}
+	}
+	t.Fatal("install_process page not found in mainModel.pages")
+	return nil
+}

--- a/installer/internal/tui/TUImodel.go
+++ b/installer/internal/tui/TUImodel.go
@@ -53,6 +53,19 @@ type Model struct {
 
 var mainModel Model
 
+// normalizedFinishAction returns mainModel.finishAction if it is one of the
+// known post-install actions, and "nothing" otherwise. This keeps the
+// completed install page from rendering a blank action if an unexpected
+// value ever reaches it.
+func normalizedFinishAction() string {
+	switch mainModel.finishAction {
+	case "reboot", "poweroff":
+		return mainModel.finishAction
+	default:
+		return "nothing"
+	}
+}
+
 // InitialModel Initialize the application
 func InitialModel(l *sdkLogger.KairosLogger, source string) Model {
 	// First create the model with the logger in case any page needs to log something
@@ -61,6 +74,7 @@ func InitialModel(l *sdkLogger.KairosLogger, source string) Model {
 		title:           DefaultTitleInteractiveInstaller(),
 		source:          source,
 		log:             l,
+		finishAction:    "nothing",
 	}
 	mainModel.pages = []Page{
 		newPrerequisitesPage(),
@@ -120,14 +134,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Hijack all keys if on install process page
 	if installPage, ok := mainModel.pages[currentIdx].(*installProcessPage); ok {
 		// If install failed or finished, any key exits, no abort modal
-		if installPage.errorMsg != "" || installPage.progress >= len(installPage.steps)-1 && mainModel.finishAction == "nothing" {
+		if installPage.errorMsg != "" || installPage.progress >= len(installPage.steps)-1 && normalizedFinishAction() == "nothing" {
 			mainModel.showAbortConfirm = false // Ensure abort modal is closed
 			if _, isKey := msg.(tea.KeyMsg); isKey {
 				return mainModel, tea.Quit
 			}
 		}
 		// If install finished with no errors and reboot/poweroff selected, block all keys so we dont block the action
-		if installPage.errorMsg == "" && installPage.progress >= len(installPage.steps)-1 && (mainModel.finishAction == "reboot" || mainModel.finishAction == "poweroff") {
+		if installPage.errorMsg == "" && installPage.progress >= len(installPage.steps)-1 && normalizedFinishAction() != "nothing" {
 			return mainModel, nil
 		}
 		if mainModel.showAbortConfirm {

--- a/installer/internal/tui/install_process_page.go
+++ b/installer/internal/tui/install_process_page.go
@@ -198,7 +198,7 @@ func (p *installProcessPage) View() string {
 		s += "\n" + warning
 	} else {
 		text := "Installation completed successfully!\n"
-		if mainModel.finishAction == "nothing" {
+		if normalizedFinishAction() == "nothing" {
 			text += "You can now reboot or shut down your system."
 		}
 		s += "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("#00FF00")).Bold(true).Render(text)
@@ -210,10 +210,11 @@ func (p *installProcessPage) Title() string { return "Installing" }
 
 func (p *installProcessPage) Help() string {
 	if p.progress >= len(p.steps)-1 || p.errorMsg != "" {
-		if mainModel.finishAction == "nothing" {
+		action := normalizedFinishAction()
+		if action == "nothing" {
 			return "Press any key to exit"
 		}
-		return "System will " + mainModel.finishAction + " shortly"
+		return "System will " + action + " shortly"
 	}
 	return "Installation in progress - Use ctrl+c to abort"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a confusing/misleading completion screen in the interactive installer TUI. Choosing "Customize Further" on the install-options page (instead of "Start Install" directly) left `Model.finishAction` at its zero value `""`, because only the "Start Install" branch set it. On the completed install page this rendered the literal `System will  shortly` (a blank action, matching the reported symptom exactly), and it silently discarded any reboot/poweroff choice the user made before customizing.

Before this fix, `ctrl+c`/`q` still exited the installer via the generic key handler further down in `Model.Update`, so this was not a true hang — but the completion screen was confusing and the user's post-install action selection was dropped.

Fix:
- Initialize `finishAction` to `"nothing"` in `InitialModel`.
- Set `finishAction` unconditionally in the install-options `"enter"` handler, before branching into "Start Install" or "Customize Further", so a reboot/poweroff choice survives the customization detour.
- Added `normalizedFinishAction()` so the completed install page's help/view text and the key-hijack logic in `Model.Update` treat any non-`"reboot"`/`"poweroff"` value as `"nothing"`, instead of rendering it verbatim.

The `kairos-agent manual-install` contract (`--reboot`/`--poweroff` flags, and `install.reboot`/`install.poweroff` in the generated cloud-config) is unchanged — `finishAction` is now always a valid value by the time it reaches those call sites.

**Validation**: Added `installer/internal/tui/TUIinstallOptionsPage_internal_test.go`. Confirmed the tests reproduce the bug by stashing the fix and running `go test ./installer/internal/tui/... -run TestIssue4412 -v`: 3 of 4 new tests failed against the pre-fix code with the exact reported symptom (`System will  shortly`); after restoring the fix all pass. Also ran `go build ./installer/...`, `go vet ./installer/...`, `go test ./installer/...` (all pass), and `golangci-lint run ./installer/internal/tui/...` (9 pre-existing findings, none introduced by this diff). Full-repo `go test ./...` has pre-existing macOS-only failures unrelated to this change (Docker-dependent `sdk/sysext` tests, a Linux-only `sdk/kcrypt` build, and a Linux-path-regex `sdk/collector` test) — none touch `installer/internal/tui`.

Note: this repo's PR pipeline runs under `pull_request_target` with a maintainer-reviewed `fork-pr-builds` environment gate for fork PRs — checks may show as waiting until a maintainer approves the run.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4412
Closes #3822