### PR TITLE
fix(ci): scope master/release/pr workflow permissions per job

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -25,13 +25,12 @@ on:
       - '.github/CODEOWNERS'
 
 permissions:
-  # See _build-iso.yaml for the reusable-workflow permission
-  # rationale (callers must cover callee).
-  contents: write
-  packages: write
-  id-token: write
-  security-events: write
-  actions: read
+  # Least-privilege baseline. A job that calls a reusable workflow
+  # needing more (or runs a privileged inline step) declares its own
+  # job-level `permissions:` matching exactly what that callee/step
+  # needs -- see _build-iso.yaml for the reusable-workflow rationale
+  # (callers must cover callee, never the other way round).
+  contents: read
 
 concurrency:
   group: ci-master-${{ github.ref }}-${{ github.repository }}
@@ -84,6 +83,9 @@ jobs:
   build-image-kairos-init:
     needs: [build-kairos-init, unit-tests, lint]
     uses: ./.github/workflows/_build-image-kairos-init.yaml
+    permissions:
+      contents: read
+      packages: write
     with:
       image_registry: ghcr.io/kairos-io/kairos
       # Scratch tag: qemu tests consume this, promote-images copies
@@ -105,6 +107,9 @@ jobs:
   build-image-kcrypt-challenger:
     needs: [build-kcrypt-challenger, unit-tests, lint]
     uses: ./.github/workflows/_build-image-kcrypt-challenger.yaml
+    permissions:
+      contents: read
+      packages: write
     with:
       image_registry: ghcr.io/kairos-io/kairos
       image_tag: master-scratch
@@ -133,6 +138,12 @@ jobs:
           - {name: 'amd64-core-ubuntu-20.04', arch: 'amd64', base_image: 'ubuntu:20.04', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
     name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      security-events: write
+      actions: read
     with:
       name: ${{ matrix.name }}
       # Consume the scratch kairos-init that build-image-kairos-init just published.
@@ -181,6 +192,12 @@ jobs:
             registry_repository: 'ci-temp-images'
     name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      security-events: write
+      actions: read
     with:
       name: ${{ matrix.name }}
       kairos_init_image: ghcr.io/kairos-io/kairos/kairos-init:master-scratch
@@ -337,6 +354,9 @@ jobs:
           - {test: 'boot-assessment', variant: 'core'}
     name: test-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
+    permissions:
+      contents: read
+      packages: read
     with:
       test: ${{ matrix.test }}
       variant: ${{ matrix.variant }}
@@ -358,6 +378,8 @@ jobs:
     # pushed to :master-scratch before this job can promote it.
     needs: [test-core, test-standard, test-standard-encryption, test-uki, build-iso-arm, build-image-kcrypt-challenger]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Login to ghcr.io
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,13 +36,11 @@ on:
       - '.github/CODEOWNERS'
 
 permissions:
-  # See _build-iso.yaml for the reusable-workflow permission
-  # rationale (callers must cover callee).
-  contents: write
-  packages: write
-  id-token: write
-  security-events: write
-  actions: read
+  # Least-privilege baseline. A job that calls a reusable workflow
+  # needing more declares its own job-level `permissions:` matching
+  # exactly what that callee needs -- see _build-iso.yaml for the
+  # reusable-workflow rationale (callers must cover callee).
+  contents: read
 
 concurrency:
   group: ci-pr-${{ github.head_ref || github.ref }}-${{ github.repository }}
@@ -65,6 +63,7 @@ jobs:
     name: authorize
     environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-builds' || 'internal' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: 'true'
 
@@ -109,6 +108,9 @@ jobs:
   build-image-kairos-init:
     needs: [build-kairos-init, unit-tests, lint]
     uses: ./.github/workflows/_build-image-kairos-init.yaml
+    permissions:
+      contents: read
+      packages: write
     with:
       image_registry: ghcr.io/kairos-io/kairos
       image_tag: pr-${{ github.event.pull_request.number }}
@@ -134,6 +136,9 @@ jobs:
   build-image-kcrypt-challenger:
     needs: [build-kcrypt-challenger, unit-tests, lint]
     uses: ./.github/workflows/_build-image-kcrypt-challenger.yaml
+    permissions:
+      contents: read
+      packages: write
     with:
       image_registry: ghcr.io/kairos-io/kairos
       image_tag: pr-${{ github.event.pull_request.number }}
@@ -181,6 +186,12 @@ jobs:
           - {name: 'amd64-core-ubuntu-20.04', arch: 'amd64', base_image: 'ubuntu:20.04', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
     name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      security-events: write
+      actions: read
     with:
       name: ${{ matrix.name }}
       kairos_init_image: ghcr.io/kairos-io/kairos/kairos-init:pr-${{ github.event.pull_request.number }}
@@ -244,6 +255,12 @@ jobs:
             registry_repository: 'ci-temp-images'
     name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      security-events: write
+      actions: read
     with:
       name: ${{ matrix.name }}
       kairos_init_image: ghcr.io/kairos-io/kairos/kairos-init:pr-${{ github.event.pull_request.number }}
@@ -435,6 +452,9 @@ jobs:
           - {test: 'boot-assessment', variant: 'core'}
     name: test-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
+    permissions:
+      contents: read
+      packages: read
     with:
       test: ${{ matrix.test }}
       variant: ${{ matrix.variant }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,14 +37,11 @@ on:
       - 'v*'
 
 permissions:
-  # See _build-iso.yaml for the reusable-workflow permission
-  # rationale. contents:write is also required to attach artifacts
-  # to the GitHub Release the tag created.
-  contents: write
-  packages: write
-  id-token: write
-  security-events: write
-  actions: read
+  # Least-privilege baseline. A job that calls a reusable workflow
+  # needing more declares its own job-level `permissions:` matching
+  # exactly what that callee needs -- see _build-iso.yaml for the
+  # reusable-workflow rationale (callers must cover callee).
+  contents: read
 
 concurrency:
   group: ci-release-${{ github.ref }}-${{ github.repository }}
@@ -68,6 +65,7 @@ jobs:
   # jq expression release-legacy.yaml carried before retirement.
   get-k3s-versions:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       kubernetes_versions: ${{ steps.get.outputs.kubernetes_versions }}
     steps:
@@ -96,6 +94,7 @@ jobs:
 
   get-k0s-versions:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       kubernetes_versions: ${{ steps.get.outputs.kubernetes_versions }}
     steps:
@@ -144,6 +143,9 @@ jobs:
   build-image-kairos-init:
     needs: [build-kairos-init, unit-tests, lint]
     uses: ./.github/workflows/_build-image-kairos-init.yaml
+    permissions:
+      contents: read
+      packages: write
     with:
       image_registry: quay.io/kairos
       image_tag: ${{ github.ref_name }}
@@ -164,6 +166,9 @@ jobs:
   build-image-kcrypt-challenger:
     needs: [build-kcrypt-challenger, unit-tests, lint]
     uses: ./.github/workflows/_build-image-kcrypt-challenger.yaml
+    permissions:
+      contents: read
+      packages: write
     with:
       image_registry: quay.io/kairos
       image_tag: ${{ github.ref_name }}
@@ -187,6 +192,12 @@ jobs:
           - {name: 'amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
     name: build-iso / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      security-events: write
+      actions: read
     with:
       name: ${{ matrix.name }}
       kairos_init_image: quay.io/kairos/kairos-init:${{ github.ref_name }}
@@ -239,6 +250,12 @@ jobs:
             kubernetes_distro: ''
     name: build-iso-arm / ${{ matrix.name }}
     uses: ./.github/workflows/_build-iso.yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      security-events: write
+      actions: read
     with:
       name: ${{ matrix.name }}
       kairos_init_image: quay.io/kairos/kairos-init:${{ github.ref_name }}
@@ -277,6 +294,12 @@ jobs:
       matrix:
         kubernetes_version: ${{ fromJson(needs.get-k3s-versions.outputs.kubernetes_versions) }}
     uses: ./.github/workflows/_build-iso.yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      security-events: write
+      actions: read
     with:
       name: 'amd64-standard-k3s-${{ matrix.kubernetes_version }}'
       kairos_init_image: quay.io/kairos/kairos-init:${{ github.ref_name }}
@@ -305,6 +328,12 @@ jobs:
         model: ['generic', 'rpi4']
         kubernetes_version: ${{ fromJson(needs.get-k3s-versions.outputs.kubernetes_versions) }}
     uses: ./.github/workflows/_build-iso.yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      security-events: write
+      actions: read
     with:
       name: 'arm64-standard-${{ matrix.model }}-k3s-${{ matrix.kubernetes_version }}'
       kairos_init_image: quay.io/kairos/kairos-init:${{ github.ref_name }}
@@ -333,6 +362,12 @@ jobs:
       matrix:
         kubernetes_version: ${{ fromJson(needs.get-k0s-versions.outputs.kubernetes_versions) }}
     uses: ./.github/workflows/_build-iso.yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      security-events: write
+      actions: read
     with:
       name: 'amd64-standard-k0s-${{ matrix.kubernetes_version }}'
       kairos_init_image: quay.io/kairos/kairos-init:${{ github.ref_name }}
@@ -366,4 +401,6 @@ jobs:
       - build-image-kairos-init
       - build-image-kcrypt-challenger
     uses: ./.github/workflows/_upload-release.yaml
+    permissions:
+      contents: write
     secrets: inherit


### PR DESCRIPTION
OpenSSF Scorecard's Token-Permissions check flags `master.yaml`, `release.yaml` and `pr.yaml` for granting `contents`/`packages`/`id-token`/`security-events` write at the top level.

Every job in these three files either calls a local reusable workflow (which already declares its own, narrower `permissions:` block: GitHub intersects caller and callee permissions, so the callee already caps the effective token regardless of the caller's grant) or runs privileged inline steps directly (`promote-images`' docker push, or jobs like `authorize` and the k3s/k0s version lookups that use `GITHUB_TOKEN` for nothing at all). The broad top-level grant was therefore already unused by most jobs, just undeclared as such.

Narrowed each workflow's top-level `permissions:` to `contents: read`, and added an explicit job-level `permissions:` block wherever a job needs more, matching exactly what its reusable callee (or inline step) already requires. This does not change what any job's token can actually do at runtime; it only makes each job's real requirement visible in the declaration, which is what Scorecard's static check inspects.

Verified: all three files parse as valid YAML, and every added job-level block was cross-checked against the exact `permissions:` the called reusable workflow (or inline step) already declares, so no job loses access it currently uses.

Draft, per this project's kairos-io write process. Awaiting review before moving out of draft.
