### PR TITLE
feature: add dry run to kairos-init

### DIFF
--- a/kairos-init/README.md
+++ b/kairos-init/README.md
@@ -30,6 +30,22 @@ docker build -t my-kairosified-image .
 
 You can then use [AuroraBoot](https://github.com/kairos-io/auroraboot) to transform that image into an ISO, RAW image, or use it as an upgrade source for a running Kairos system.
 
+## Dry-run
+
+Pass `--dry-run` to print the resolved yip stages that would run without
+applying any change to the system. The console logger is silenced so
+stdout is the raw yip YAML — the same format `yip` itself consumes, so
+you can pipe it back into `yip` (or diff it across builds) directly:
+
+```bash
+kairos-init --dry-run --version 1.0.0 > preview.yaml
+kairos-init --dry-run --version 1.0.0 --stage init | yip -
+```
+
+The output is a full `schema.YipConfig` (commands, files, packages,
+services, etc.). Nothing is written to `/etc/kairos` and no binary copy,
+`yip` execution, or provider hook runs during a dry run.
+
 ## NVIDIA / Jetson
 
 ### Jetson AGX Thor QSPI firmware

--- a/kairos-init/README.md
+++ b/kairos-init/README.md
@@ -33,7 +33,7 @@ You can then use [AuroraBoot](https://github.com/kairos-io/auroraboot) to transf
 ## Dry-run
 
 Pass `--dry-run` to print the resolved yip stages that would run without
-applying any change to the system. The console logger is silenced so
+executing them (no `yip` execution, file copies, or provider hook runs). The console logger is silenced so
 stdout is the raw yip YAML — the same format `yip` itself consumes, so
 you can pipe it back into `yip` (or diff it across builds) directly:
 

--- a/kairos-init/main.go
+++ b/kairos-init/main.go
@@ -126,6 +126,9 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("FIPS is not supported on riscv64")
 		}
 		preRun(cmd, args)
+		if config.DefaultConfig.DryRun {
+			return nil
+		}
 		if required := values.Model(config.DefaultConfig.Model).RequiredArch(); required != "" && required.String() != runtime.GOARCH {
 			return fmt.Errorf(
 				"model %q requires architecture %q but kairos-init is running on %q. "+
@@ -136,7 +139,9 @@ var rootCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logger := logger.NewKairosLogger("kairos-init", loglevelFlag.Value, false)
+		// In dry-run, silence the console logger so stdout stays machine-readable.
+		// Logs still land in journald / /var/log/kairos/kairos-init.log.
+		logger := logger.NewKairosLogger("kairos-init", loglevelFlag.Value, config.DefaultConfig.DryRun)
 		logger.Infof("Starting kairos-init version %s", values.GetVersion())
 		logger.Debug(litter.Sdump(values.GetFullVersion()))
 
@@ -172,6 +177,12 @@ var rootCmd = &cobra.Command{
 
 		litter.Config.HideZeroValues = true
 		litter.Config.HidePrivateFields = true
+
+		if config.DefaultConfig.DryRun {
+			_, err = os.Stdout.WriteString(runStages.ToString())
+			return err
+		}
+
 		// Save the stages to a file for debugging and future use
 		if stageFlag.Value == "all" {
 			_ = os.WriteFile("/etc/kairos/kairos-init-all-stage.yaml", []byte(runStages.ToString()), 0644)
@@ -225,6 +236,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&version, "version", "v", "", "set a version number to use for the generated system. Its used to identify this system for upgrades and such. Required.")
 	rootCmd.Flags().BoolVarP(&config.DefaultConfig.Extensions, "stage-extensions", "x", false, "enable stage extensions mode")
 	rootCmd.Flags().Var(skipStepsFlag, "skip-step", "Skip one or more steps. Valid values are: "+strings.Join(skipStepsFlag.Allowed, ", ")+". You can pass multiple values separated by commas, for example: --skip-step initrd,workarounds")
+	rootCmd.Flags().BoolVar(&config.DefaultConfig.DryRun, "dry-run", false, "print the resolved yip stages to stdout and exit without applying any change to the system")
 	// Mark required flags
 	_ = rootCmd.MarkFlagRequired("version")
 

--- a/kairos-init/main.go
+++ b/kairos-init/main.go
@@ -236,7 +236,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&version, "version", "v", "", "set a version number to use for the generated system. Its used to identify this system for upgrades and such. Required.")
 	rootCmd.Flags().BoolVarP(&config.DefaultConfig.Extensions, "stage-extensions", "x", false, "enable stage extensions mode")
 	rootCmd.Flags().Var(skipStepsFlag, "skip-step", "Skip one or more steps. Valid values are: "+strings.Join(skipStepsFlag.Allowed, ", ")+". You can pass multiple values separated by commas, for example: --skip-step initrd,workarounds")
-	rootCmd.Flags().BoolVar(&config.DefaultConfig.DryRun, "dry-run", false, "print the resolved yip stages to stdout and exit without applying any change to the system")
+	rootCmd.Flags().BoolVar(&config.DefaultConfig.DryRun, "dry-run", false, "print the resolved yip stages to stdout and exit without running yip stages, copying configs/binaries, or invoking provider hooks (logs may still be written)")
 	// Mark required flags
 	_ = rootCmd.MarkFlagRequired("version")
 

--- a/kairos-init/pkg/config/config.go
+++ b/kairos-init/pkg/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Extensions       bool
 	VersionOverrides VersionOverrides
 	SkipSteps        []string
+	DryRun           bool
 }
 
 type Provider struct {

--- a/kairos-init/pkg/stages/stages.go
+++ b/kairos-init/pkg/stages/stages.go
@@ -101,6 +101,11 @@ func RunInstallStage(logger logger.KairosLogger) (schema.YipConfig, error) {
 	// Add extensions from disk
 	data.Stages["after-install"] = append(data.Stages["after-install"], GetStageExtensions("after-install", logger)...)
 
+	if config.DefaultConfig.DryRun {
+		logger.Info("Dry-run: skipping execution of install stages and binary/config copies")
+		return data, nil
+	}
+
 	for _, st := range []string{"before-install", "install", "after-install"} {
 		err = initExecutor.Run(st, vfs.OSFS, yipConsole, data.ToString())
 		if err != nil {
@@ -193,6 +198,11 @@ func RunInitStage(logger logger.KairosLogger) (schema.YipConfig, error) {
 
 	// Add extensions from disk
 	data.Stages["after-init"] = append(data.Stages["after-init"], GetStageExtensions("after-init", logger)...)
+
+	if config.DefaultConfig.DryRun {
+		logger.Info("Dry-run: skipping execution of init stages")
+		return data, nil
+	}
 
 	for _, st := range []string{"before-init", "init", "after-init"} {
 		err = initExecutor.Run(st, vfs.OSFS, yipConsole, data.ToString())


### PR DESCRIPTION
Adds a dry-run flag to kairos-init which outputs a yip compatible yaml file of what it would have done based on the current system is run on.

<!-- please add an icon to the title of this PR (see https://github.com/kairos-io/kairos/blob/master/CONTRIBUTING.md#step-5-push-your-feature-branch-to-your-fork), and delete this line and similar ones -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3599
