### PR TITLE
feat(agent): run a first-boot cloud-config stage

### DIFF
--- a/agent/internal/agent/hooks/firstboot.go
+++ b/agent/internal/agent/hooks/firstboot.go
@@ -15,8 +15,13 @@ type FirstBootStage struct{}
 
 func (b FirstBootStage) Run(c sdkConfig.Config, _ sdkSpec.Spec) error {
 	c.Logger.Logger.Info().Msgf("Running %s hook", cnst.FirstBootHook)
+	// A failure here is logged, not returned. Propagating it would abort the
+	// sentinel-gated block before the firstboot sentinel is written, so a node
+	// with strict mode on would re-run this hook (and re-install bundles, and
+	// rewrite grubenv) on every restart of the agent unit and never publish its
+	// bootstrap event. RunStage already logs the details for the operator.
 	if err := utils.RunStage(&c, cnst.FirstBootHook); err != nil {
-		return err
+		c.Logger.Logger.Err(err).Msgf("Failed running the %s stage, continuing so the firstboot sentinel still gets written", cnst.FirstBootHook)
 	}
 	c.Logger.Logger.Info().Msgf("Finish %s hook", cnst.FirstBootHook)
 	return nil

--- a/agent/internal/agent/hooks/firstboot.go
+++ b/agent/internal/agent/hooks/firstboot.go
@@ -1,0 +1,23 @@
+package hook
+
+import (
+	cnst "github.com/kairos-io/kairos/v4/agent/pkg/constants"
+	"github.com/kairos-io/kairos/v4/agent/pkg/utils"
+	sdkConfig "github.com/kairos-io/kairos/v4/sdk/types/config"
+	sdkSpec "github.com/kairos-io/kairos/v4/sdk/types/spec"
+)
+
+// FirstBootStage runs the first-boot cloud-config stage. Unlike boot, network or
+// fs, this stage has no systemd unit driving it: the agent fires it once, from
+// the sentinel-gated first boot block, so a cloud-config can hook into the very
+// first boot of a node and never again.
+type FirstBootStage struct{}
+
+func (b FirstBootStage) Run(c sdkConfig.Config, _ sdkSpec.Spec) error {
+	c.Logger.Logger.Info().Msgf("Running %s hook", cnst.FirstBootHook)
+	if err := utils.RunStage(&c, cnst.FirstBootHook); err != nil {
+		return err
+	}
+	c.Logger.Logger.Info().Msgf("Finish %s hook", cnst.FirstBootHook)
+	return nil
+}

--- a/agent/internal/agent/hooks/hook.go
+++ b/agent/internal/agent/hooks/hook.go
@@ -33,8 +33,9 @@ var FinishUpgrade = []Interface{
 
 // FirstBoot is a list of hooks that run on the first boot of the node.
 var FirstBoot = []Interface{
-	&BundleFirstBoot{},
-	&GrubFirstBootOptions{},
+	&BundleFirstBoot{},      // Installs bundles
+	&GrubFirstBootOptions{}, // Applies grub options
+	&FirstBootStage{},       // Runs the first-boot cloud-config stage, last so it sees a fully provisioned node
 }
 
 // FinishUKIInstall is a list of hooks that run when the install process is finished completely.

--- a/agent/internal/agent/hooks/hooks_test.go
+++ b/agent/internal/agent/hooks/hooks_test.go
@@ -191,7 +191,10 @@ var _ = Describe("Hooks", func() {
 
 	Context("FirstBootStage", func() {
 		BeforeEach(func() {
-			fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{})
+			// An empty /proc/cmdline keeps RunStage's cmdline read from
+			// manufacturing an error of its own on every call, which would
+			// otherwise mask what the strict specs below assert on.
+			fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{"/proc/cmdline": ""})
 			Expect(err).Should(BeNil())
 			memLog = &bytes.Buffer{}
 			logger = sdkLogger.NewBufferLogger(memLog)
@@ -232,16 +235,19 @@ var _ = Describe("Hooks", func() {
 			Expect(memLog.String()).To(ContainSubstring("Finish first-boot hook"))
 		})
 
-		It("propagates a cloud-init failure when strict mode is enabled", func() {
+		It("logs a cloud-init failure in strict mode instead of failing the hook", func() {
 			cloudInit.Error = true
 			cfg.Strict = true
 			stage := hook.FirstBootStage{}
 			err = stage.Run(*cfg, nil)
-			Expect(err).ShouldNot(BeNil())
-			// The hook returns before logging completion on a strict failure,
-			// which is what leaves the sentinel unwritten one level up in
-			// agent.Run (not exercised here -- see hooks_test.go package doc).
-			Expect(memLog.String()).ToNot(ContainSubstring("Finish first-boot hook"))
+			Expect(err).Should(BeNil())
+			// Swallowing the error is what keeps
+			// machine.CreateSentinel("firstboot") reachable in agent.Run (not
+			// exercised by this suite), so the node is not stuck re-running the
+			// first boot block. The log line is the operator's only trace.
+			Expect(memLog.String()).To(ContainSubstring("continuing so the firstboot sentinel still gets written"))
+			Expect(memLog.String()).To(ContainSubstring("cloud init failure"))
+			Expect(memLog.String()).To(ContainSubstring("Finish first-boot hook"))
 		})
 
 		It("does not fail the hook when strict mode is off, even if the runner errors", func() {
@@ -250,6 +256,9 @@ var _ = Describe("Hooks", func() {
 			stage := hook.FirstBootStage{}
 			err = stage.Run(*cfg, nil)
 			Expect(err).Should(BeNil())
+			// Non-strict runs never reach the hook's own error branch: RunStage
+			// absorbs the failure itself and hands back nil.
+			Expect(memLog.String()).ToNot(ContainSubstring("continuing so the firstboot sentinel still gets written"))
 			Expect(memLog.String()).To(ContainSubstring("Finish first-boot hook"))
 		})
 

--- a/agent/internal/agent/hooks/hooks_test.go
+++ b/agent/internal/agent/hooks/hooks_test.go
@@ -262,6 +262,24 @@ var _ = Describe("Hooks", func() {
 			Expect(memLog.String()).To(ContainSubstring("Finish first-boot hook"))
 		})
 
+		It("keeps the FirstBoot hook chain alive when the stage fails in strict mode", func() {
+			// This is the actual failure mode from the bug report: agent.Run
+			// walks hook.FirstBoot as a single chain and only reaches
+			// machine.CreateSentinel("firstboot") if that chain returns nil.
+			// The specs above only exercise FirstBootStage in isolation, so
+			// they can't tell us whether hook.Run -- which returns early on
+			// the first error, see hook.go -- still makes it past this stage
+			// when it's last in line and the node is strict. Drive the real
+			// chain to be sure nothing upstream of FirstBootStage regresses
+			// that guarantee.
+			cloudInit.Error = true
+			cfg.Strict = true
+			err = hook.Run(*cfg, nil, hook.FirstBoot...)
+			Expect(err).Should(BeNil())
+			Expect(cloudInit.ExecStages).To(ContainElement(cnst.FirstBootHook))
+			Expect(memLog.String()).To(ContainSubstring("continuing so the firstboot sentinel still gets written"))
+		})
+
 		It("runs last in the FirstBoot hook list, after bundles and grub options", func() {
 			Expect(hook.FirstBoot).To(HaveLen(3))
 			Expect(hook.FirstBoot[0]).To(BeAssignableToTypeOf(&hook.BundleFirstBoot{}))

--- a/agent/internal/agent/hooks/hooks_test.go
+++ b/agent/internal/agent/hooks/hooks_test.go
@@ -188,4 +188,80 @@ var _ = Describe("Hooks", func() {
 		})
 
 	})
+
+	Context("FirstBootStage", func() {
+		BeforeEach(func() {
+			fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{})
+			Expect(err).Should(BeNil())
+			memLog = &bytes.Buffer{}
+			logger = sdkLogger.NewBufferLogger(memLog)
+			logger.SetLevel("debug")
+			cloudInit = &v1mock.FakeCloudInitRunner{}
+			cfg = config.NewConfig(
+				config.WithFs(fs),
+				config.WithLogger(logger),
+				config.WithCloudInitRunner(cloudInit),
+			)
+			cfg.Collector = collector.Config{}
+		})
+		AfterEach(func() {
+			cleanup()
+		})
+
+		It("drives the cloud-init runner through the first-boot stage family", func() {
+			stage := hook.FirstBootStage{}
+			err = stage.Run(*cfg, nil)
+			Expect(err).Should(BeNil())
+
+			// RunStage (already covered end-to-end in agent/pkg/utils) fans a
+			// single stage name out into before/main/after, and may revisit
+			// them again for the dot-notation cmdline pass. What belongs to
+			// this hook's own contract is: every stage name it produces is
+			// part of the first-boot family, and before/main/after each show
+			// up at least once -- i.e. FirstBootStage handed "first-boot",
+			// not some other stage name, to RunStage.
+			Expect(cloudInit.ExecStages).To(ContainElements(
+				cnst.FirstBootHook+".before",
+				cnst.FirstBootHook,
+				cnst.FirstBootHook+".after",
+			))
+			for _, s := range cloudInit.ExecStages {
+				Expect(s).To(HavePrefix(cnst.FirstBootHook))
+			}
+			Expect(memLog.String()).To(ContainSubstring("Running first-boot hook"))
+			Expect(memLog.String()).To(ContainSubstring("Finish first-boot hook"))
+		})
+
+		It("propagates a cloud-init failure when strict mode is enabled", func() {
+			cloudInit.Error = true
+			cfg.Strict = true
+			stage := hook.FirstBootStage{}
+			err = stage.Run(*cfg, nil)
+			Expect(err).ShouldNot(BeNil())
+			// The hook returns before logging completion on a strict failure,
+			// which is what leaves the sentinel unwritten one level up in
+			// agent.Run (not exercised here -- see hooks_test.go package doc).
+			Expect(memLog.String()).ToNot(ContainSubstring("Finish first-boot hook"))
+		})
+
+		It("does not fail the hook when strict mode is off, even if the runner errors", func() {
+			cloudInit.Error = true
+			cfg.Strict = false
+			stage := hook.FirstBootStage{}
+			err = stage.Run(*cfg, nil)
+			Expect(err).Should(BeNil())
+			Expect(memLog.String()).To(ContainSubstring("Finish first-boot hook"))
+		})
+
+		It("runs last in the FirstBoot hook list, after bundles and grub options", func() {
+			Expect(hook.FirstBoot).To(HaveLen(3))
+			Expect(hook.FirstBoot[0]).To(BeAssignableToTypeOf(&hook.BundleFirstBoot{}))
+			Expect(hook.FirstBoot[1]).To(BeAssignableToTypeOf(&hook.GrubFirstBootOptions{}))
+			Expect(hook.FirstBoot[2]).To(BeAssignableToTypeOf(&hook.FirstBootStage{}))
+		})
+
+		It("names the stage first-boot", func() {
+			Expect(cnst.FirstBootHook).To(Equal("first-boot"))
+		})
+	})
 })

--- a/agent/pkg/constants/constants.go
+++ b/agent/pkg/constants/constants.go
@@ -72,6 +72,7 @@ const (
 	AfterUpgradeChrootHook       = "after-upgrade-chroot"
 	AfterUpgradeHook             = "after-upgrade"
 	BeforeUpgradeHook            = "before-upgrade"
+	FirstBootHook                = "first-boot"
 	TransitionImgFile            = "transition.img"
 	RunningStateDir              = "/run/initramfs/cos-state" // TODO: converge this constant with StateDir/RecoveryDir in dracut module from cos-toolkit
 	RunningRecoveryStateDir      = "/run/initramfs/isoscan"   // TODO: converge this constant with StateDir/RecoveryDir in dracut module from cos-toolkit


### PR DESCRIPTION
> Automated triage agent (`kairos-triage-agent`) running as `@itxaka-agent`.
> This comment was generated by software. A human maintainer can override any
> action taken here.

Fixes: #444

Adds a `first-boot` yip cloud-config stage: a `stages: { first-boot: [...] }` block now fires exactly once, on the node's first boot, through the same `first-boot`/`first-boot.before`/`first-boot.after` mechanism (`agent/pkg/utils.RunStage`) that already drives `boot`/`network`/`fs`/`reconcile`.

Runs last inside the existing sentinel-gated block in `agent.Run()` (`agent/internal/agent/agent.go`) — after the two existing Go-only first-boot hooks (`BundleFirstBoot`, `GrubFirstBootOptions`), so cloud-config sees a fully-provisioned node, and before `machine.CreateSentinel("firstboot")` is written. A failure in the stage is logged, not propagated: on a `strict: true` node a broken first-boot cloud-config no longer puts the agent into a restart loop (bundles re-installed, grub options rewritten, `EventBootstrap` never published) every 5 seconds — it boots through and the failure is visible in the agent log instead.

The previously-proposed mechanism, `machine.ExecuteInlineCloudConfig`, turned out to be dead code — it shells out to an `elemental` binary that doesn't exist in Kairos v4 — so this uses `agent/pkg/utils.RunStage` instead, matching every other stage.

Full history is on the linked issue: full audit trail of what each role (coder/tester/docs/reviewer) did across 2 review rounds is in the summary comment on #444.

One open item for a maintainer or follow-up PR: there's no place in this repo that enumerates valid yip stage names for `first-boot` to join (checked README, docs/, CONTRIBUTING.md, schema — `sdk/schema/root_schema.go`'s `Stages` map is unvalidated free-form). The user-facing stage reference lives in kairos-io/kairos-docs, which is out of scope for this agent's run — flagging so a docs PR there isn't forgotten.
