### PR TITLE
feat(immucore): add rd.immucore.break breakpoints

### DIFF
--- a/immucore/README.md
+++ b/immucore/README.md
@@ -98,7 +98,7 @@ The immutable rootfs can be configured with the following kernel parameters:
   console to an interactive shell, like dracut's `rd.break`. The boot resumes
   when that shell exits, so this is for looking around mid-boot, not for
   recovering from a failure (that shell still comes up on its own). Valid values
-  are the step names shown in the DAG diagrams below, e.g.
+  are the DAG step names (not the `<init>` node herd itself adds), e.g.
   `rd.immucore.break=mount-root` or `rd.immucore.break=uki-pivot-to-sysroot`.
   Several steps can be given comma-separated (`rd.immucore.break=load-config,mount-root`)
   or by repeating the stanza. A name that matches no step is ignored. To see all

--- a/immucore/README.md
+++ b/immucore/README.md
@@ -94,6 +94,15 @@ The immutable rootfs can be configured with the following kernel parameters:
 
 * `rd.immucore.uki`: Enables UKI booting
 
+* `rd.immucore.break=<step>`: Stops the boot right before `<step>` and hands the
+  console to an interactive shell, like dracut's `rd.break`. The boot resumes
+  when that shell exits, so this is for looking around mid-boot, not for
+  recovering from a failure (that shell still comes up on its own). Valid values
+  are the step names shown in the DAG diagrams below, e.g.
+  `rd.immucore.break=mount-root` or `rd.immucore.break=uki-pivot-to-sysroot`.
+  Several steps can be given comma-separated (`rd.immucore.break=load-config,mount-root`)
+  or by repeating the stanza. A name that matches no step is ignored.
+
 * `rd.immucore.sysrootwait=<seconds>`: Waits for the sysroot to be mounted up to <seconds> before continuing with the boot process. This is useful when booting from CD/Netboot as immucore doesn't mount the /sysroot in those cases, but we want to run the initramfs stage once the system is ready. Sometimes dracut can be really slow and the default 1 minute of waiting is not enough. In those cases you can increase this value to wait more time. Defaults to 60s.
 
 ### In-RAM boot (`kairos.ram.*`)

--- a/immucore/README.md
+++ b/immucore/README.md
@@ -105,6 +105,15 @@ The immutable rootfs can be configured with the following kernel parameters:
   available step names for your boot configuration, run `immucore --dry-run` to
   display the full DAG.
 
+  There is a ceiling on how long you can sit at a breakpoint: systemd bounds the
+  start of `immucore.service` by its start timeout (`TimeoutStartSec=` on the
+  unit, or `DefaultTimeoutStartSec` from `systemd-system.conf` when the unit
+  sets none). When that expires systemd moves on to
+  `initrd-switch-root.target` with none of immucore's mounts done and nothing
+  said on the console — the same silent boot-continue the `RebootOrWait` doc
+  comment in `internal/utils/common.go` describes. Raise `TimeoutStartSec=` on
+  `immucore.service` if you need to hold a breakpoint open longer than that.
+
 * `rd.immucore.sysrootwait=<seconds>`: Waits for the sysroot to be mounted up to <seconds> before continuing with the boot process. This is useful when booting from CD/Netboot as immucore doesn't mount the /sysroot in those cases, but we want to run the initramfs stage once the system is ready. Sometimes dracut can be really slow and the default 1 minute of waiting is not enough. In those cases you can increase this value to wait more time. Defaults to 60s.
 
 ### In-RAM boot (`kairos.ram.*`)

--- a/immucore/README.md
+++ b/immucore/README.md
@@ -101,7 +101,9 @@ The immutable rootfs can be configured with the following kernel parameters:
   are the step names shown in the DAG diagrams below, e.g.
   `rd.immucore.break=mount-root` or `rd.immucore.break=uki-pivot-to-sysroot`.
   Several steps can be given comma-separated (`rd.immucore.break=load-config,mount-root`)
-  or by repeating the stanza. A name that matches no step is ignored.
+  or by repeating the stanza. A name that matches no step is ignored. To see all
+  available step names for your boot configuration, run `immucore --dry-run` to
+  display the full DAG.
 
 * `rd.immucore.sysrootwait=<seconds>`: Waits for the sysroot to be mounted up to <seconds> before continuing with the boot process. This is useful when booting from CD/Netboot as immucore doesn't mount the /sysroot in those cases, but we want to run the initramfs stage once the system is ready. Sometimes dracut can be really slow and the default 1 minute of waiting is not enough. In those cases you can increase this value to wait more time. Defaults to 60s.
 

--- a/immucore/internal/constants/constants.go
+++ b/immucore/internal/constants/constants.go
@@ -153,26 +153,34 @@ const (
 	CmdlineAutoCreatePartitionsWipe = "kairos.ram.wipe"
 	CmdlineAutoCreateOemSize        = "kairos.ram.oem="
 	CmdlineAutoCreatePersistentSize = "kairos.ram.persistent="
-	UkiLivecdMountPoint             = "/run/initramfs/live"
-	UkiIsoBaseTree                  = "/run/rootfsbase"
-	UkiIsoBootImage                 = "efiboot.img"
-	UkiLivecdPath                   = "/dev/disk/by-label/UKI_ISO_INSTALL"
-	UkiDefaultcdrom                 = "/dev/sr0"
-	UkiDefaultcdromFsType           = "iso9660"
-	UkiDefaultEfiimgFsType          = "vfat"
-	UkiSysrootDir                   = "sysroot"
-	PersistentStateTarget           = "/usr/local/.state"
-	LogDir                          = "/run/immucore"
-	PathAppend                      = "/usr/bin:/usr/sbin:/bin:/sbin"
-	PATH                            = "PATH"
-	DefaultPCR                      = 11
-	SysExt                          = "sysext"
-	ConfExt                         = "confext"
-	SourceSysExtDir                 = "/var/lib/kairos/extensions/"
-	SourceConfExtDir                = "/var/lib/kairos/confexts/"
-	DestSysExtDir                   = "/run/extensions"
-	DestConfExtDir                  = "/run/confexts"
-	VerityCertDir                   = "/run/verity.d/"
-	SysextDefaultPolicy             = "--image-policy=\"root=signed+absent:usr=signed+absent\""
-	EfiDir                          = "/efi"
+
+	// CmdlineBreak requests dracut-style breakpoints. Its values are step
+	// names, i.e. the Op* constants above (rd.immucore.break=mount-root), and
+	// several can be given either comma-separated or by repeating the stanza.
+	// Immucore stops right before a named step, hands the console to a shell
+	// and resumes the boot once that shell exits.
+	CmdlineBreak = "rd.immucore.break="
+
+	UkiLivecdMountPoint    = "/run/initramfs/live"
+	UkiIsoBaseTree         = "/run/rootfsbase"
+	UkiIsoBootImage        = "efiboot.img"
+	UkiLivecdPath          = "/dev/disk/by-label/UKI_ISO_INSTALL"
+	UkiDefaultcdrom        = "/dev/sr0"
+	UkiDefaultcdromFsType  = "iso9660"
+	UkiDefaultEfiimgFsType = "vfat"
+	UkiSysrootDir          = "sysroot"
+	PersistentStateTarget  = "/usr/local/.state"
+	LogDir                 = "/run/immucore"
+	PathAppend             = "/usr/bin:/usr/sbin:/bin:/sbin"
+	PATH                   = "PATH"
+	DefaultPCR             = 11
+	SysExt                 = "sysext"
+	ConfExt                = "confext"
+	SourceSysExtDir        = "/var/lib/kairos/extensions/"
+	SourceConfExtDir       = "/var/lib/kairos/confexts/"
+	DestSysExtDir          = "/run/extensions"
+	DestConfExtDir         = "/run/confexts"
+	VerityCertDir          = "/run/verity.d/"
+	SysextDefaultPolicy    = "--image-policy=\"root=signed+absent:usr=signed+absent\""
+	EfiDir                 = "/efi"
 )

--- a/immucore/internal/constants/constants.go
+++ b/immucore/internal/constants/constants.go
@@ -153,6 +153,28 @@ const (
 	CmdlineAutoCreatePartitionsWipe = "kairos.ram.wipe"
 	CmdlineAutoCreateOemSize        = "kairos.ram.oem="
 	CmdlineAutoCreatePersistentSize = "kairos.ram.persistent="
+	UkiLivecdMountPoint             = "/run/initramfs/live"
+	UkiIsoBaseTree                  = "/run/rootfsbase"
+	UkiIsoBootImage                 = "efiboot.img"
+	UkiLivecdPath                   = "/dev/disk/by-label/UKI_ISO_INSTALL"
+	UkiDefaultcdrom                 = "/dev/sr0"
+	UkiDefaultcdromFsType           = "iso9660"
+	UkiDefaultEfiimgFsType          = "vfat"
+	UkiSysrootDir                   = "sysroot"
+	PersistentStateTarget           = "/usr/local/.state"
+	LogDir                          = "/run/immucore"
+	PathAppend                      = "/usr/bin:/usr/sbin:/bin:/sbin"
+	PATH                            = "PATH"
+	DefaultPCR                      = 11
+	SysExt                          = "sysext"
+	ConfExt                         = "confext"
+	SourceSysExtDir                 = "/var/lib/kairos/extensions/"
+	SourceConfExtDir                = "/var/lib/kairos/confexts/"
+	DestSysExtDir                   = "/run/extensions"
+	DestConfExtDir                  = "/run/confexts"
+	VerityCertDir                   = "/run/verity.d/"
+	SysextDefaultPolicy             = "--image-policy=\"root=signed+absent:usr=signed+absent\""
+	EfiDir                          = "/efi"
 
 	// CmdlineBreak requests dracut-style breakpoints. Its values are step
 	// names, i.e. the Op* constants above (rd.immucore.break=mount-root), and
@@ -160,27 +182,4 @@ const (
 	// Immucore stops right before a named step, hands the console to a shell
 	// and resumes the boot once that shell exits.
 	CmdlineBreak = "rd.immucore.break="
-
-	UkiLivecdMountPoint    = "/run/initramfs/live"
-	UkiIsoBaseTree         = "/run/rootfsbase"
-	UkiIsoBootImage        = "efiboot.img"
-	UkiLivecdPath          = "/dev/disk/by-label/UKI_ISO_INSTALL"
-	UkiDefaultcdrom        = "/dev/sr0"
-	UkiDefaultcdromFsType  = "iso9660"
-	UkiDefaultEfiimgFsType = "vfat"
-	UkiSysrootDir          = "sysroot"
-	PersistentStateTarget  = "/usr/local/.state"
-	LogDir                 = "/run/immucore"
-	PathAppend             = "/usr/bin:/usr/sbin:/bin:/sbin"
-	PATH                   = "PATH"
-	DefaultPCR             = 11
-	SysExt                 = "sysext"
-	ConfExt                = "confext"
-	SourceSysExtDir        = "/var/lib/kairos/extensions/"
-	SourceConfExtDir       = "/var/lib/kairos/confexts/"
-	DestSysExtDir          = "/run/extensions"
-	DestConfExtDir         = "/run/confexts"
-	VerityCertDir          = "/run/verity.d/"
-	SysextDefaultPolicy    = "--image-policy=\"root=signed+absent:usr=signed+absent\""
-	EfiDir                 = "/efi"
 )

--- a/immucore/internal/utils/breakpoint.go
+++ b/immucore/internal/utils/breakpoint.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -28,12 +29,28 @@ var runBreakpointShell = spawnBreakpointShell
 // concurrently, and two shells sharing one console cannot both be typed into.
 var breakpointMu sync.Mutex
 
+var (
+	breakpointStepsOnce  sync.Once
+	breakpointStepsCache []string
+)
+
 // BreakpointSteps returns the step names requested on the cmdline via
 // rd.immucore.break=. The stanza can be repeated and each occurrence can carry
 // a comma-separated list, so rd.immucore.break=load-config,mount-root and
 // rd.immucore.break=load-config rd.immucore.break=mount-root mean the same
 // thing. Names are the Op* constants; anything else simply never matches.
+//
+// The cmdline is fixed for the life of the process, so it is read and parsed
+// once. BreakpointRequested asks for this on every DAG step, which would
+// otherwise be one /proc/cmdline read per step.
 func BreakpointSteps() []string {
+	breakpointStepsOnce.Do(func() {
+		breakpointStepsCache = parseBreakpointSteps()
+	})
+	return slices.Clone(breakpointStepsCache)
+}
+
+func parseBreakpointSteps() []string {
 	var out []string
 	for _, v := range ReadCMDLineArg(constants.CmdlineBreak) {
 		for _, name := range strings.Split(v, ",") {

--- a/immucore/internal/utils/breakpoint.go
+++ b/immucore/internal/utils/breakpoint.go
@@ -1,0 +1,205 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/kairos-io/kairos/v4/immucore/internal/constants"
+	"golang.org/x/term"
+)
+
+// breakpointShells is the search order for the shell a breakpoint hands the
+// console to, same as the error-path emergency shell uses. A variable so tests
+// can point it at something that is not an interactive shell.
+var breakpointShells = []string{"/bin/bash", "/bin/sh", "/sysroot/bin/bash", "/sysroot/bin/sh"}
+
+// runBreakpointShell spawns the shell and blocks until the operator leaves it.
+// Indirected through a variable so tests can exercise the surrounding plumbing
+// without a console.
+var runBreakpointShell = spawnBreakpointShell
+
+// breakpointMu serializes breakpoints. herd runs independent steps
+// concurrently, and two shells sharing one console cannot both be typed into.
+var breakpointMu sync.Mutex
+
+// BreakpointSteps returns the step names requested on the cmdline via
+// rd.immucore.break=. The stanza can be repeated and each occurrence can carry
+// a comma-separated list, so rd.immucore.break=load-config,mount-root and
+// rd.immucore.break=load-config rd.immucore.break=mount-root mean the same
+// thing. Names are the Op* constants; anything else simply never matches.
+func BreakpointSteps() []string {
+	var out []string
+	for _, v := range ReadCMDLineArg(constants.CmdlineBreak) {
+		for _, name := range strings.Split(v, ",") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			out = append(out, name)
+		}
+	}
+	return UniqueSlice(out)
+}
+
+// BreakpointRequested reports whether step was named on the cmdline.
+func BreakpointRequested(step string) bool {
+	step = strings.TrimSpace(step)
+	if step == "" {
+		return false
+	}
+	for _, want := range BreakpointSteps() {
+		if want == step {
+			return true
+		}
+	}
+	return false
+}
+
+// MaybeBreakpoint drops to a breakpoint shell when step was requested on the
+// cmdline, and returns once that shell exits. It returns immediately when no
+// breakpoint asks for this step, which is the case for every step on a normal
+// boot.
+func MaybeBreakpoint(step string) {
+	if !BreakpointRequested(step) {
+		return
+	}
+	DropToBreakpointShell(step)
+}
+
+// DropToBreakpointShell hands the console to an interactive shell and blocks
+// until it exits, then returns so the caller can carry on with the boot.
+//
+// This is deliberately not DropToEmergencyShell: that one ends in
+// syscall.Exec, which replaces the immucore process image. Correct for a
+// failure we cannot come back from, useless for a breakpoint, where the whole
+// point is that the DAG keeps going afterwards.
+func DropToBreakpointShell(step string) {
+	breakpointMu.Lock()
+	defer breakpointMu.Unlock()
+
+	KLog.Logger.Info().Str("step", step).Msg("Breakpoint reached, dropping to a shell. Exit the shell to resume the boot")
+
+	if err := runBreakpointShell(RenderBreakpointBanner(step)); err != nil {
+		KLog.Logger.Warn().Err(err).Str("step", step).Msg("Breakpoint shell failed")
+	}
+
+	KLog.Logger.Info().Str("step", step).Msg("Breakpoint released, resuming boot")
+}
+
+// RenderBreakpointBanner builds what the operator sees on the console before
+// the shell prompt. Kept separate from the spawn logic so it can be tested
+// without exec-ing anything, like RenderFailureSummary is.
+func RenderBreakpointBanner(step string) string {
+	var b strings.Builder
+	b.WriteString("========================================\n")
+	fmt.Fprintf(&b, "      IMMUCORE BREAKPOINT: %s\n", step)
+	b.WriteString("========================================\n")
+	fmt.Fprintf(&b, "Stopped before step %q (%s%s).\n", step, constants.CmdlineBreak, step)
+	fmt.Fprintf(&b, "Logs: %s\n", constants.LogDir)
+	b.WriteString("Exit this shell to resume the boot.\n")
+	b.WriteString("========================================\n")
+	return b.String()
+}
+
+// spawnBreakpointShell runs the first available shell as a child process,
+// attached to the console, and waits for it to exit.
+func spawnBreakpointShell(banner string) error {
+	tty := openBreakpointConsole()
+	out := io.Writer(os.Stderr)
+	if tty != nil {
+		out = tty
+		defer func() { _ = tty.Close() }()
+	} else {
+		KLog.Logger.Warn().Msg("Could not open a console for the breakpoint shell, using the inherited stdio")
+	}
+
+	_, _ = fmt.Fprint(out, banner)
+
+	for _, sh := range breakpointShells {
+		if _, err := os.Stat(sh); err != nil {
+			continue
+		}
+		started, err := runShellAndWait(sh, tty)
+		if !started {
+			KLog.Logger.Debug().Err(err).Str("shell", sh).Msg("Could not start the breakpoint shell")
+			continue
+		}
+		_, _ = fmt.Fprint(out, "Resuming boot.\n")
+		return err
+	}
+
+	return fmt.Errorf("no shell to break into, tried %s", strings.Join(breakpointShells, ", "))
+}
+
+// runShellAndWait starts sh as a child process and blocks until it exits.
+// started reports whether the child ran at all, so the caller can move on to
+// the next candidate when this one could not be executed.
+func runShellAndWait(sh string, tty *os.File) (started bool, err error) {
+	cmd := breakpointShellCmd(sh, tty, tty != nil)
+	if err := cmd.Start(); err != nil {
+		if cmd.SysProcAttr == nil {
+			return false, err
+		}
+		// TIOCSCTTY refuses to move a terminal that is already the
+		// controlling one of another session. Fall back to sharing
+		// immucore's session, which costs job control in the shell but
+		// still gives the operator a prompt.
+		KLog.Logger.Debug().Err(err).Str("shell", sh).Msg("Could not give the breakpoint shell its own session, sharing immucore's")
+		cmd = breakpointShellCmd(sh, tty, false)
+		if err := cmd.Start(); err != nil {
+			return false, err
+		}
+	}
+
+	err = cmd.Wait()
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		// Leaving an interactive shell non-zero (Ctrl-C, a failed last
+		// command) is a normal way out, not a breakpoint failure.
+		return true, nil
+	}
+	return true, err
+}
+
+// breakpointShellCmd builds the shell command. With ownSession the child
+// becomes a session leader owning the console, so that its job control works
+// and a Ctrl-C in the shell does not land on immucore.
+func breakpointShellCmd(sh string, tty *os.File, ownSession bool) *exec.Cmd {
+	cmd := exec.Command(sh) // #nosec G204 -- sh comes from breakpointShells, not from the cmdline
+	cmd.Env = shellEnvWithPath()
+
+	if tty == nil {
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+		return cmd
+	}
+
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = tty, tty, tty
+	if ownSession {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true, Ctty: 0}
+	}
+	return cmd
+}
+
+// openBreakpointConsole opens the console the operator is actually looking at,
+// read-write and without taking it as our own controlling terminal. Returns
+// nil when none of the candidates is a usable terminal.
+func openBreakpointConsole() *os.File {
+	for _, dev := range ConsoleDevices() {
+		f, err := os.OpenFile(dev, os.O_RDWR|syscall.O_NOCTTY, 0)
+		if err != nil {
+			continue
+		}
+		if !term.IsTerminal(int(f.Fd())) {
+			_ = f.Close()
+			continue
+		}
+		return f
+	}
+	return nil
+}

--- a/immucore/internal/utils/breakpoint.go
+++ b/immucore/internal/utils/breakpoint.go
@@ -116,7 +116,7 @@ func spawnBreakpointShell(banner string) error {
 		out = tty
 		defer func() { _ = tty.Close() }()
 	} else {
-		KLog.Logger.Warn().Msg("Could not open a console for the breakpoint shell, using the inherited stdio")
+		KLog.Logger.Warn().Msg("No usable console for the breakpoint shell, falling back to the inherited stdio; if that stdin is not a terminal the shell exits at once and the boot resumes")
 	}
 
 	_, _ = fmt.Fprint(out, banner)

--- a/immucore/internal/utils/breakpoint_internal_test.go
+++ b/immucore/internal/utils/breakpoint_internal_test.go
@@ -1,0 +1,185 @@
+package utils
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/kairos-io/kairos/v4/immucore/internal/constants"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("breakpoints", func() {
+	var cmdlinePath string
+
+	writeCmdline := func(s string) {
+		Expect(os.WriteFile(cmdlinePath, []byte(s+"\n"), 0o600)).To(Succeed())
+	}
+
+	BeforeEach(func() {
+		cmdlinePath = filepath.Join(GinkgoT().TempDir(), "cmdline")
+		writeCmdline("")
+
+		old, had := os.LookupEnv("HOST_PROC_CMDLINE")
+		Expect(os.Setenv("HOST_PROC_CMDLINE", cmdlinePath)).To(Succeed())
+		DeferCleanup(func() {
+			if had {
+				Expect(os.Setenv("HOST_PROC_CMDLINE", old)).To(Succeed())
+				return
+			}
+			Expect(os.Unsetenv("HOST_PROC_CMDLINE")).To(Succeed())
+		})
+	})
+
+	Context("reading the cmdline", func() {
+		It("picks up a single requested step", func() {
+			writeCmdline("root=LABEL=COS_ACTIVE rd.immucore.break=mount-root quiet")
+			Expect(BreakpointSteps()).To(Equal([]string{constants.OpMountRoot}))
+			Expect(BreakpointRequested(constants.OpMountRoot)).To(BeTrue())
+			Expect(BreakpointRequested(constants.OpLoadConfig)).To(BeFalse())
+		})
+
+		It("requests nothing when the stanza is absent", func() {
+			writeCmdline("root=LABEL=COS_ACTIVE rd.immucore.debug quiet")
+			Expect(BreakpointSteps()).To(BeEmpty())
+			Expect(BreakpointRequested(constants.OpMountRoot)).To(BeFalse())
+		})
+
+		It("requests nothing when the stanza carries no value", func() {
+			writeCmdline("rd.immucore.break=")
+			Expect(BreakpointSteps()).To(BeEmpty())
+			Expect(BreakpointRequested(constants.OpMountRoot)).To(BeFalse())
+		})
+
+		It("accepts several steps, comma-separated or repeated, without duplicates", func() {
+			writeCmdline("rd.immucore.break=load-config,mount-root rd.immucore.break=mount-root rd.immucore.break=overlay-mount")
+			Expect(BreakpointSteps()).To(Equal([]string{
+				constants.OpLoadConfig,
+				constants.OpMountRoot,
+				constants.OpOverlayMount,
+			}))
+			Expect(BreakpointRequested(constants.OpLoadConfig)).To(BeTrue())
+			Expect(BreakpointRequested(constants.OpOverlayMount)).To(BeTrue())
+		})
+
+		It("matches step names whole, not by prefix", func() {
+			writeCmdline("rd.immucore.break=mount")
+			Expect(BreakpointRequested(constants.OpMountRoot)).To(BeFalse())
+			Expect(BreakpointRequested(constants.OpMountOEM)).To(BeFalse())
+			Expect(BreakpointRequested(constants.OpMountState)).To(BeFalse())
+		})
+
+		It("never breaks on an unnamed step", func() {
+			writeCmdline("rd.immucore.break=mount-root")
+			Expect(BreakpointRequested("")).To(BeFalse())
+		})
+	})
+
+	Context("dropping to the shell", func() {
+		var spawned []string
+
+		fakeShell := func(err error) {
+			old := runBreakpointShell
+			runBreakpointShell = func(banner string) error {
+				spawned = append(spawned, banner)
+				return err
+			}
+			DeferCleanup(func() { runBreakpointShell = old })
+		}
+
+		BeforeEach(func() {
+			spawned = nil
+		})
+
+		It("spawns a shell for a requested step and comes back", func() {
+			fakeShell(nil)
+			writeCmdline("rd.immucore.break=mount-root")
+
+			MaybeBreakpoint(constants.OpMountRoot)
+
+			Expect(spawned).To(HaveLen(1))
+			Expect(spawned[0]).To(ContainSubstring(constants.OpMountRoot))
+			Expect(spawned[0]).To(ContainSubstring("Exit this shell to resume the boot"))
+		})
+
+		It("spawns nothing for a step nobody asked about", func() {
+			fakeShell(nil)
+			writeCmdline("rd.immucore.break=mount-root")
+
+			MaybeBreakpoint(constants.OpLoadConfig)
+
+			Expect(spawned).To(BeEmpty())
+		})
+
+		It("carries on when the shell could not be spawned", func() {
+			fakeShell(errors.New("no shell for you"))
+			writeCmdline("rd.immucore.break=mount-root")
+
+			MaybeBreakpoint(constants.OpMountRoot)
+
+			Expect(spawned).To(HaveLen(1))
+		})
+	})
+
+	Context("the shell child process", func() {
+		var dir string
+
+		useShells := func(shells ...string) {
+			old := breakpointShells
+			breakpointShells = shells
+			DeferCleanup(func() { breakpointShells = old })
+		}
+
+		writeShell := func(name, body string) string {
+			path := filepath.Join(dir, name)
+			Expect(os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o700)).To(Succeed())
+			return path
+		}
+
+		BeforeEach(func() {
+			dir = GinkgoT().TempDir()
+		})
+
+		It("waits for the shell to exit before handing control back", func() {
+			marker := filepath.Join(dir, "shell-exited")
+			useShells(writeShell("fakeshell", "sleep 0.2; touch "+marker))
+
+			Expect(spawnBreakpointShell("banner\n")).To(Succeed())
+
+			// The marker is only written by the child right before it exits,
+			// so its presence here is what proves we waited rather than
+			// resuming the boot underneath the operator.
+			Expect(marker).To(BeAnExistingFile())
+		})
+
+		It("treats a non-zero exit as a normal way out of the shell", func() {
+			useShells(writeShell("fakeshell", "exit 3"))
+			Expect(spawnBreakpointShell("banner\n")).To(Succeed())
+		})
+
+		It("falls through to the next candidate when one cannot be run", func() {
+			marker := filepath.Join(dir, "shell-exited")
+			unusable := filepath.Join(dir, "not-a-shell")
+			Expect(os.WriteFile(unusable, []byte("not executable"), 0o600)).To(Succeed())
+			useShells(filepath.Join(dir, "missing"), unusable, writeShell("fakeshell", "touch "+marker))
+
+			Expect(spawnBreakpointShell("banner\n")).To(Succeed())
+			Expect(marker).To(BeAnExistingFile())
+		})
+
+		It("reports when there is no shell to break into", func() {
+			useShells(filepath.Join(dir, "missing"))
+			Expect(spawnBreakpointShell("banner\n")).To(MatchError(ContainSubstring("no shell to break into")))
+		})
+	})
+
+	Context("the console banner", func() {
+		It("names the step and the stanza that stopped the boot", func() {
+			out := RenderBreakpointBanner(constants.OpOverlayMount)
+			Expect(out).To(ContainSubstring("IMMUCORE BREAKPOINT: overlay-mount"))
+			Expect(out).To(ContainSubstring(constants.CmdlineBreak + constants.OpOverlayMount))
+			Expect(out).To(ContainSubstring(constants.LogDir))
+		})
+	})
+})

--- a/immucore/internal/utils/breakpoint_internal_test.go
+++ b/immucore/internal/utils/breakpoint_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -19,8 +20,13 @@ import (
 var _ = Describe("breakpoints", func() {
 	var cmdlinePath string
 
+	// BreakpointSteps parses the cmdline once per process, so every rewrite
+	// here has to drop that cache or the case would assert on whatever the
+	// previous one wrote.
 	writeCmdline := func(s string) {
 		Expect(os.WriteFile(cmdlinePath, []byte(s+"\n"), 0o600)).To(Succeed())
+		breakpointStepsOnce = sync.Once{}
+		breakpointStepsCache = nil
 	}
 
 	BeforeEach(func() {

--- a/immucore/internal/utils/breakpoint_internal_test.go
+++ b/immucore/internal/utils/breakpoint_internal_test.go
@@ -1,13 +1,19 @@
 package utils
 
 import (
+	"bytes"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
+	"time"
 
+	"github.com/creack/pty"
 	"github.com/kairos-io/kairos/v4/immucore/internal/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
 )
 
 var _ = Describe("breakpoints", func() {
@@ -180,6 +186,56 @@ var _ = Describe("breakpoints", func() {
 			Expect(out).To(ContainSubstring("IMMUCORE BREAKPOINT: overlay-mount"))
 			Expect(out).To(ContainSubstring(constants.CmdlineBreak + constants.OpOverlayMount))
 			Expect(out).To(ContainSubstring(constants.LogDir))
+		})
+	})
+
+	// This is the one branch none of the tests above exercise: what happens
+	// when TIOCSCTTY genuinely refuses to hand the console over because
+	// another session already owns it as its controlling tty (the exact
+	// scenario runShellAndWait's comment describes). A plain file (even a
+	// TempDir file opened O_RDWR) can never trigger that refusal -- only a
+	// real pty slave that another process has already Setctty'd onto can.
+	Context("the console session fallback", func() {
+		It("falls back to sharing immucore's session when the console already belongs to another session", func() {
+			master, slave, err := pty.Open()
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = master.Close() }()
+			defer func() { _ = slave.Close() }()
+
+			// Claim the slave as another session's controlling tty first, so
+			// the breakpoint shell's own Setctty attempt below is guaranteed
+			// to hit EPERM -- TIOCSCTTY refuses to steal a tty that already
+			// is a session's ctty.
+			holder := exec.Command("sleep", "5")
+			holder.Stdin, holder.Stdout, holder.Stderr = slave, slave, slave
+			holder.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true, Ctty: 0}
+			Expect(holder.Start()).To(Succeed())
+			defer func() {
+				_ = holder.Process.Kill()
+				_, _ = holder.Process.Wait()
+			}()
+			// give the holder a beat to actually own the tty before we race it
+			time.Sleep(150 * time.Millisecond)
+
+			var logbuf bytes.Buffer
+			oldLogger := KLog.Logger
+			KLog.Logger = zerolog.New(&logbuf).Level(zerolog.DebugLevel)
+			defer func() { KLog.Logger = oldLogger }()
+
+			dir := GinkgoT().TempDir()
+			marker := filepath.Join(dir, "shell-exited")
+			shPath := filepath.Join(dir, "fakeshell")
+			Expect(os.WriteFile(shPath, []byte("#!/bin/sh\ntouch "+marker+"\n"), 0o700)).To(Succeed())
+
+			started, err := runShellAndWait(shPath, slave)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(started).To(BeTrue())
+			// The marker only exists if the fallback attempt actually ran
+			// the shell to completion, proving the retry recovered rather
+			// than swallowing the first Start() error.
+			Expect(marker).To(BeAnExistingFile())
+			Expect(logbuf.String()).To(ContainSubstring("sharing immucore's"))
 		})
 	})
 })

--- a/immucore/internal/utils/common.go
+++ b/immucore/internal/utils/common.go
@@ -667,7 +667,9 @@ func DropToEmergencyShellWithError(reason string) {
 	DropToEmergencyShell()
 }
 
-func DropToEmergencyShell() {
+// shellEnvWithPath returns the environment for a shell we hand the console to,
+// with the usual PATH appended: under UKI there is nothing else setting one.
+func shellEnvWithPath() []string {
 	env := os.Environ()
 	// try to extract any existing path from the environment
 	pathAppend := constants.PathAppend
@@ -677,7 +679,11 @@ func DropToEmergencyShell() {
 			pathAppend = fmt.Sprintf("%s:%s", pathAppend, splitted[1])
 		}
 	}
-	env = append(env, fmt.Sprintf("%s=%s", constants.PATH, pathAppend))
+	return append(env, fmt.Sprintf("%s=%s", constants.PATH, pathAppend))
+}
+
+func DropToEmergencyShell() {
+	env := shellEnvWithPath()
 	if err := syscall.Exec("/bin/bash", []string{"/bin/bash"}, env); err != nil {
 		if err := syscall.Exec("/bin/sh", []string{"/bin/sh"}, env); err != nil {
 			if err := syscall.Exec("/sysroot/bin/bash", []string{"/sysroot/bin/bash"}, env); err != nil {

--- a/immucore/pkg/cmd/root.go
+++ b/immucore/pkg/cmd/root.go
@@ -96,6 +96,10 @@ func NewApp() *cli.App {
 
 		utils.KLog.Logger.Info().Msg(st.WriteDAG(g))
 
+		if steps := utils.BreakpointSteps(); len(steps) > 0 {
+			utils.KLog.Logger.Info().Strs("steps", steps).Msg("Breakpoints requested via rd.immucore.break; a name that is not a step listed above is ignored")
+		}
+
 		// Once we print the dag we can exit already
 		if c.Bool("dry-run") {
 			return nil

--- a/immucore/pkg/state/breakpoint_internal_test.go
+++ b/immucore/pkg/state/breakpoint_internal_test.go
@@ -1,0 +1,78 @@
+package state
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	cnst "github.com/kairos-io/kairos/v4/immucore/internal/constants"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spectrocloud-labs/herd"
+)
+
+var _ = Describe("step breakpoints", func() {
+	stubHook := func(fn func(string)) {
+		old := breakpointHook
+		breakpointHook = fn
+		DeferCleanup(func() { breakpointHook = old })
+	}
+
+	BeforeEach(func() {
+		ResetTimeline()
+	})
+
+	It("consults the breakpoint before running the step, then resumes it", func() {
+		var order []string
+		stubHook(func(step string) { order = append(order, "break:"+step) })
+
+		g := herd.DAG(herd.EnableInit)
+		Expect(g.Add(cnst.OpMountRoot, TimedCallback(cnst.OpMountRoot, func(_ context.Context) error {
+			order = append(order, "run:"+cnst.OpMountRoot)
+			return nil
+		}))).To(Succeed())
+
+		Expect(g.Run(context.Background())).To(Succeed())
+		Expect(order).To(Equal([]string{"break:" + cnst.OpMountRoot, "run:" + cnst.OpMountRoot}))
+		Expect(Timings()).To(HaveKey(cnst.OpMountRoot))
+	})
+
+	It("keeps the time spent in the shell out of the step timing", func() {
+		stubHook(func(_ string) { time.Sleep(300 * time.Millisecond) })
+
+		g := herd.DAG(herd.EnableInit)
+		Expect(g.Add(cnst.OpLoadConfig, TimedCallback(cnst.OpLoadConfig, func(_ context.Context) error {
+			return nil
+		}))).To(Succeed())
+
+		Expect(g.Run(context.Background())).To(Succeed())
+		Expect(Timings()[cnst.OpLoadConfig].Duration).To(BeNumerically("<", 300*time.Millisecond))
+	})
+
+	It("runs every step untouched when the cmdline asks for no breakpoint", func() {
+		// Exercises the real hook, not a stub: no rd.immucore.break stanza
+		// means every step goes straight through.
+		cmdline := filepath.Join(GinkgoT().TempDir(), "cmdline")
+		Expect(os.WriteFile(cmdline, []byte("root=LABEL=COS_ACTIVE rd.immucore.debug\n"), 0o600)).To(Succeed())
+		old, had := os.LookupEnv("HOST_PROC_CMDLINE")
+		Expect(os.Setenv("HOST_PROC_CMDLINE", cmdline)).To(Succeed())
+		DeferCleanup(func() {
+			if had {
+				Expect(os.Setenv("HOST_PROC_CMDLINE", old)).To(Succeed())
+				return
+			}
+			Expect(os.Unsetenv("HOST_PROC_CMDLINE")).To(Succeed())
+		})
+
+		called := false
+		g := herd.DAG(herd.EnableInit)
+		Expect(g.Add(cnst.OpLoadConfig, TimedCallback(cnst.OpLoadConfig, func(_ context.Context) error {
+			called = true
+			return nil
+		}))).To(Succeed())
+
+		Expect(g.Run(context.Background())).To(Succeed())
+		Expect(called).To(BeTrue())
+	})
+})

--- a/immucore/pkg/state/timing.go
+++ b/immucore/pkg/state/timing.go
@@ -48,11 +48,21 @@ func RunTimed(name string, fn func() error) error {
 	return err
 }
 
+// breakpointHook is consulted before every timed step. A variable so tests can
+// observe the breakpoint check without a console to drop into.
+var breakpointHook = internalUtils.MaybeBreakpoint
+
 // TimedCallback wraps a herd callback so its wall-clock duration is recorded under name,
 // and returns it as a herd.WithCallback OpOption. This is the drop-in replacement for
 // herd.WithCallback(fn) in step registrations: herd.WithCallback(fn) -> state.TimedCallback(name, fn).
+//
+// It is also where rd.immucore.break= is honored: since nearly every step in
+// the DAG registers through here, one check covers them all. The breakpoint
+// runs before the step and outside RunTimed, so time spent poking around in
+// the shell does not land in the boot timeline.
 func TimedCallback(name string, fn func(context.Context) error) herd.OpOption {
 	return herd.WithCallback(func(ctx context.Context) error {
+		breakpointHook(name)
 		return RunTimed(name, func() error { return fn(ctx) })
 	})
 }


### PR DESCRIPTION
> Automated triage agent (`kairos-triage-agent`) running as `@itxaka-agent`.
> This comment was generated by software. A human maintainer can override any
> action taken here.

Fixes: #1157

## What

Adds a dracut-`rd.break`-style breakpoint to immucore's boot DAG: `rd.immucore.break=<step>[,<step>...]` (repeatable) stops the boot right before the named step and hands the console to an interactive shell, resuming the DAG when that shell exits.

## Why

There was no way to pause a boot that is otherwise succeeding in order to look around mid-boot — the only existing shell drop is `DropToEmergencyShellWithError`, which only fires on a real DAG failure and never returns (it execs and replaces the process). This is a different, additive mechanism: a child process the caller waits on, not a process replacement.

## How

- One hook point: `TimedCallback` (`immucore/pkg/state/timing.go`), which nearly every DAG step already routes through, checks the requested step names against the one currently running.
- Valid step names are the `Op*` constants the DAG is built from — `immucore --dry-run` prints the full resolved DAG (and, as of this PR, echoes which breakpoint steps were actually requested) so an operator can check spelling against their own boot configuration before rebooting into it.
- The breakpoint shell is a new fork-and-wait helper, not a reuse of the existing exec-and-replace one: it opens the console read-write, tries to give itself its own session so job control works, falls back to sharing immucore's session if the console already belongs to one, and falls back further to inherited stdio (with a warning that names the likely outcome) if no console can be opened at all.
- Breakpoints are serialized with a mutex since the DAG runs independent steps concurrently.

## Verified

Built a test ISO and booted it under QEMU/KVM. With `rd.immucore.break=wait-for-sysroot`: DAG dump → breakpoint banner → live interactive shell (proved live, not a frozen console) → `exit` → boot resumes and completes normally. Control boot with no flag: identical DAG shape and timings, zero breakpoint output — confirmed no-op when the flag is absent. The boot-timeline shows shell dwell time is excluded from step timing as designed. Full logs and the exact QEMU/build commands are in the audit trail linked below.

## Review

Went two rounds. Round 0 flagged a flaky test barrier, a stale README pointer, an oversized diff from an incidental gofmt re-indent, and a fallback warning message that didn't match what the operator would actually observe under the real deployed systemd unit — the latter two verified empirically (one confirmed via a synthetic gofmt repro, one confirmed via checking systemd's actual `StandardInput=` default and the generated unit file) before being published. A fifth finding was dropped after empirical verification showed its suggested fix didn't work as described. Round 1 confirmed all four fixes land correctly and approved with no further comments.

Full chronological audit trail (every phase, every round, every verdict): https://github.com/kairos-io/kairos/issues/1157#issuecomment-5585208900
