### PR TITLE
docs: link the contributor ladder from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ How to contribute
    sure to file an issue first.
 -  **Check good first-issue** - check out [good first issues](https://github.com/kairos-io/kairos/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) if you want to contribute to a specific problem
 -  **Read about our code of conduct and governance**: Kairos is an Open source, community-driven project with a [governance](https://github.com/kairos-io/community/blob/main/GOVERNANCE.md) and adopts CNCF [Code of conduct](https://github.com/kairos-io/kairos/blob/master/CODE_OF_CONDUCT.md)
+-  **Grow into a project role**: Kairos has a [contributor ladder](https://github.com/kairos-io/community/blob/main/GOVERNANCE.md#project-roles), from Contributor to Approver to Maintainer to Administrator, with a checklist for each step
 
 Guiding user stories
 --------------------


### PR DESCRIPTION
Part of #4245.

CONTRIBUTING.md linked GOVERNANCE.md in general, but not the
contributor ladder specifically. Add a direct link to the Project
Roles section, so a new contributor finds Contributor -> Approver ->
Maintainer -> Administrator without reading all of GOVERNANCE.md
first.

---

*Not an agent acting on its own: Mauro used AI to help draft this PR.*