### PR TITLE
:bug: reject unsigned dm-verity sysext/confext merges under Trusted Boot

### DIFF
--- a/immucore/internal/constants/constants.go
+++ b/immucore/internal/constants/constants.go
@@ -173,6 +173,6 @@ const (
 	DestSysExtDir                   = "/run/extensions"
 	DestConfExtDir                  = "/run/confexts"
 	VerityCertDir                   = "/run/verity.d/"
-	SysextDefaultPolicy             = "--image-policy=\"root=verity+signed+absent:usr=verity+signed+absent\""
+	SysextDefaultPolicy             = "--image-policy=\"root=signed+absent:usr=signed+absent\""
 	EfiDir                          = "/efi"
 )

--- a/kairos-init/pkg/bundled/cloudconfigs/99_sysext.yaml
+++ b/kairos-init/pkg/bundled/cloudconfigs/99_sysext.yaml
@@ -28,9 +28,9 @@ stages:
             TimeoutStartSec=10
             # override exec and reload to set the image policy
             ExecStart=
-            ExecStart=systemd-sysext refresh --image-policy="root=verity+signed+absent:usr=verity+signed+absent"
+            ExecStart=systemd-sysext refresh --image-policy="root=signed+absent:usr=signed+absent"
             ExecReload=
-            ExecReload=systemd-sysext refresh --image-policy="root=verity+signed+absent:usr=verity+signed+absent"
+            ExecReload=systemd-sysext refresh --image-policy="root=signed+absent:usr=signed+absent"
             # set the sysext hierarchies so we dont overwrite our mount at /usr/local
             # set them very specifically instead of a generic /usr/local as systemd <= 255 mounts the overlay as RO
             # and we dont want the full /usr/local to be RO as we store state in there
@@ -49,9 +49,9 @@ stages:
             TimeoutStartSec=10
             # override exec and reload to set the image policy
             ExecStart=
-            ExecStart=systemd-confext refresh --image-policy="root=verity+signed+absent:usr=verity+signed+absent"
+            ExecStart=systemd-confext refresh --image-policy="root=signed+absent:usr=signed+absent"
             ExecReload=
-            ExecReload=systemd-confext refresh --image-policy="root=verity+signed+absent:usr=verity+signed+absent"
+            ExecReload=systemd-confext refresh --image-policy="root=signed+absent:usr=signed+absent"
             [Unit]
             # Make it timeout early to avoid blocking boot if keys are not in there to unlock sysext
             JobRunningTimeoutSec=5

--- a/kairos-init/pkg/validation/cloudconfigs_sysext_policy_test.go
+++ b/kairos-init/pkg/validation/cloudconfigs_sysext_policy_test.go
@@ -1,0 +1,62 @@
+package validation_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	sysextPathRe  = regexp.MustCompile(`^\s+- path: (\S+)`)
+	imagePolicyRe = regexp.MustCompile(`--image-policy="([^"]+)"`)
+)
+
+var _ = Describe("Bundled sysext cloudconfig image policy", func() {
+	It("requires a valid signature under Trusted Boot (UKI) instead of falling back to unsigned verity", func() {
+		content, err := os.ReadFile(filepath.Join("..", "bundled", "cloudconfigs", "99_sysext.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Track which drop-in file each --image-policy value belongs to, since
+		// the UKI and non-UKI drop-ins intentionally use different policies.
+		var currentPath string
+		found := map[string][]string{}
+		for _, line := range strings.Split(string(content), "\n") {
+			if m := sysextPathRe.FindStringSubmatch(line); m != nil {
+				currentPath = m[1]
+			}
+			if m := imagePolicyRe.FindStringSubmatch(line); m != nil {
+				found[currentPath] = append(found[currentPath], m[1])
+			}
+		}
+
+		ukiDropIns := []string{
+			"/etc/systemd/system/systemd-sysext.service.d/kairos-uki.conf",
+			"/etc/systemd/system/systemd-confext.service.d/kairos-uki.conf",
+		}
+		for _, path := range ukiDropIns {
+			Expect(found[path]).NotTo(BeEmpty(), "expected --image-policy occurrences in %s", path)
+			for _, policy := range found[path] {
+				// A bare "verity" alternative (without "signed") lets systemd
+				// fall back to unsigned dm-verity when signature checking
+				// fails, contradicting the Trusted Boot docs which promise
+				// only signed+verity sysexts are accepted.
+				Expect(policy).To(Equal(`root=signed+absent:usr=signed+absent`), path)
+			}
+		}
+
+		nonUkiDropIns := []string{
+			"/etc/systemd/system/systemd-sysext.service.d/kairos.conf",
+			"/etc/systemd/system/systemd-confext.service.d/kairos.conf",
+		}
+		for _, path := range nonUkiDropIns {
+			Expect(found[path]).NotTo(BeEmpty(), "expected --image-policy occurrences in %s", path)
+			for _, policy := range found[path] {
+				Expect(policy).To(Equal(`root=verity+absent:usr=verity+absent`), path)
+			}
+		}
+	})
+})


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

On a UKI (Trusted Boot) Kairos host, `systemd-sysext`/`systemd-confext` are configured with
`--image-policy="root=verity+signed+absent:usr=verity+signed+absent"`. Per `systemd.image-policy(7)`,
`+` separates *acceptable alternatives*, so this policy actually accepts signed-verity **or**
unsigned-verity **or** absent. When signature verification fails (`-ENOKEY`), systemd silently
falls back to the unsigned-verity alternative and merges the extension anyway — contradicting the
Trusted Boot docs, which promise only signed+verity sysexts are accepted under UKI.

This drops the bare `verity` alternative from the UKI branches, leaving only `signed+absent`.
Per `systemd.image-policy(7)`, `signed` images "also implicitly qualify for verity", so this still
accepts legitimately signed+verity extensions (Kairos's own output) — it only removes the
unsigned/signature-invalid fallback. The non-UKI branch (`verity+absent`, documented as not
enforcing signatures) is unchanged.

The same flawed policy string was also used as `immucore`'s `SysextDefaultPolicy` constant, which
gates `systemd-dissect --validate` calls made only in `IsUKI()` branches before symlinking a raw
sysext/confext image into the active extensions directory. Same root cause, same fix, applied for
consistency.

**Validation**:
- `go test ./kairos-init/pkg/validation/... -run TestValidation -v` — 23/23 pass, including a new
  spec (`cloudconfigs_sysext_policy_test.go`) that scans the bundled `99_sysext.yaml` and asserts
  the UKI drop-ins use `root=signed+absent:usr=signed+absent` while the non-UKI drop-ins keep
  `root=verity+absent:usr=verity+absent`. Confirmed fail-then-pass: reverting only the yaml change
  (`git stash` on that file, keeping the new test) makes this spec fail; restoring the fix makes it
  pass again.
- `golangci-lint run ./kairos-init/pkg/validation/... ./immucore/internal/constants/...` — 0 issues.
- `GOOS=linux go build ./kairos-init/... ./immucore/...` succeeds (both modules pull in Linux-only
  syscalls — e.g. `yip`'s cdrom mount plugin, `pault.ag/go/modprobe` — so they only build under
  `GOOS=linux`, which matches this repo's CI, `ubuntu-latest`; native darwin build fails the same
  way on unmodified `master`, confirmed by stashing this diff).
- Could not execute `immucore/pkg/state`/`immucore/internal/utils` tests on this macOS/arm64
  machine (cross-compiled Linux test binaries can't run locally: "exec format error"). The
  `immucore/internal/constants` change is a one-line string constant, character-for-character the
  same transformation already proven correct for the yaml file above, with no other call sites or
  tests depending on the old value.
- Confirmed base branch (`master`) CI is green (`gh run list --repo kairos-io/kairos --branch
  master --limit 5`); branch is cut from current `upstream/master` tip.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4425