### PR TITLE
refactor(cli): move edit-config to top-level kairos sub-tool

### DIFF
--- a/cmd/kairos/register_editconfig.go
+++ b/cmd/kairos/register_editconfig.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	editconfig "github.com/kairos-io/kairos/v4/editconfig/pkg/cmd"
+)
+
+func init() {
+	// edit-config is a top-level sub-tool rather than nested under `agent` or
+	// `provider`. Its concern -- editing and validating a cloud-init file --
+	// is orthogonal to whatever provider is (or isn't) installed and to the
+	// agent's install / upgrade lifecycle, so hiding it behind either would
+	// misrepresent when a user is expected to reach for it.
+	register("edit-config", editconfig.Run)
+}

--- a/editconfig/pkg/cmd/cmd.go
+++ b/editconfig/pkg/cmd/cmd.go
@@ -1,4 +1,12 @@
-package cli
+// Package cmd implements the `kairos edit-config` CLI: open the persistent
+// cloud-init configuration in $EDITOR, validate before saving, and reopen the
+// editor with the errors inlined when validation fails.
+//
+// It is registered as a top-level sub-tool of the multi-call kairos binary
+// (see cmd/kairos/register_editconfig.go) rather than under any specific
+// sub-tool, because touching cloud-init has nothing to do with any particular
+// provider or with the agent's install / upgrade lifecycle.
+package cmd
 
 import (
 	"bytes"
@@ -18,36 +26,46 @@ import (
 
 const defaultCloudInitPath = "/oem/90_custom.yaml"
 
-const validationMessageStart = "# kairos provider edit-config: validation failed"
-const validationMessageEnd = "# kairos provider: end validation errors"
+const validationMessageStart = "# kairos edit-config: validation failed"
+const validationMessageEnd = "# kairos edit-config: end validation errors"
 
-var EditConfigCMD = cli.Command{
-	Name:      "edit-config",
-	Usage:     "Edit and validate the persistent cloud-init configuration",
-	UsageText: "edit-config [--file PATH]",
-	Description: `
+// Run executes the edit-config CLI and returns a process exit code. The
+// multi-call kairos binary invokes this when argv[1] is "edit-config".
+func Run() int {
+	app := &cli.App{
+		Name:      "kairos edit-config",
+		Usage:     "Edit and validate the persistent cloud-init configuration",
+		UsageText: "kairos edit-config [--file PATH]",
+		Description: `
 Opens the persistent cloud-init configuration in $EDITOR. Changes are validated
 before the configuration is replaced, so invalid edits are never saved.
 `,
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "file",
-			Usage: "Cloud-init file to edit",
-			Value: defaultCloudInitPath,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "file",
+				Usage: "Cloud-init file to edit",
+				Value: defaultCloudInitPath,
+			},
 		},
-	},
-	Before: func(c *cli.Context) error {
-		if c.Args().Len() != 0 {
-			return fmt.Errorf("edit-config does not accept positional arguments")
-		}
-		if os.Geteuid() != 0 {
-			return errors.New("this command requires root privileges")
-		}
-		return nil
-	},
-	Action: func(c *cli.Context) error {
-		return editCloudInit(c.String("file"), os.Getenv("EDITOR"), c.App.Writer)
-	},
+		Before: func(c *cli.Context) error {
+			if c.Args().Len() != 0 {
+				return fmt.Errorf("edit-config does not accept positional arguments")
+			}
+			if os.Geteuid() != 0 {
+				return errors.New("this command requires root privileges")
+			}
+			return nil
+		},
+		Action: func(c *cli.Context) error {
+			return editCloudInit(c.String("file"), os.Getenv("EDITOR"), c.App.Writer)
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
 }
 
 func editCloudInit(path, editor string, output io.Writer) error {
@@ -61,7 +79,7 @@ func editCloudInit(path, editor string, output io.Writer) error {
 		return fmt.Errorf("stat cloud-init file: %w", err)
 	}
 
-	temp, err := os.CreateTemp(filepath.Dir(path), ".kairos-provider-edit-*.yaml")
+	temp, err := os.CreateTemp(filepath.Dir(path), ".kairos-edit-config-*.yaml")
 	if err != nil {
 		return fmt.Errorf("create temporary cloud-init file: %w", err)
 	}
@@ -171,7 +189,7 @@ func runEditor(editor, path string) error {
 }
 
 func replaceFile(path string, content []byte, info os.FileInfo) error {
-	temp, err := os.CreateTemp(filepath.Dir(path), ".kairos-provider-save-*.yaml")
+	temp, err := os.CreateTemp(filepath.Dir(path), ".kairos-edit-config-save-*.yaml")
 	if err != nil {
 		return err
 	}

--- a/editconfig/pkg/cmd/cmd_test.go
+++ b/editconfig/pkg/cmd/cmd_test.go
@@ -1,4 +1,4 @@
-package cli
+package cmd
 
 import (
 	"bytes"

--- a/editconfig/pkg/cmd/suite_test.go
+++ b/editconfig/pkg/cmd/suite_test.go
@@ -1,0 +1,13 @@
+package cmd
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEditConfigCmdSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "edit-config cmd Suite")
+}

--- a/provider/README.md
+++ b/provider/README.md
@@ -25,9 +25,8 @@ where it answers to two different callers:
   provider contract, and it is what makes other providers (`provider-rke2`,
   `provider-k3s`, ...) interchangeable with this one.
 - **A CLI**, when `argv[1]` is anything else. `get-kubeconfig`, `role`,
-  `bridge`, `register`, `generate-token`, `edit-config` and friends. Nothing
-  in the provider contract requires this half; it is specific to this
-  provider.
+  `bridge`, `register`, `generate-token` and friends. Nothing in the provider
+  contract requires this half; it is specific to this provider.
 
 ## Reaching the CLI
 

--- a/provider/internal/cli/start.go
+++ b/provider/internal/cli/start.go
@@ -231,7 +231,6 @@ For all the example cases, see: https://kairos.io/docs/
 			&CreateConfigCMD,
 			&GenerateTokenCMD,
 			&ValidateSchemaCMD,
-			&EditConfigCMD,
 			&VersionCMD,
 		},
 	}


### PR DESCRIPTION
Addresses: https://github.com/kairos-io/kairos/issues/4397#issuecomment-5505886626

edit-config touches the persistent cloud-init file, which has nothing to do with the p2p provider that the provider binary owns. Landing it in the provider made it reachable only through kairos provider edit-config, which requires a provider installed and forces users of core images to reach for a command that has no relation to what a provider does.

Move it out of provider/internal/cli and register it as its own top-level sub-tool of the multi-call kairos binary, so users run it as kairos edit-config directly. The command lives in a new editconfig/pkg/cmd package rather than under agent/, because its concern is orthogonal to the agent's install / upgrade lifecycle too, and future config-touching commands can join it there without picking a sub-tool to hide under.

Refs kairos-io/kairos#4397.

I'm not particularly satisfied with how it's wired up but in the lack of a common cli library, that's the simpler option. We can improve when we get to this: https://github.com/kairos-io/kairos/issues/4394
