### PR TITLE
:robot: Isolate bundle E2E images on GHCR

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -227,6 +227,7 @@ jobs:
       model: 'generic'
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+      bundle_image_tag: master-scratch
       release-matcher: ${{ matrix.release-matcher || '' }}
     secrets: inherit
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -302,6 +302,7 @@ jobs:
       model: 'generic'
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+      bundle_image_tag: pr-${{ github.event.pull_request.number }}
       release-matcher: ${{ matrix.release-matcher || '' }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head
       caller-vetted-ref: true

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -94,6 +94,14 @@ on:
         required: false
         type: string
         default: ''
+      bundle_image_tag:
+        description: |
+          Docker-safe tag for the bundles test image, such as pr-<number>
+          or master-scratch. Normalize branch/ref names before passing them
+          (e.g. replace / with -); raw branch names may not be valid tags.
+        required: false
+        type: string
+        default: ''
       suite_timeout:
         description: |
           ginkgo's suite timeout, as a Go duration.
@@ -111,22 +119,9 @@ on:
         type: string
         default: '60m'
 
-    secrets:
-      QUAY_USERNAME:
-        description: |
-          Registry user for quay.io/kairos/ci-temp-images. Needs WRITE, not just
-          read: this workflow pulls the image under test and also pushes a
-          bundles-test image back to the same repository.
-        required: true
-      QUAY_PASSWORD:
-        description: "Registry token matching QUAY_USERNAME. Same write scope."
-        required: true
-
-# The Quay push in the "bundles" cell authenticates with the
-# QUAY_USERNAME/QUAY_PASSWORD secrets above, not GITHUB_TOKEN, so
-# this workflow never needs GITHUB_TOKEN write access.
 permissions:
   contents: read
+  packages: write
 
 jobs:
   test:  # decentralized k8s needs to run in github hosted workers for network stuff to work
@@ -139,6 +134,8 @@ jobs:
     # hanging in AfterEach while it gathers logs -- is bounded by minutes
     # rather than by GitHub's 6h default.
     timeout-minutes: 120
+    env:
+      BUNDLE_IMAGE_REPO: ghcr.io/kairos-io/kairos/bundles-test
     steps:
       - name: Split base image
         id: split
@@ -215,22 +212,22 @@ jobs:
             [registry."registry.docker-mirror.svc.cluster.local:5000"]
               insecure = true
               http = true
-      - name: Login to Quay Registry
-        # Only the bundles test actually pushes to quay -- it builds
-        # a per-run bundles-test image and pushes it to
-        # quay.io/kairos/ci-temp-images:bundles-test (see "Prepare
-        # test bundle" step below). Every other cell either pulls
-        # nothing at CI level or reaches public quay repos
-        # (luet's quay.io/kairos/packages) which need no login. The
-        # OS image lives at ghcr.io/kairos-io/kairos/${flavor} now,
-        # not at ci-temp-images, so IMAGE_NAME pulls from ghcr
-        # inside the VM and needs no CI-level quay creds either.
+      - name: Login to GitHub Container Registry
         if: inputs.test == 'bundles'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate test bundle image tag
+        if: inputs.test == 'bundles'
+        env:
+          BUNDLE_IMAGE_TAG: ${{ inputs.bundle_image_tag }}
+        run: |
+          if [[ ! "$BUNDLE_IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "::error::bundle_image_tag must be a valid, non-empty container tag"
+            exit 1
+          fi
       - name: Block all traffic to metadata ip  # For cloud runners, the metadata ip can interact with our test machines
         if: runner.environment == 'self-hosted'
         run: |
@@ -348,16 +345,25 @@ jobs:
           out-file-path: ""
       - name: Prepare test bundle
         if: ${{ inputs.test == 'bundles' }}
+        id: bundle
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           file: examples/bundle/Dockerfile
           platforms: linux/${{ inputs.arch }}
           push: true
-          tags: quay.io/kairos/ci-temp-images:bundles-test
-          # https://docs.redhat.com/en/documentation/red_hat_quay/3.4/html/use_red_hat_quay/working_with_tags#tag-expiration
-          labels: |
-            quay.expires-after=6h
+          tags: ${{ env.BUNDLE_IMAGE_REPO }}:${{ inputs.bundle_image_tag }}
+      - name: Export test bundle digest
+        if: ${{ inputs.test == 'bundles' }}
+        env:
+          BUNDLE_DIGEST: ${{ steps.bundle.outputs.digest }}
+        run: |
+          if [[ ! "$BUNDLE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Build did not return a valid bundle digest"
+            exit 1
+          fi
+          printf 'BUNDLE_IMAGE=%s@%s\n' \
+            "$BUNDLE_IMAGE_REPO" "$BUNDLE_DIGEST" >> "$GITHUB_ENV"
       - name: Run tests
         if: ${{ !startsWith(inputs.test, 'encryption-') }}
         env:

--- a/tests/assets/bundles.yaml
+++ b/tests/assets/bundles.yaml
@@ -22,4 +22,5 @@ install:
   bundles:
     - rootfs_path: /var/lib/extensions/kubo
       targets:
-        - container://quay.io/kairos/ci-temp-images:bundles-test
+        # Rendered by bundles_test.go from BUNDLE_IMAGE.
+        - container://__BUNDLE_IMAGE__

--- a/tests/bundles_test.go
+++ b/tests/bundles_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -11,32 +12,55 @@ import (
 	. "github.com/spectrocloud/peg/matcher"
 )
 
+const bundleImagePlaceholder = "__BUNDLE_IMAGE__"
+
+func createBundleDatasource(bundleImage string) string {
+	content, err := os.ReadFile("assets/bundles.yaml")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	template := string(content)
+	ExpectWithOffset(1, strings.Count(template, bundleImagePlaceholder)).To(
+		Equal(1), "bundle datasource must contain exactly one image placeholder",
+	)
+
+	config, err := os.CreateTemp("", "bundles-*.yaml")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	defer func() { _ = os.Remove(config.Name()) }()
+
+	_, err = config.WriteString(strings.Replace(template, bundleImagePlaceholder, bundleImage, 1))
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, config.Close()).To(Succeed())
+
+	return CreateDatasource(config.Name())
+}
+
 var _ = Describe("kairos bundles test", Label("bundles"), func() {
 	var vm VM
 	var datasource string
+	var bundleImage string
 
 	BeforeEach(func() {
-		datasource = CreateDatasource("assets/bundles.yaml")
+		bundleImage = os.Getenv("BUNDLE_IMAGE")
+		Expect(bundleImage).ToNot(BeEmpty(), "BUNDLE_IMAGE must be set to the digest-pinned bundle image built by CI")
+		datasource = createBundleDatasource(bundleImage)
+		DeferCleanup(func() { Expect(os.Remove(datasource)).To(Succeed()) })
 		Expect(os.Setenv("DATASOURCE", datasource)).ToNot(HaveOccurred())
+		DeferCleanup(func() { Expect(os.Unsetenv("DATASOURCE")).To(Succeed()) })
 
 		_, vm = startVM()
+		DeferCleanup(func() {
+			if CurrentSpecReport().Failed() {
+				gatherLogs(vm)
+				serial, _ := os.ReadFile(filepath.Join(vm.StateDir, "serial.log"))
+				_ = os.MkdirAll("logs", os.ModePerm|os.ModeDir)
+				_ = os.WriteFile(filepath.Join("logs", "serial.log"), serial, os.ModePerm)
+				fmt.Println(string(serial))
+			}
+
+			err := vm.Destroy(nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
 		vm.EventuallyConnects(1200)
-	})
-
-	AfterEach(func() {
-		if CurrentSpecReport().Failed() {
-			gatherLogs(vm)
-			serial, _ := os.ReadFile(filepath.Join(vm.StateDir, "serial.log"))
-			_ = os.MkdirAll("logs", os.ModePerm|os.ModeDir)
-			_ = os.WriteFile(filepath.Join("logs", "serial.log"), serial, os.ModePerm)
-			fmt.Println(string(serial))
-		}
-
-		err := vm.Destroy(nil)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(os.Unsetenv("DATASOURCE")).ToNot(HaveOccurred())
-		Expect(os.Remove(datasource)).ToNot(HaveOccurred())
 	})
 
 	Context("reboots and passes functional tests", func() {
@@ -104,10 +128,7 @@ var _ = Describe("kairos bundles test", Label("bundles"), func() {
 
 			By("checking that there are no duplicate entries in the config (issue#2019)", func() {
 				out, _ := vm.Sudo("cat /oem/90_custom.yaml")
-				// https://pkg.go.dev/regexp/syntax
-				// ?s -> "let . match \n (default false)"
-				Expect(out).To(MatchRegexp("^(?s)(.*quay\\.io/kairos/ci-temp-images:bundles-test.*){1}$"))
-				Expect(out).ToNot(MatchRegexp("(?s)quay.io/kairos/ci-temp-images.*quay.io/kairos/ci-temp-images"))
+				Expect(strings.Count(out, bundleImage)).To(Equal(1))
 			})
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Concurrent bundle E2E jobs currently overwrite the same mutable Quay tag, so a VM can install another run's bundle. This change pushes to GHCR using caller-scoped tags and passes the immutable build digest to the test.

- Push to `ghcr.io/kairos-io/kairos/bundles-test`, with `pr-<number>` and `master-scratch` tags.
- Authenticate with `GITHUB_TOKEN` and remove the reusable workflow's Quay secrets.
- Define the bundle repository once, use it for both push and digest export, and validate the tag and build digest.
- Require `BUNDLE_IMAGE` explicitly. There is no legacy tag fallback.
- Render the datasource from exactly one placeholder and check that the selected image appears once in the installed config.
- Register cleanup after each resource is created, so missing input does not trigger cleanup against an uninitialized VM.

Rebased onto `b2c341f9`. The obsolete release workflow change is dropped: upstream removed those QEMU jobs. Existing upstream timeout and workflow changes are preserved.

**Which issue(s) this PR fixes**:

Fixes #4310

**Rollout and accepted tradeoffs**

- This PR's `pull_request_target` run uses the base-branch reusable workflow, which does not export `BUNDLE_IMAGE`. The bundles cell is therefore expected to fail with the explicit missing-input assertion before merge. [Jimmy confirmed this is acceptable](https://github.com/kairos-io/kairos/pull/4451#discussion_r3949468491). After merge, callers supply the digest through the updated workflow.
- Before the first updated bundles run can succeed, a maintainer must ensure the new `kairos/bundles-test` GHCR package is **public** and linked to this repository with Actions write access. Seed the package if necessary, set its visibility to public, and verify an anonymous pull of its digest. The VM has no registry credentials. Package visibility has not been verified from this environment.
- GHCR has no Quay-style `expires-after` label. Package retention is deliberately outside this PR, matching the existing CI packages. [Jimmy explicitly accepted this tradeoff](https://github.com/kairos-io/kairos/pull/4451#discussion_r3931310085); this change does not implement automatic expiry.

**Validation**

On the revised files:
- `git diff --check` and `gofmt`: clean.
- Parsed the workflow YAML and rendered bundle datasource.
- Executed the actual Bash tag/digest validators with valid, empty, malformed, and length-boundary inputs; verified the exact exported digest reference.
- Checked caller tags and package permissions, the single repository definition, removal of Quay fallback/secrets, and cleanup registration order.

Docker and KVM are unavailable here, so the revised Go E2E suite has not been compiled or run locally. The earlier [independent QA run](https://github.com/kairos-io/kairos/pull/4451#issuecomment-5614116453) passed the digest-pinned bundle test on the previous revision; it is not a run of this new commit.

The previous CI revision passed its bundles cell, unit tests, and lint. Its two failed jobs were `encryption-remote-auto` (cert-manager deployments did not become Available) and `provider-qrcode-install` (suite timeout while waiting in node pairing). Neither log implicates bundle image selection; their status must be reassessed on the rebased run.
