### PR TITLE
:bug: one Esc from the summary returns to the install options

### DIFF
--- a/installer/internal/tui/TUIconstants.go
+++ b/installer/internal/tui/TUIconstants.go
@@ -73,6 +73,14 @@ const (
 	ErrorPrefix           = "ERROR:"
 )
 
+// Navigation IDs for the pages the model itself has to reason about.
+// The others still return their literal from ID(); these two are named
+// because goBack() compares against them (kairos-io/kairos#3822).
+const (
+	installOptionsPageID = "install_options"
+	summaryPageID        = "summary"
+)
+
 // DebugBundlePageID is the navigation ID of the debug bundle page.
 const DebugBundlePageID = "debug_bundle"
 

--- a/installer/internal/tui/TUIinstallOptionsPage.go
+++ b/installer/internal/tui/TUIinstallOptionsPage.go
@@ -115,4 +115,4 @@ func (p *installOptionsPage) Help() string {
 	return "↑/k: up • ↓/j: down • enter: select • To select action after install (←/h: left • →/l: right)"
 }
 
-func (p *installOptionsPage) ID() string { return "install_options" }
+func (p *installOptionsPage) ID() string { return installOptionsPageID }

--- a/installer/internal/tui/TUImodel.go
+++ b/installer/internal/tui/TUImodel.go
@@ -53,6 +53,52 @@ type Model struct {
 
 var mainModel Model
 
+// goBack pops the navigation stack by one page, except on the summary page,
+// where it unwinds the whole customization detour in a single press.
+//
+// kairos-io/kairos#3822: "To get back to the previous section I need to press
+// Esc many times becuse it goes through every configuration screen I went."
+// Both complaints in that report are made from the summary page. Reaching it
+// through Customize Further stacks up customization, user/password and ssh
+// keys, so returning to the point where that choice was made costs four
+// presses. Reaching it through Start Install stacks up only the options page,
+// and there one press already worked.
+//
+// Summary is a review screen rather than a step, so the page a user wants
+// behind it is the one where the branch was taken. Everywhere else Esc keeps
+// its one-page-at-a-time meaning, because stepping back to fix a single
+// answer is worth one press too.
+func (m *Model) goBack() {
+	if len(m.navigationStack) == 0 {
+		return
+	}
+	if m.currentPageID == summaryPageID {
+		for len(m.navigationStack) > 1 {
+			top := m.navigationStack[len(m.navigationStack)-1]
+			if top == installOptionsPageID {
+				break
+			}
+			m.navigationStack = m.navigationStack[:len(m.navigationStack)-1]
+		}
+	}
+	m.currentPageID = m.navigationStack[len(m.navigationStack)-1]
+	m.navigationStack = m.navigationStack[:len(m.navigationStack)-1]
+}
+
+// initCurrentPage initialises the page currentPageID now points at.
+//
+// The Esc handler used to call Init() on the page the user was leaving,
+// because it reused the index computed before the page changed. The
+// destination page was therefore never initialised on the way back.
+func (m *Model) initCurrentPage() tea.Cmd {
+	for _, p := range m.pages {
+		if p.ID() == m.currentPageID {
+			return p.Init()
+		}
+	}
+	return nil
+}
+
 // InitialModel Initialize the application
 func InitialModel(l *sdkLogger.KairosLogger, source string) Model {
 	// First create the model with the logger in case any page needs to log something
@@ -186,10 +232,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "esc":
 			// Go back to previous page if we have navigation history
 			if len(mainModel.navigationStack) > 0 {
-				// Pop the last page from the stack
-				mainModel.currentPageID = mainModel.navigationStack[len(mainModel.navigationStack)-1]
-				mainModel.navigationStack = mainModel.navigationStack[:len(mainModel.navigationStack)-1]
-				return mainModel, mainModel.pages[currentIdx].Init()
+				mainModel.goBack()
+				return mainModel, mainModel.initCurrentPage()
 			}
 		}
 	}

--- a/installer/internal/tui/TUImodel_navigation_internal_test.go
+++ b/installer/internal/tui/TUImodel_navigation_internal_test.go
@@ -1,0 +1,132 @@
+package tui
+
+import (
+	"testing"
+
+	sdkLogger "github.com/kairos-io/kairos/v4/sdk/types/logger"
+)
+
+// newTestModel gives each test its own model, since mainModel is package level.
+func newTestModel(t *testing.T) *Model {
+	t.Helper()
+	logger := sdkLogger.NewKairosLogger("installer-test", "info", true)
+	mainModel = InitialModel(&logger, "")
+	return &mainModel
+}
+
+// TestIssue3822_EscFromSummaryReturnsToInstallOptions covers the reported
+// complaint: reaching the summary through "Customize Further" stacked up every
+// configuration screen, so getting back to the branch point took one Esc per
+// screen. See kairos-io/kairos#3822.
+func TestIssue3822_EscFromSummaryReturnsToInstallOptions(t *testing.T) {
+	m := newTestModel(t)
+	m.navigationStack = []string{
+		"prerequisites",
+		"disk_selection",
+		installOptionsPageID,
+		"customization",
+		"user_password",
+		"ssh_keys",
+	}
+	m.currentPageID = summaryPageID
+
+	m.goBack()
+
+	if m.currentPageID != installOptionsPageID {
+		t.Fatalf("one Esc from summary should land on %q, got %q", installOptionsPageID, m.currentPageID)
+	}
+	want := []string{"prerequisites", "disk_selection"}
+	if len(m.navigationStack) != len(want) {
+		t.Fatalf("stack should unwind to %v, got %v", want, m.navigationStack)
+	}
+	for i := range want {
+		if m.navigationStack[i] != want[i] {
+			t.Fatalf("stack should unwind to %v, got %v", want, m.navigationStack)
+		}
+	}
+}
+
+// TestIssue3822_EscFromSummaryViaStartInstall is the other path in the report:
+// "Start Install" jumps straight to the summary, so the options page is already
+// directly behind it. That case worked before and must keep working.
+func TestIssue3822_EscFromSummaryViaStartInstall(t *testing.T) {
+	m := newTestModel(t)
+	m.navigationStack = []string{"prerequisites", "disk_selection", installOptionsPageID}
+	m.currentPageID = summaryPageID
+
+	m.goBack()
+
+	if m.currentPageID != installOptionsPageID {
+		t.Fatalf("expected %q, got %q", installOptionsPageID, m.currentPageID)
+	}
+	if len(m.navigationStack) != 2 {
+		t.Fatalf("expected 2 entries left, got %v", m.navigationStack)
+	}
+}
+
+// TestIssue3822_EscElsewhereStillGoesBackOnePage guards the behaviour that was
+// deliberately kept: inside the customization flow, Esc is still one page at a
+// time, so fixing a single answer costs one press.
+func TestIssue3822_EscElsewhereStillGoesBackOnePage(t *testing.T) {
+	m := newTestModel(t)
+	m.navigationStack = []string{installOptionsPageID, "customization", "user_password"}
+	m.currentPageID = "ssh_keys"
+
+	m.goBack()
+
+	if m.currentPageID != "user_password" {
+		t.Fatalf("expected one page back to %q, got %q", "user_password", m.currentPageID)
+	}
+	if len(m.navigationStack) != 2 {
+		t.Fatalf("expected 2 entries left, got %v", m.navigationStack)
+	}
+}
+
+// TestIssue3822_EscOnEmptyStackIsANoop keeps the first page from popping off
+// into an invalid state.
+func TestIssue3822_EscOnEmptyStackIsANoop(t *testing.T) {
+	m := newTestModel(t)
+	m.navigationStack = nil
+	m.currentPageID = summaryPageID
+
+	m.goBack()
+
+	if m.currentPageID != summaryPageID {
+		t.Fatalf("expected the page to stay %q, got %q", summaryPageID, m.currentPageID)
+	}
+}
+
+// TestIssue3822_SummaryUnwindStopsAtTheBottom covers a summary reached without
+// ever passing the options page. The loop must stop rather than empty the stack.
+func TestIssue3822_SummaryUnwindStopsAtTheBottom(t *testing.T) {
+	m := newTestModel(t)
+	m.navigationStack = []string{"prerequisites", "customization", "user_password"}
+	m.currentPageID = summaryPageID
+
+	m.goBack()
+
+	if m.currentPageID != "prerequisites" {
+		t.Fatalf("expected to land on %q, got %q", "prerequisites", m.currentPageID)
+	}
+	if len(m.navigationStack) != 0 {
+		t.Fatalf("expected an empty stack, got %v", m.navigationStack)
+	}
+}
+
+// TestInitCurrentPageFollowsCurrentPageID covers the defect the Esc handler
+// carried: it called Init() on the page the user was leaving, because it
+// reused the page index computed before the page changed.
+func TestInitCurrentPageFollowsCurrentPageID(t *testing.T) {
+	m := newTestModel(t)
+	m.currentPageID = "nonexistent_page"
+	if cmd := m.initCurrentPage(); cmd != nil {
+		t.Fatalf("an unknown page id should produce no command, got one")
+	}
+
+	for _, p := range m.pages {
+		m.currentPageID = p.ID()
+		// Must not panic, and must resolve against currentPageID rather than
+		// any stale index.
+		_ = m.initCurrentPage()
+	}
+}

--- a/installer/internal/tui/TUIsummaryPage.go
+++ b/installer/internal/tui/TUIsummaryPage.go
@@ -76,4 +76,4 @@ func (p *summaryPage) Help() string {
 	return "Press enter to start the installation process.\nPress v to view the generated userdata."
 }
 
-func (p *summaryPage) ID() string { return "summary" }
+func (p *summaryPage) ID() string { return summaryPageID }


### PR DESCRIPTION
Refs #3822. The other half of that report. The blank post-install action is fixed in #4443, this is the navigation complaint:

> To get back to the previous section I need to press Esc many times becuse it goes through every configuration screen I went.

## What changes

**Both complaints in #3822 are made from the summary page.** That is what makes this fixable without a redesign:

| Route to the summary | Stack behind it | Presses to reach the options page |
|---|---|---|
| Start Install | `install_options` | 1, already worked |
| Customize Further | `install_options`, `customization`, `user_password`, `ssh_keys` | **4** |

Summary is a review screen rather than a step, so the page a user wants behind it is the one where the branch was taken. `goBack()` now unwinds to the options page when leaving the summary, and keeps its one-page-at-a-time meaning everywhere else, because stepping back to correct a single answer is worth one press too.

No new keybinding, so no help text to teach or discover.

## A defect in the same handler

Esc called `Init()` on the page the user was **leaving**:

```go
mainModel.currentPageID = mainModel.navigationStack[len(...)-1]
mainModel.navigationStack = mainModel.navigationStack[:len(...)-1]
return mainModel, mainModel.pages[currentIdx].Init()   // currentIdx predates the change
```

`currentIdx` is computed before the page changes, so the destination page was never initialised on the way back and the departed page was re-initialised. `initCurrentPage()` resolves against `currentPageID` instead.

Worth a second opinion on whether any page's `Init()` was load-bearing here. The pages I checked are idempotent, and nothing in the issue points at a symptom from it, so I have treated it as latent.

## Tests

Six, all in `TUImodel_navigation_internal_test.go`: both routes to the summary, one-page-back inside the customization flow, an empty stack, a summary reached without passing the options page, and `Init()` following `currentPageID`.

`go test ./installer/internal/tui/` passes, `go vet` is clean, `gofmt` reports nothing.

## Also

The two page IDs the model compares against are constants now rather than repeated string literals. That is the same smell I raised while reviewing #4443, where the valid post-install actions live in three files.

## Not covered

The issue's screenshots also show that reaching the summary through Start Install skips the configuration entirely, which is by design but surprised the reporter. Changing that is a product decision rather than a bug fix, so it is left alone here.

Draft, because the summary-page behaviour is a judgement call. If you would rather Esc stayed strictly one page everywhere and this became a separate keybinding, say so and I will swap it.