### PR TITLE
fix(ci): repoint upload-cloud-images at the renamed release workflow

### DIFF
--- a/.github/workflows/upload-cloud-images.yaml
+++ b/.github/workflows/upload-cloud-images.yaml
@@ -4,12 +4,6 @@ name: Upload cloud images
 # these jobs need, instead of racing the same tag push. See the commit
 # message for why (mauromorales/mission-control#174 has the evidence).
 #
-# The release workflow was named "Release AMD64 artifacts" and got
-# renamed to "release" in ae314796 (2026-08-21, the monorepo canonical
-# pipeline). This trigger was not updated then, so since that date it
-# has matched no workflow and never fired -- uploads have silently
-# fallen back to the daily schedule below instead of running right
-# after a release.
 on:
   workflow_run:
     workflows: ["release"]

--- a/.github/workflows/upload-cloud-images.yaml
+++ b/.github/workflows/upload-cloud-images.yaml
@@ -1,11 +1,18 @@
 name: Upload cloud images
 
-# Sequenced after "Release AMD64 artifacts" actually publishes the hadron tag
+# Sequenced after the release workflow actually publishes the hadron tag
 # these jobs need, instead of racing the same tag push. See the commit
 # message for why (mauromorales/mission-control#174 has the evidence).
+#
+# The release workflow was named "Release AMD64 artifacts" and got
+# renamed to "release" in ae314796 (2026-08-21, the monorepo canonical
+# pipeline). This trigger was not updated then, so since that date it
+# has matched no workflow and never fired -- uploads have silently
+# fallen back to the daily schedule below instead of running right
+# after a release.
 on:
   workflow_run:
-    workflows: ["Release AMD64 artifacts"]
+    workflows: ["release"]
     types:
       - completed
   schedule:


### PR DESCRIPTION
## What

`upload-cloud-images.yaml`'s `workflow_run` trigger listened for a workflow named "Release AMD64 artifacts". That workflow was renamed to "release" in ae314796 (2026-08-21, the monorepo canonical pipeline). The trigger was not updated.

## Why it matters

Since 2026-08-21, `workflow_run` has matched no workflow, so it never fires. Cloud image uploads to GCP/AWS/Azure have been silently falling back to the daily 2am schedule instead of running right after a release completes -- the exact race the workflow_run trigger was originally added to fix (see the file's own header comment).

## What changed

One line: `workflows: ["Release AMD64 artifacts"]` -> `workflows: ["release"]`, plus a comment recording why.

## Context

Found while investigating an OpenSSF Scorecard question, unrelated to the score itself. Filed as its own fix rather than folded into anything else.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CuhYDmBnaQHhbpJ3AtJh6w
