### PR TITLE
fix(deps): bump github.com/mudler/yip v1.26.0 → v1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/mudler/go-pluggable v0.0.0-20230126220627-7710299a0ae5
 	github.com/mudler/go-processmanager v0.1.1
-	github.com/mudler/yip v1.26.0
+	github.com/mudler/yip v1.26.1
 	github.com/nxadm/tail v1.4.11
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -753,6 +753,8 @@ github.com/mudler/water v0.0.0-20250808092830-dd90dcf09025 h1:WFLP5FHInarYGXi6B/
 github.com/mudler/water v0.0.0-20250808092830-dd90dcf09025/go.mod h1:QuIFdRstyGJt+MTTkWY+mtD7U6xwjOR6SwKUjmLZtR4=
 github.com/mudler/yip v1.26.0 h1:3vhBC5On7kSlkb7jjLCeAEA+v3ChkzSCpAjAxqvqiDA=
 github.com/mudler/yip v1.26.0/go.mod h1:nwV/hboHZzzgCe1Qjy5hUujhAsBkYqTIe2xxmvi/J+g=
+github.com/mudler/yip v1.26.1 h1:UrD/KFH0xNrPQw5SkirH1qslwWykAZUAsUfWEu1fuqs=
+github.com/mudler/yip v1.26.1/go.mod h1:nwV/hboHZzzgCe1Qjy5hUujhAsBkYqTIe2xxmvi/J+g=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=


### PR DESCRIPTION
## Summary

- Bumps `github.com/mudler/yip` from `v1.26.0` to `v1.26.1`
- Picks up [mudler/yip#336](https://github.com/mudler/yip/pull/336): Hetzner native metadata API fix

## Why

Hetzner removed all EC2-compatible metadata routes on **2026-08-01** ([changelog](https://docs.hetzner.cloud/changelog#2026-08-01-removed-metadata-routes)).

`v1.26.0` still used the old AWS-shared constants pointing at `/latest/meta-data/` — so `Probe()` returned `false`, the Hetzner datasource was never selected, and Kairos nodes booted with no hostname, no SSH keys, and no cloud-config applied.

`v1.26.1` fixes this by fetching `/hetzner/v1/metadata` (the native endpoint), parsing the full YAML response, and preserving SSH key provisioning via the `public-keys` field in that document.

Closes #4374

## Test plan

- [ ] Boot a Kairos node on Hetzner Cloud after this bump and verify cloud-config is applied (hostname set, SSH keys present)