### PR TITLE
fix(ci): key the k8s image tag off distro, not version, and build a k0s image every push

### DIFF
--- a/.github/scripts/verify_k8s_tag.py
+++ b/.github/scripts/verify_k8s_tag.py
@@ -14,10 +14,23 @@ executes all three and compares results.
 
 This script extracts the real `run:` shell out of the three workflow files
 via PyYAML, substitutes the `${{ inputs.* }}` expressions the same way
-GitHub Actions would, and executes the result under bash. Nothing here is
-copy-pasted shell logic: a future drift between the three copies shows up
-as a mismatch between what this script observed the files doing, not as a
+GitHub Actions would, and executes the result under bash. The two tag
+formats come out of `_build-iso.yaml`'s input default and `release.yaml`'s
+overrides rather than being retyped here. Nothing in this file is
+copy-pasted shell logic or a copied format string: a future drift shows up
+as a mismatch between what the script observed the files doing, not as a
 passing test of text duplicated into this file.
+
+Deriving the segment correctly is only half of it -- the two sides also
+have to agree on which cell is which. So the second half walks pr.yaml and
+master.yaml and, for every `reusable-qemu-test.yaml` / `_uki-test.yaml`
+job, resolves the `kubernetes_distro` it passes against the `build-iso`
+matrix cell sharing its base_image/arch/model. Exactly one cell has to
+match, and its computed variant has to be the variant the test job claims;
+otherwise the suite is booting one cell's image and reporting as another's
+coverage. Build cells are also checked pairwise for a unique pushed tag and
+a unique upload-sarif category, both of which collapse when two cells
+differ only by k8s distro.
 
 Usage:
     python3 .github/scripts/verify_k8s_tag.py
@@ -55,6 +68,24 @@ def step(doc, job, name_fragment):
     raise KeyError(name_fragment)
 
 
+def wf_call_inputs(doc):
+    # YAML 1.1 resolves a bare `on` to the boolean True, which is what
+    # PyYAML hands back for a workflow's trigger key.
+    trigger = doc["on"] if "on" in doc else doc[True]
+    return trigger["workflow_call"]["inputs"]
+
+
+def input_default(doc, name):
+    spec = wf_call_inputs(doc)[name]
+    if "default" in spec:
+        return spec["default"]
+    if spec.get("required"):
+        raise KeyError(f"{name} is required and has no default")
+    # A non-required workflow_call input without a default arrives as the
+    # zero value of its type.
+    return {"string": "", "boolean": False, "number": 0}[spec["type"]]
+
+
 def subst_inputs(script, inputs):
     def repl(m):
         key = m.group(1)
@@ -83,15 +114,22 @@ setup_script = step(factory, "build", "Setup environment")["run"]
 
 
 def factory_tag(distro, version, trusted_boot=False, tag_format=None,
-                artifact_format=None):
+                artifact_format=None, base_image="ghcr.io/kairos-io/hadron:v0.5.1",
+                model="generic", arch="amd64"):
+    """Run reusable-factory.yaml's real "Setup environment" step.
+
+    Returns UPPERCASE keys for shell variables printed after the step, and
+    lowercase keys for whatever the step wrote to $GITHUB_OUTPUT (the same
+    values later steps read back as steps.setup.outputs.*).
+    """
     inputs = {
         "kubernetes_distro": distro,
         "kubernetes_version": version,
         "version": "v4.5.0",
         "kairos_version": "v4.0.0",
-        "base_image": "ghcr.io/kairos-io/hadron:v0.5.1",
-        "model": "generic",
-        "arch": "amd64",
+        "base_image": base_image,
+        "model": model,
+        "arch": arch,
         "trusted_boot": "true" if trusted_boot else "false",
         "custom_tag_format": tag_format or "",
         "custom_artifact_format": artifact_format or "",
@@ -108,7 +146,8 @@ def factory_tag(distro, version, trusted_boot=False, tag_format=None,
         'git() { echo "v4.5.0"; }\n'
     )
     out = run(script + '\nprintf "TAG=%s\\nARTIFACT=%s\\nK8S=%s\\nDEFAULT_TAG=%s\\n" '
-                        '"$TAG" "$ARTIFACT_NAME" "$K8S" "$DEFAULT_TAG"', prelude)
+                        '"$TAG" "$ARTIFACT_NAME" "$K8S" "$DEFAULT_TAG"'
+                        '\ncat "$GITHUB_OUTPUT"', prelude)
     return dict(
         line.split("=", 1) for line in out.strip().splitlines() if "=" in line
     )
@@ -151,17 +190,44 @@ def uki_tag(distro, version, variant):
     return out.strip().split("IMAGE_NAME=")[1]
 
 
-PR_TAG_FMT = "$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL$K8S-$VERSION$UKI"
-REL_TAG_FMT = "$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION$K8S$UKI"
+# ---- the two tag formats, read out of the workflows that set them -----------
+# Retyping these as literals would let someone reorder _build-iso.yaml's
+# default (say, move $K8S after $VERSION) and keep this file green while the
+# real build and the two mirrors disagreed.
+build_iso = load(f"{WF}/_build-iso.yaml")
+release = load(f"{WF}/release.yaml")
+
+PR_TAG_FMT = input_default(build_iso, "custom_tag_format")
+
+release_fmts = {
+    name: job["with"]["custom_tag_format"]
+    for name, job in release["jobs"].items()
+    if "custom_tag_format" in (job.get("with") or {})
+}
+if not release_fmts:
+    raise SystemExit("release.yaml passes no custom_tag_format")
+if len(set(release_fmts.values())) != 1:
+    raise SystemExit(f"release.yaml's custom_tag_format copies diverged: {release_fmts}")
+REL_TAG_FMT = next(iter(release_fmts.values()))
+
+print(f"tag formats in use ({len(release_fmts)} release jobs agree):")
+print(f"  _build-iso.yaml default: {PR_TAG_FMT}")
+print(f"  release.yaml override:   {REL_TAG_FMT}\n")
 
 failures = []
 
 
-def check(label, got, want):
-    status = "ok  " if got == want else "FAIL"
+def fail(label, got, want):
+    failures.append((label, got, want))
+    print(f"  [FAIL] {label}\n         got  {got}\n         want {want}")
+
+
+def check(label, got, want, terse=False):
     if got != want:
-        failures.append((label, got, want))
-    print(f"  [{status}] {label}\n         got  {got}\n         want {want}")
+        return fail(label, got, want)
+    print(f"  [ok  ] {label}")
+    if not terse:
+        print(f"         got  {got}\n         want {want}")
 
 
 print("== pr/master build cells (kubernetes_version: auto) ==")
@@ -173,7 +239,7 @@ check("k3s tag", k3s["TAG"], "hadron-v0.5.1-standard-amd64-generic-k3s-v4.5.0")
 check("k0s tag", k0s["TAG"], "hadron-v0.5.1-standard-amd64-generic-k0s-v4.5.0")
 print(f"  k3s vs k0s collide? {k3s['TAG'] == k0s['TAG']}")
 if k3s["TAG"] == k0s["TAG"]:
-    failures.append(("k3s/k0s tag collision", k3s["TAG"], "distinct tags"))
+    fail("k3s/k0s tag collision", k3s["TAG"], "distinct tags")
 
 print("\n== release cells (kubernetes_version pinned) -- must be byte-identical to before ==")
 relcore = factory_tag("", "auto", tag_format=REL_TAG_FMT,
@@ -224,8 +290,199 @@ check("qemu pinned", qemu_tag("k3s", "v1.33.9+k3s1", "standard"),
       "ghcr.io/kairos-io/kairos/hadron:"
       + factory_tag("k3s", "v1.33.9+k3s1", tag_format=PR_TAG_FMT)["TAG"])
 
+
+# ---- callers: each test job must resolve to one build cell ------------------
+# The mirror checks above take the distro from this file on both sides, so they
+# cannot see a test job aimed at a cell that was built with a different
+# kubernetes_distro. That is the coupling that breaks quietly: `standard` alone
+# does not identify a k3s image once a k0s cell computes the same variant, so a
+# test job can end up booting one cell's image while reporting as the other's
+# coverage. Walk the callers instead and require each test job to land on
+# exactly one build-iso matrix cell.
+
+CALLEES = {
+    "_build-iso.yaml": build_iso,
+    "reusable-qemu-test.yaml": qemu,
+    "_uki-test.yaml": uki,
+}
+
+MATRIX_REF = re.compile(
+    r"^\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*(?:\|\|\s*'([^']*)'\s*)?\}\}$"
+)
+
+
+def callee(job):
+    return job.get("uses", "").rsplit("/", 1)[-1]
+
+
+def matrix_rows(job):
+    include = ((job.get("strategy") or {}).get("matrix") or {}).get("include")
+    return include or [{}]
+
+
+def resolve(job, row, key):
+    """What `job` passes for `key`, for one matrix row.
+
+    Falls back to the callee's declared input default when the job does not
+    pass the key at all, so an omitted input is read from the workflow that
+    defines it rather than assumed here.
+    """
+    passed = job.get("with") or {}
+    if key not in passed:
+        return input_default(CALLEES[callee(job)], key)
+    val = passed[key]
+    if not isinstance(val, str):
+        return val
+    m = MATRIX_REF.match(val.strip())
+    if m:
+        name, fallback = m.group(1), m.group(2)
+        if name not in row:
+            if fallback is None:
+                raise SystemExit(f"matrix.{name} missing from row {row}")
+            return fallback
+        got = row[name]
+        if got == "" and fallback is not None:
+            return fallback
+        return got
+    if "${{" in val:
+        raise SystemExit(f"cannot resolve {key}={val!r} without a GitHub runner")
+    return val
+
+
+def as_bool(val):
+    return val if isinstance(val, bool) else str(val).lower() == "true"
+
+
+GH_EXPR = re.compile(r"\$\{\{(.+?)\}\}")
+GH_TERNARY = re.compile(r"([\w.]+)\s*&&\s*'([^']*)'\s*\|\|\s*'([^']*)'")
+
+
+def eval_ghexpr(expr, inputs, outputs):
+    """Evaluate the expression subset the factory's `category:` values use:
+    context lookups plus the `<cond> && '<a>' || '<b>'` idiom."""
+
+    def lookup(ref):
+        ref = ref.strip()
+        for prefix, source in (("inputs.", inputs),
+                               ("steps.setup.outputs.", outputs)):
+            if ref.startswith(prefix):
+                return source[ref[len(prefix):]]
+        raise SystemExit(f"unsupported expression context: {ref}")
+
+    def repl(m):
+        body = m.group(1).strip()
+        tern = GH_TERNARY.fullmatch(body)
+        if tern:
+            cond = lookup(tern.group(1))
+            falsy = cond in ("", "false", False, None)
+            return tern.group(3) if falsy else tern.group(2)
+        return str(lookup(body))
+
+    return GH_EXPR.sub(repl, expr)
+
+
+sarif_steps = [
+    (st["name"], st["with"]["category"])
+    for st in factory["jobs"]["build"]["steps"]
+    if "upload-sarif" in str(st.get("uses", ""))
+]
+if not sarif_steps:
+    raise SystemExit("reusable-factory.yaml has no upload-sarif step")
+
+for caller_name in ("pr.yaml", "master.yaml"):
+    caller = load(f"{WF}/{caller_name}")
+    print(f"\n== {caller_name}: build cells ==")
+    cells = []
+    for job_name, job in caller["jobs"].items():
+        if callee(job) != "_build-iso.yaml":
+            continue
+        for row in matrix_rows(job):
+            cell = {
+                "name": resolve(job, row, "name"),
+                "base_image": resolve(job, row, "base_image"),
+                "arch": resolve(job, row, "arch"),
+                "model": resolve(job, row, "model"),
+                "distro": resolve(job, row, "kubernetes_distro"),
+                "version": resolve(job, row, "kubernetes_version"),
+                "trusted_boot": as_bool(resolve(job, row, "trusted_boot")),
+                "iso": as_bool(resolve(job, row, "iso")),
+            }
+            cell["out"] = factory_tag(
+                cell["distro"], cell["version"],
+                trusted_boot=cell["trusted_boot"],
+                base_image=cell["base_image"], model=cell["model"],
+                arch=cell["arch"],
+                tag_format=resolve(job, row, "custom_tag_format"),
+            )
+            cells.append(cell)
+            print(f"  {cell['name']:<26} distro={cell['distro'] or '-':<4}"
+                  f" variant={cell['out']['variant']:<8} iso={str(cell['iso']):<5}"
+                  f" tag={cell['out']['TAG']}")
+
+    # Two cells whose pushed tag is identical race each other into the same
+    # registry reference, and two cells whose SARIF category is identical are
+    # rejected by upload-sarif as a misconfigured run.
+    seen = {}
+    for cell in cells:
+        got = cell["out"]["TAG"]
+        if got in seen:
+            fail(f"{caller_name} pushed tag", got,
+                 f"unique per cell ({seen[got]} vs {cell['name']})")
+        seen[got] = cell["name"]
+    for step_name, expr in sarif_steps:
+        seen = {}
+        for cell in cells:
+            cat = eval_ghexpr(expr, {"arch": cell["arch"], "model": cell["model"],
+                                     "trusted_boot": cell["trusted_boot"]},
+                              cell["out"])
+            if cat in seen:
+                fail(f"{caller_name} {step_name!r} category", cat,
+                     f"unique per cell ({seen[cat]} vs {cell['name']})")
+            seen[cat] = cell["name"]
+
+    print(f"\n== {caller_name}: test jobs must name the cell they consume ==")
+    for job_name, job in caller["jobs"].items():
+        target = callee(job)
+        if target not in ("reusable-qemu-test.yaml", "_uki-test.yaml"):
+            continue
+        # reusable-qemu-test.yaml boots plain ISOs; _uki-test.yaml is the
+        # trusted-boot path, so it consumes the trusted_boot cells.
+        wants_uki = target == "_uki-test.yaml"
+        for row in matrix_rows(job):
+            label = job_name
+            if "test" in row:
+                label += f" [{row['test']}]"
+            distro = resolve(job, row, "kubernetes_distro")
+            version = resolve(job, row, "kubernetes_version")
+            variant = resolve(job, row, "variant")
+            key = (resolve(job, row, "base_image"), resolve(job, row, "arch"),
+                   resolve(job, row, "model"), wants_uki)
+            siblings = [c for c in cells
+                        if (c["base_image"], c["arch"], c["model"],
+                            c["trusted_boot"]) == key]
+            hits = [c for c in siblings
+                    if (c["distro"], c["version"]) == (distro, version)]
+            if len(hits) != 1:
+                offered = ", ".join(
+                    f"{c['name']}={c['distro'] or '-'}/{c['version']}"
+                    for c in siblings
+                ) or "no cell with that base_image/arch/model"
+                check(f"{label} distro={distro or '-'}/{version}",
+                      f"{len(hits)} build cells ({offered})",
+                      "exactly 1 build cell")
+                continue
+            cell = hits[0]
+            check(f"{label} -> {cell['name']} variant",
+                  variant, cell["out"]["variant"], terse=True)
+            if not cell["iso"]:
+                check(f"{label} -> {cell['name']} artifact",
+                      "iso: false, no ISO artifact to download",
+                      "a cell built with iso: true")
+
 print()
 if failures:
     print(f"{len(failures)} FAILURE(S)")
+    for label, got, want in failures:
+        print(f"  {label}\n    got  {got}\n    want {want}")
     sys.exit(1)
 print("all checks pass")

--- a/.github/scripts/verify_k8s_tag.py
+++ b/.github/scripts/verify_k8s_tag.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Regression guard for kairos-io/kairos#4579.
+
+The `$K8S` image-tag segment is hand-derived in shell in three places --
+reusable-factory.yaml's "Setup environment" step (the source of truth) and
+two mirrors that reconstruct the same tag to find the image under test:
+reusable-qemu-test.yaml's "Set Image tag" step and _uki-test.yaml's
+"Compute IMAGE_NAME" step. reusable-factory.yaml is a cross-repo callable
+(also used by kairos-io/hadron and friends), so it cannot `uses:` a local
+composite action or `scripts/` reference to collapse the three copies into
+one -- see the coder journal for kairos-io/kairos#4579 round 0. That means
+nothing stops the three copies drifting again except a check that actually
+executes all three and compares results.
+
+This script extracts the real `run:` shell out of the three workflow files
+via PyYAML, substitutes the `${{ inputs.* }}` expressions the same way
+GitHub Actions would, and executes the result under bash. Nothing here is
+copy-pasted shell logic: a future drift between the three copies shows up
+as a mismatch between what this script observed the files doing, not as a
+passing test of text duplicated into this file.
+
+Usage:
+    python3 .github/scripts/verify_k8s_tag.py
+
+Requires: PyYAML (`pip install pyyaml`). No repo-wide Python dependency is
+introduced -- this is a standalone script, not part of any package, and it
+is not currently wired into a CI job (see `make verify-k8s-tag`, which
+mirrors how `make lint-workflows-actions`/actionlint are local-only checks
+in this repo too). Run it by hand after touching any of the three files
+above, or any caller (pr.yaml/master.yaml) that feeds them
+kubernetes_distro/kubernetes_version.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+import yaml
+
+WF = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "workflows")
+)
+
+
+def load(path):
+    with open(path) as fh:
+        return yaml.safe_load(fh)
+
+
+def step(doc, job, name_fragment):
+    for st in doc["jobs"][job]["steps"]:
+        if name_fragment in st.get("name", ""):
+            return st
+    raise KeyError(name_fragment)
+
+
+def subst_inputs(script, inputs):
+    def repl(m):
+        key = m.group(1)
+        if key not in inputs:
+            raise KeyError(f"unstubbed input: {key}")
+        return str(inputs[key])
+
+    script = re.sub(r"\$\{\{\s*inputs\.([A-Za-z0-9_]+)\s*\}\}", repl, script)
+    script = re.sub(r"\$\{\{\s*github\.sha\s*\}\}", "deadbeef", script)
+    return script
+
+
+def run(script, env_prelude=""):
+    full = "set -u\n" + env_prelude + "\n" + script + "\n"
+    p = subprocess.run(["bash", "-c", full], capture_output=True, text=True)
+    if p.returncode != 0:
+        print(full)
+        print(p.stderr)
+        raise SystemExit(f"shell failed: {p.returncode}")
+    return p.stdout
+
+
+# ---- factory: run the real "Setup environment" step -------------------------
+factory = load(f"{WF}/reusable-factory.yaml")
+setup_script = step(factory, "build", "Setup environment")["run"]
+
+
+def factory_tag(distro, version, trusted_boot=False, tag_format=None,
+                artifact_format=None):
+    inputs = {
+        "kubernetes_distro": distro,
+        "kubernetes_version": version,
+        "version": "v4.5.0",
+        "kairos_version": "v4.0.0",
+        "base_image": "ghcr.io/kairos-io/hadron:v0.5.1",
+        "model": "generic",
+        "arch": "amd64",
+        "trusted_boot": "true" if trusted_boot else "false",
+        "custom_tag_format": tag_format or "",
+        "custom_artifact_format": artifact_format or "",
+        "registry_domain": "ghcr.io",
+        "registry_namespace": "kairos-io/kairos",
+        "registry_repository": "",
+        "keys_dir": "",
+        "sysext_dir": "",
+        "single_efi_cmdline": "",
+    }
+    script = subst_inputs(setup_script, inputs)
+    prelude = (
+        'GITHUB_ENV=$(mktemp); GITHUB_OUTPUT=$(mktemp); export GITHUB_ENV GITHUB_OUTPUT\n'
+        'git() { echo "v4.5.0"; }\n'
+    )
+    out = run(script + '\nprintf "TAG=%s\\nARTIFACT=%s\\nK8S=%s\\nDEFAULT_TAG=%s\\n" '
+                        '"$TAG" "$ARTIFACT_NAME" "$K8S" "$DEFAULT_TAG"', prelude)
+    return dict(
+        line.split("=", 1) for line in out.strip().splitlines() if "=" in line
+    )
+
+
+# ---- qemu test mirror -------------------------------------------------------
+qemu = load(f"{WF}/reusable-qemu-test.yaml")
+qemu_step = step(qemu, "test", "Set Image tag")
+
+
+def qemu_tag(distro, version, variant):
+    script = qemu_step["run"]
+    prelude = (
+        'GITHUB_ENV=$(mktemp); export GITHUB_ENV\n'
+        'git() { echo "v4.5.0"; }\n'
+        'PREFIX_TEMPLATE=\'ghcr.io/kairos-io/kairos/${flavor}\'\n'
+        f'FLAVOR=hadron\nFLAVOR_RELEASE=v0.5.1\nVARIANT={variant}\n'
+        f'ARCH=amd64\nMODEL=generic\n'
+        f'KUBERNETES_DISTRO="{distro}"\nKUBERNETES_VERSION_INPUT="{version}"\n'
+    )
+    out = run(script + '\ncat "$GITHUB_ENV"', prelude)
+    return out.strip().split("IMAGE_NAME=")[1]
+
+
+# ---- uki test mirror --------------------------------------------------------
+uki = load(f"{WF}/_uki-test.yaml")
+uki_step = step(uki, "test", "Compute IMAGE_NAME")
+
+
+def uki_tag(distro, version, variant):
+    script = uki_step["run"]
+    prelude = (
+        'GITHUB_ENV=$(mktemp); export GITHUB_ENV\n'
+        'PREFIX_TEMPLATE=\'ghcr.io/kairos-io/kairos/${flavor}\'\n'
+        f'FLAVOR=hadron-trusted\nFLAVOR_RELEASE=v0.5.1\nVARIANT={variant}\n'
+        f'ARCH=amd64\nMODEL=generic\nVERSION=v4.5.0\n'
+        f'KUBERNETES_DISTRO="{distro}"\nKUBERNETES_VERSION_INPUT="{version}"\n'
+    )
+    out = run(script + '\ncat "$GITHUB_ENV"', prelude)
+    return out.strip().split("IMAGE_NAME=")[1]
+
+
+PR_TAG_FMT = "$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL$K8S-$VERSION$UKI"
+REL_TAG_FMT = "$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION$K8S$UKI"
+
+failures = []
+
+
+def check(label, got, want):
+    status = "ok  " if got == want else "FAIL"
+    if got != want:
+        failures.append((label, got, want))
+    print(f"  [{status}] {label}\n         got  {got}\n         want {want}")
+
+
+print("== pr/master build cells (kubernetes_version: auto) ==")
+core = factory_tag("", "auto", tag_format=PR_TAG_FMT)
+k3s = factory_tag("k3s", "auto", tag_format=PR_TAG_FMT)
+k0s = factory_tag("k0s", "auto", tag_format=PR_TAG_FMT)
+check("core tag", core["TAG"], "hadron-v0.5.1-core-amd64-generic-v4.5.0")
+check("k3s tag", k3s["TAG"], "hadron-v0.5.1-standard-amd64-generic-k3s-v4.5.0")
+check("k0s tag", k0s["TAG"], "hadron-v0.5.1-standard-amd64-generic-k0s-v4.5.0")
+print(f"  k3s vs k0s collide? {k3s['TAG'] == k0s['TAG']}")
+if k3s["TAG"] == k0s["TAG"]:
+    failures.append(("k3s/k0s tag collision", k3s["TAG"], "distinct tags"))
+
+print("\n== release cells (kubernetes_version pinned) -- must be byte-identical to before ==")
+relcore = factory_tag("", "auto", tag_format=REL_TAG_FMT,
+                      artifact_format="kairos-$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION$K8S$UKI")
+check("release core", relcore["TAG"], "v0.5.1-core-amd64-generic-v4.5.0")
+relk3s = factory_tag("k3s", "v1.33.9+k3s1", tag_format=REL_TAG_FMT,
+                     artifact_format="kairos-$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION$K8S$UKI")
+check("release k3s", relk3s["TAG"],
+      "v0.5.1-standard-amd64-generic-v4.5.0-k3s-v1.33.9-k3s1")
+relk0s = factory_tag("k0s", "v1.33.4+k0s.0", tag_format=REL_TAG_FMT,
+                     artifact_format="kairos-$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION$K8S$UKI")
+check("release k0s", relk0s["TAG"],
+      "v0.5.1-standard-amd64-generic-v4.5.0-k0s-v1.33.4-k0s.0")
+check("release k3s artifact", relk3s["ARTIFACT"],
+      "kairos-hadron-v0.5.1-standard-amd64-generic-v4.5.0-k3s-v1.33.9-k3s1")
+
+print("\n== DEFAULT_TAG (no custom format) -- must match the old two-branch shape ==")
+check("default core", factory_tag("", "auto")["DEFAULT_TAG"],
+      "v0.5.1-core-amd64-generic-v4.5.0")
+check("default k3s pinned", factory_tag("k3s", "v1.33.9+k3s1")["DEFAULT_TAG"],
+      "v0.5.1-standard-amd64-generic-v4.5.0-k3s-v1.33.9-k3s1")
+check("default k0s auto", factory_tag("k0s", "auto")["DEFAULT_TAG"],
+      "v0.5.1-standard-amd64-generic-v4.5.0-k0s")
+
+print("\n== DEFAULT artifact name: no trailing bare dash on auto ==")
+check("default artifact k0s auto", factory_tag("k0s", "auto")["ARTIFACT"],
+      "kairos-v0.5.1-standard-amd64-generic-v4.5.0-k0s")
+
+print("\n== test mirrors must reconstruct exactly what the build cell pushed ==")
+check("qemu test-standard", qemu_tag("k3s", "auto", "standard"),
+      "ghcr.io/kairos-io/kairos/hadron:" + k3s["TAG"])
+check("qemu test-core", qemu_tag("", "auto", "core"),
+      "ghcr.io/kairos-io/kairos/hadron:" + core["TAG"])
+
+uki_k3s = factory_tag("k3s", "auto", trusted_boot=True, tag_format=PR_TAG_FMT)
+uki_core = factory_tag("", "auto", trusted_boot=True, tag_format=PR_TAG_FMT)
+# the UKI build cells use the hadron-trusted base, so re-derive with it
+print("  (uki build tags use base hadron-trusted; compare suffix shape)")
+check("uki standard mirror", uki_tag("k3s", "auto", "standard"),
+      "ghcr.io/kairos-io/kairos/hadron-trusted:"
+      + uki_k3s["TAG"].replace("hadron-", "hadron-trusted-", 1))
+check("uki core mirror", uki_tag("", "auto", "core"),
+      "ghcr.io/kairos-io/kairos/hadron-trusted:"
+      + uki_core["TAG"].replace("hadron-", "hadron-trusted-", 1))
+
+print("\n== pinned version flows through the mirrors too ==")
+check("qemu pinned", qemu_tag("k3s", "v1.33.9+k3s1", "standard"),
+      "ghcr.io/kairos-io/kairos/hadron:"
+      + factory_tag("k3s", "v1.33.9+k3s1", tag_format=PR_TAG_FMT)["TAG"])
+
+print()
+if failures:
+    print(f"{len(failures)} FAILURE(S)")
+    sys.exit(1)
+print("all checks pass")

--- a/.github/scripts/verify_k8s_tag.py
+++ b/.github/scripts/verify_k8s_tag.py
@@ -14,12 +14,12 @@ executes all three and compares results.
 
 This script extracts the real `run:` shell out of the three workflow files
 via PyYAML, substitutes the `${{ inputs.* }}` expressions the same way
-GitHub Actions would, and executes the result under bash. The two tag
-formats come out of `_build-iso.yaml`'s input default and `release.yaml`'s
-overrides rather than being retyped here. Nothing in this file is
-copy-pasted shell logic or a copied format string: a future drift shows up
-as a mismatch between what the script observed the files doing, not as a
-passing test of text duplicated into this file.
+GitHub Actions would, and executes the result under bash. The tag and
+artifact formats come out of `_build-iso.yaml`'s input defaults and
+`release.yaml`'s overrides rather than being retyped here. Nothing in this
+file is copy-pasted shell logic or a copied format string: a future drift
+shows up as a mismatch between what the script observed the files doing,
+not as a passing test of text duplicated into this file.
 
 Deriving the segment correctly is only half of it -- the two sides also
 have to agree on which cell is which. So the second half walks pr.yaml and
@@ -28,9 +28,9 @@ job, resolves the `kubernetes_distro` it passes against the `build-iso`
 matrix cell sharing its base_image/arch/model. Exactly one cell has to
 match, and its computed variant has to be the variant the test job claims;
 otherwise the suite is booting one cell's image and reporting as another's
-coverage. Build cells are also checked pairwise for a unique pushed tag and
-a unique upload-sarif category, both of which collapse when two cells
-differ only by k8s distro.
+coverage. Build cells are also checked pairwise for a unique pushed tag, a
+unique uploaded artifact name and a unique upload-sarif category, all three
+of which collapse when two cells differ only by k8s distro.
 
 Usage:
     python3 .github/scripts/verify_k8s_tag.py
@@ -190,7 +190,7 @@ def uki_tag(distro, version, variant):
     return out.strip().split("IMAGE_NAME=")[1]
 
 
-# ---- the two tag formats, read out of the workflows that set them -----------
+# ---- the tag and artifact formats, read out of the workflows that set them ---
 # Retyping these as literals would let someone reorder _build-iso.yaml's
 # default (say, move $K8S after $VERSION) and keep this file green while the
 # real build and the two mirrors disagreed.
@@ -198,21 +198,37 @@ build_iso = load(f"{WF}/_build-iso.yaml")
 release = load(f"{WF}/release.yaml")
 
 PR_TAG_FMT = input_default(build_iso, "custom_tag_format")
+PR_ARTIFACT_FMT = input_default(build_iso, "custom_artifact_format")
 
-release_fmts = {
-    name: job["with"]["custom_tag_format"]
-    for name, job in release["jobs"].items()
-    if "custom_tag_format" in (job.get("with") or {})
-}
-if not release_fmts:
-    raise SystemExit("release.yaml passes no custom_tag_format")
-if len(set(release_fmts.values())) != 1:
-    raise SystemExit(f"release.yaml's custom_tag_format copies diverged: {release_fmts}")
-REL_TAG_FMT = next(iter(release_fmts.values()))
 
-print(f"tag formats in use ({len(release_fmts)} release jobs agree):")
+def release_format(key):
+    """The single value release.yaml's jobs pass for `key`.
+
+    release.yaml repeats the same format across its build jobs; one copy
+    drifting is itself the bug, so read them all and refuse to pick one
+    when they disagree.
+    """
+    fmts = {
+        name: job["with"][key]
+        for name, job in release["jobs"].items()
+        if key in (job.get("with") or {})
+    }
+    if not fmts:
+        raise SystemExit(f"release.yaml passes no {key}")
+    if len(set(fmts.values())) != 1:
+        raise SystemExit(f"release.yaml's {key} copies diverged: {fmts}")
+    return next(iter(fmts.values())), len(fmts)
+
+
+REL_TAG_FMT, rel_tag_jobs = release_format("custom_tag_format")
+REL_ARTIFACT_FMT, rel_artifact_jobs = release_format("custom_artifact_format")
+
+print(f"tag formats in use ({rel_tag_jobs} release jobs agree):")
 print(f"  _build-iso.yaml default: {PR_TAG_FMT}")
-print(f"  release.yaml override:   {REL_TAG_FMT}\n")
+print(f"  release.yaml override:   {REL_TAG_FMT}")
+print(f"artifact formats in use ({rel_artifact_jobs} release jobs agree):")
+print(f"  _build-iso.yaml default: {PR_ARTIFACT_FMT}")
+print(f"  release.yaml override:   {REL_ARTIFACT_FMT}\n")
 
 failures = []
 
@@ -243,14 +259,14 @@ if k3s["TAG"] == k0s["TAG"]:
 
 print("\n== release cells (kubernetes_version pinned) -- must be byte-identical to before ==")
 relcore = factory_tag("", "auto", tag_format=REL_TAG_FMT,
-                      artifact_format="kairos-$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION$K8S$UKI")
+                      artifact_format=REL_ARTIFACT_FMT)
 check("release core", relcore["TAG"], "v0.5.1-core-amd64-generic-v4.5.0")
 relk3s = factory_tag("k3s", "v1.33.9+k3s1", tag_format=REL_TAG_FMT,
-                     artifact_format="kairos-$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION$K8S$UKI")
+                     artifact_format=REL_ARTIFACT_FMT)
 check("release k3s", relk3s["TAG"],
       "v0.5.1-standard-amd64-generic-v4.5.0-k3s-v1.33.9-k3s1")
 relk0s = factory_tag("k0s", "v1.33.4+k0s.0", tag_format=REL_TAG_FMT,
-                     artifact_format="kairos-$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION$K8S$UKI")
+                     artifact_format=REL_ARTIFACT_FMT)
 check("release k0s", relk0s["TAG"],
       "v0.5.1-standard-amd64-generic-v4.5.0-k0s-v1.33.4-k0s.0")
 check("release k3s artifact", relk3s["ARTIFACT"],
@@ -320,12 +336,17 @@ def matrix_rows(job):
     return include or [{}]
 
 
-def resolve(job, row, key):
+_RAISE = object()
+
+
+def resolve(job, row, key, dynamic=_RAISE):
     """What `job` passes for `key`, for one matrix row.
 
     Falls back to the callee's declared input default when the job does not
     pass the key at all, so an omitted input is read from the workflow that
-    defines it rather than assumed here.
+    defines it rather than assumed here. An expression this script cannot
+    evaluate is a hard error unless the caller supplies `dynamic`, which is
+    then returned in its place.
     """
     passed = job.get("with") or {}
     if key not in passed:
@@ -345,6 +366,8 @@ def resolve(job, row, key):
             return fallback
         return got
     if "${{" in val:
+        if dynamic is not _RAISE:
+            return dynamic
         raise SystemExit(f"cannot resolve {key}={val!r} without a GitHub runner")
     return val
 
@@ -406,6 +429,12 @@ for caller_name in ("pr.yaml", "master.yaml"):
                 "version": resolve(job, row, "kubernetes_version"),
                 "trusted_boot": as_bool(resolve(job, row, "trusted_boot")),
                 "iso": as_bool(resolve(job, row, "iso")),
+                # The factory gates both upload-artifact steps on iso/raw,
+                # so an image-only cell publishes no artifact name at all.
+                # A `raw:` the caller computes on the runner counts as an
+                # upload here, which keeps the check on the strict side.
+                "uploads": as_bool(resolve(job, row, "iso", dynamic=True))
+                or as_bool(resolve(job, row, "raw", dynamic=True)),
             }
             cell["out"] = factory_tag(
                 cell["distro"], cell["version"],
@@ -413,20 +442,37 @@ for caller_name in ("pr.yaml", "master.yaml"):
                 base_image=cell["base_image"], model=cell["model"],
                 arch=cell["arch"],
                 tag_format=resolve(job, row, "custom_tag_format"),
+                artifact_format=resolve(job, row, "custom_artifact_format"),
             )
             cells.append(cell)
-            print(f"  {cell['name']:<26} distro={cell['distro'] or '-':<4}"
-                  f" variant={cell['out']['variant']:<8} iso={str(cell['iso']):<5}"
-                  f" tag={cell['out']['TAG']}")
+            line = (f"  {cell['name']:<26} distro={cell['distro'] or '-':<4}"
+                    f" variant={cell['out']['variant']:<8}"
+                    f" iso={str(cell['iso']):<5} tag={cell['out']['TAG']}")
+            if cell["uploads"]:
+                line += f"\n  {'':<26} artifact={cell['out']['ARTIFACT']}"
+            print(line)
 
     # Two cells whose pushed tag is identical race each other into the same
-    # registry reference, and two cells whose SARIF category is identical are
-    # rejected by upload-sarif as a misconfigured run.
+    # registry reference; two cells uploading the same artifact name fail the
+    # run on upload-artifact (v4 and later refuse a duplicate name, and
+    # v4.3.0-rc3 shipped exactly that collision -- every k3s/k0s cell writing
+    # kairos-hadron-v0.5.1-standard-amd64-generic.iso.zip); and two cells whose
+    # SARIF category is identical are rejected by upload-sarif as a
+    # misconfigured run.
     seen = {}
     for cell in cells:
         got = cell["out"]["TAG"]
         if got in seen:
             fail(f"{caller_name} pushed tag", got,
+                 f"unique per cell ({seen[got]} vs {cell['name']})")
+        seen[got] = cell["name"]
+    seen = {}
+    for cell in cells:
+        if not cell["uploads"]:
+            continue
+        got = cell["out"]["ARTIFACT"]
+        if got in seen:
+            fail(f"{caller_name} uploaded artifact", got,
                  f"unique per cell ({seen[got]} vs {cell['name']})")
         seen[got] = cell["name"]
     for step_name, expr in sarif_steps:

--- a/.github/workflows/_build-iso.yaml
+++ b/.github/workflows/_build-iso.yaml
@@ -138,8 +138,9 @@ on:
           _uki-test.yaml resolve to (`$FLAVOR-` prefix so tests find
           the fresh image); release.yaml overrides this to drop the
           prefix and match the tag shape v4.2.0 shipped.
-          $K8S expands to `-$KUBERNETES_DISTRO-$SANITIZED_KUBERNETES_VERSION`
-          when a k8s pair is set and empty otherwise; $VERSION is
+          $K8S expands to `-$KUBERNETES_DISTRO` whenever a distro is set,
+          plus `-$SANITIZED_KUBERNETES_VERSION` when the version is pinned
+          rather than `auto`, and is empty for a core cell; $VERSION is
           factory-action's `git describe --tags --dirty --always`.
         type: string
         default: '$FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL$K8S-$VERSION$UKI'

--- a/.github/workflows/_uki-test.yaml
+++ b/.github/workflows/_uki-test.yaml
@@ -42,13 +42,35 @@ on:
         type: string
         required: true
 
+      kubernetes_distro:
+        description: |
+          k8s distro baked into the UKI image under test: k3s, k0s, or
+          empty for a core image. Feeds the $K8S segment of the tag this
+          workflow reconstructs to find that image, so it must match the
+          `kubernetes_distro` the build cell was given. The standard UKI
+          cell carries k3s; the core one carries nothing.
+        type: string
+        required: false
+        default: ''
+
+      kubernetes_version:
+        description: |
+          k8s version baked into the UKI image under test, or "auto" when
+          the build cell let kairos-init choose. Only affects the tag this
+          workflow reconstructs; must match the build cell's
+          `kubernetes_version`.
+        type: string
+        required: false
+        default: 'auto'
+
       container_image_prefix:
         description: |
           Where the fresh trusted-boot OS image lives. The literal
           `${flavor}` token is expanded from base_image, matching the
           same convention reusable-qemu-test.yaml uses. The tag suffix
-          `<flavor>-<flavor_release>-<variant>-<arch>-<model>-<sha>-uki`
-          is appended internally.
+          `<flavor>-<flavor_release>-<variant>-<arch>-<model><k8s>-<sha>-uki`
+          is appended internally, where `<k8s>` comes from
+          kubernetes_distro/kubernetes_version below.
         type: string
         default: 'quay.io/kairos/ci-temp-images'
 
@@ -201,15 +223,36 @@ jobs:
           VARIANT: ${{ inputs.variant }}
           ARCH: ${{ inputs.arch }}
           MODEL: ${{ inputs.model }}
+          KUBERNETES_DISTRO: ${{ inputs.kubernetes_distro }}
+          KUBERNETES_VERSION_INPUT: ${{ inputs.kubernetes_version }}
         run: |
           # Match _build-iso.yaml's custom_tag_format:
           # $FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL$K8S-$VERSION$UKI
-          # UKI cells never carry a k8s pair, so $K8S is empty. $UKI is
-          # -uki here (trusted_boot=true is the whole point of this file).
-          # $VERSION was set two steps up via `git describe --tags --dirty`
-          # and is already in the env, matching factory-action's setup.
+          # $UKI is -uki here (trusted_boot=true is the whole point of this
+          # file). $VERSION was set two steps up via `git describe --tags
+          # --dirty` and is already in the env, matching factory-action's
+          # setup.
+          #
+          # $K8S derivation, kept identical to reusable-factory.yaml's
+          # setup step (and to reusable-qemu-test.yaml). "auto" resolves to
+          # the empty string there so kairos-init picks the version, and
+          # the segment is gated on the distro so it survives that. The
+          # standard UKI cell is a k3s image, so this is not decorative.
+          if [[ "$KUBERNETES_VERSION_INPUT" == "auto" ]]; then
+            KUBERNETES_VERSION=""
+          else
+            KUBERNETES_VERSION="$KUBERNETES_VERSION_INPUT"
+          fi
+          SANITIZED_KUBERNETES_VERSION="${KUBERNETES_VERSION//+/-}"
+          K8S=""
+          if [[ -n "$KUBERNETES_DISTRO" ]]; then
+            K8S="-$KUBERNETES_DISTRO"
+            if [[ -n "$SANITIZED_KUBERNETES_VERSION" ]]; then
+              K8S="$K8S-$SANITIZED_KUBERNETES_VERSION"
+            fi
+          fi
           PREFIX="${PREFIX_TEMPLATE//\$\{flavor\}/$FLAVOR}"
-          echo "IMAGE_NAME=${PREFIX}:${FLAVOR}-${FLAVOR_RELEASE}-${VARIANT}-${ARCH}-${MODEL}-${VERSION}-uki" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME=${PREFIX}:${FLAVOR}-${FLAVOR_RELEASE}-${VARIANT}-${ARCH}-${MODEL}${K8S}-${VERSION}-uki" >> "$GITHUB_ENV"
 
       - name: Download UKI ISO artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -293,6 +293,11 @@ jobs:
       model: 'generic'
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+      # These cells consume the amd64-standard build cell's image, which
+      # is a k3s one. The pushed tag carries the distro, so the test side
+      # has to name it: `standard` alone does not identify a k3s image,
+      # since a k0s cell computes the same variant.
+      kubernetes_distro: 'k3s'
       release-matcher: ${{ matrix.release-matcher || '' }}
     secrets: inherit
 
@@ -324,6 +329,8 @@ jobs:
       model: 'generic'
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+      # Same amd64-standard (k3s) image test-standard consumes.
+      kubernetes_distro: 'k3s'
       kcrypt_challenger_image: ghcr.io/kairos-io/kairos/kcrypt-challenger:master-scratch
     secrets: inherit
 
@@ -333,13 +340,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {test: 'install-upgrade', variant: 'standard'}
-          - {test: 'boot-assessment', variant: 'core'}
+          - {test: 'install-upgrade', variant: 'standard', kubernetes_distro: 'k3s'}
+          - {test: 'boot-assessment', variant: 'core', kubernetes_distro: ''}
     name: test-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}
       variant: ${{ matrix.variant }}
+      # Mirrors the kubernetes_distro of the build-iso UKI cell each test
+      # consumes: amd64-standard-uki is k3s, amd64-core-uki is neither.
+      kubernetes_distro: ${{ matrix.kubernetes_distro }}
       base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1'
       arch: 'amd64'
       model: 'generic'

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -124,6 +124,8 @@ jobs:
         include:
           - {name: 'amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
           - {name: 'amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
+          # k0s build coverage, image-only (see pr.yaml for rationale).
+          - {name: 'amd64-standard-k0s', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: false, trusted_boot: false, kubernetes_distro: 'k0s', fips: false}
           # FIPS core cell (see pr.yaml for rationale).
           - {name: 'amd64-core-fips', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron-fips:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: true}
           # UKI cells feed test-uki (see pr.yaml for the shape).

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -148,7 +148,10 @@ jobs:
   # the slow arm64/nvidia builds that no test consumes.
   #
   # build-iso: amd64 core, amd64 standard, amd64 standard-uki,
-  # amd64 core-uki -- everything the qemu suites boot.
+  # amd64 core-uki -- everything the qemu suites boot -- plus
+  # amd64 standard-k0s, which is image-only (iso: false) and boots
+  # nowhere; it exists so the k0s provider's build-time work runs
+  # on every PR instead of first on a release tag.
   # build-iso-arm: arm64 core + rpi3 + rpi4 + both nvidia jetson
   # cells -- build-only smoke coverage (no qemu on arm64 in CI).
   #
@@ -163,6 +166,20 @@ jobs:
         include:
           - {name: 'amd64-core', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: '', fips: false}
           - {name: 'amd64-standard', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: true, trusted_boot: false, kubernetes_distro: 'k3s', fips: false}
+          # k0s build coverage. iso: false on purpose -- the k0s provider
+          # does its work at image build time (runs the k0s installer,
+          # relocates the binary out of /usr/local/bin, writes the service
+          # units), so pushing the OS container image is enough to exercise
+          # it. That is the whole class of defect #4299 was: k0s
+          # control-plane components fell back to root because the native
+          # system users were never created, and nothing built a k0s image
+          # outside release.yaml so it shipped. Runtime k0s coverage (does
+          # the cluster come up) is a separate, larger gap; this cell does
+          # not claim to close it. Skipping the ISO also keeps the cost of
+          # the extra cell off the critical path the test-* jobs wait on:
+          # no auroraboot run, so it is the amd64-standard cell's work
+          # minus the slowest step.
+          - {name: 'amd64-standard-k0s', arch: 'amd64', base_image: 'ghcr.io/kairos-io/hadron:v0.5.1', model: 'generic', iso: false, trusted_boot: false, kubernetes_distro: 'k0s', fips: false}
           # FIPS core cell. hadron-fips is a distinct base image from
           # hadron (FIPS-hardened kernel + userspace); passing fips:true
           # additionally flips the FIPS=fips build_arg in images/Dockerfile

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -379,6 +379,11 @@ jobs:
       model: 'generic'
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+      # These cells consume the amd64-standard build cell's image, which
+      # is a k3s one. The pushed tag carries the distro, so the test side
+      # has to name it: `standard` alone does not identify a k3s image,
+      # since a k0s cell computes the same variant.
+      kubernetes_distro: 'k3s'
       release-matcher: ${{ matrix.release-matcher || '' }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head
       caller-vetted-ref: true
@@ -415,6 +420,8 @@ jobs:
       model: 'generic'
       secureboot: false
       container_image_prefix: 'ghcr.io/kairos-io/kairos/${flavor}'
+      # Same amd64-standard (k3s) image test-standard consumes.
+      kubernetes_distro: 'k3s'
       kcrypt_challenger_image: ghcr.io/kairos-io/kairos/kcrypt-challenger:pr-${{ github.event.pull_request.number }}
       ref: refs/pull/${{ github.event.pull_request.number }}/head
       caller-vetted-ref: true
@@ -431,13 +438,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {test: 'install-upgrade', variant: 'standard'}
-          - {test: 'boot-assessment', variant: 'core'}
+          - {test: 'install-upgrade', variant: 'standard', kubernetes_distro: 'k3s'}
+          - {test: 'boot-assessment', variant: 'core', kubernetes_distro: ''}
     name: test-uki / ${{ matrix.test }}
     uses: ./.github/workflows/_uki-test.yaml
     with:
       test: ${{ matrix.test }}
       variant: ${{ matrix.variant }}
+      # Mirrors the kubernetes_distro of the build-iso UKI cell each test
+      # consumes: amd64-standard-uki is k3s, amd64-core-uki is neither.
+      kubernetes_distro: ${{ matrix.kubernetes_distro }}
       base_image: 'ghcr.io/kairos-io/hadron-trusted:v0.5.1'
       arch: 'amd64'
       model: 'generic'

--- a/.github/workflows/reusable-factory.yaml
+++ b/.github/workflows/reusable-factory.yaml
@@ -262,12 +262,25 @@ on:
       custom_tag_format:
         type: string
         required: false
-        description: "Custom tag format using variables like $FLAVOR_RELEASE, $VARIANT, $ARCH, $MODEL, $VERSION, $KUBERNETES_DISTRO, $KUBERNETES_VERSION, $UKI, $COMMIT_SHA. If not provided, uses default format."
+        description: |
+          Custom tag format using variables like $FLAVOR, $FLAVOR_RELEASE,
+          $VARIANT, $ARCH, $MODEL, $VERSION, $KUBERNETES_DISTRO,
+          $KUBERNETES_VERSION, $K8S, $UKI, $COMMIT_SHA. $K8S is
+          `-<kubernetes_distro>` whenever kubernetes_distro is set, with
+          `-<sanitized kubernetes_version>` appended when
+          kubernetes_version is not `auto`, and empty otherwise. If not
+          provided, uses default format.
 
       custom_artifact_format:
         type: string
         required: false
-        description: "Custom artifact filename format using variables like $FLAVOR_RELEASE, $VARIANT, $ARCH, $MODEL, $VERSION, $KUBERNETES_DISTRO, $KUBERNETES_VERSION, $UKI, $COMMIT_SHA. If not provided, uses auroraboot's default naming."
+        description: |
+          Custom artifact filename format using variables like $FLAVOR,
+          $FLAVOR_RELEASE, $VARIANT, $ARCH, $MODEL, $VERSION,
+          $KUBERNETES_DISTRO, $KUBERNETES_VERSION, $K8S, $UKI,
+          $COMMIT_SHA. $K8S follows the same rule as in
+          custom_tag_format. If not provided, uses auroraboot's default
+          naming.
 
       custom_job_name_format:
         type: string

--- a/.github/workflows/reusable-factory.yaml
+++ b/.github/workflows/reusable-factory.yaml
@@ -708,6 +708,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "kubernetes_version=$KUBERNETES_VERSION" >> $GITHUB_OUTPUT
           echo "kubernetes_distro=$KUBERNETES_DISTRO" >> $GITHUB_OUTPUT
+          echo "k8s=$K8S" >> $GITHUB_OUTPUT
           echo "flavor=$FLAVOR" >> $GITHUB_OUTPUT
           echo "flavor_release=$FLAVOR_RELEASE" >> $GITHUB_OUTPUT
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
@@ -982,19 +983,23 @@ jobs:
           output: trivy.sarif
           severity: critical
 
+      # The category identifies one analysis of one artifact. Two uploads
+      # sharing it within a run are rejected as a misconfiguration, so it
+      # has to carry every axis the matrix varies -- including $K8S, since
+      # `variant` collapses k3s and k0s to `standard`.
       - name: Upload Trivy scan results to GitHub Security tab
         if: inputs.trivy_sarif
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
           sarif_file: 'trivy.sarif'
-          category: ${{ steps.setup.outputs.flavor }}-${{ steps.setup.outputs.flavor_release }}-${{ steps.setup.outputs.variant }}-${{ inputs.arch }}-${{ inputs.model }}${{ inputs.trusted_boot && '-uki' || '' }}
+          category: ${{ steps.setup.outputs.flavor }}-${{ steps.setup.outputs.flavor_release }}-${{ steps.setup.outputs.variant }}-${{ inputs.arch }}-${{ inputs.model }}${{ steps.setup.outputs.k8s }}${{ inputs.trusted_boot && '-uki' || '' }}
 
       - name: Upload Grype scan results to GitHub Security tab
         if: inputs.grype_sarif
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
           sarif_file: 'grype.sarif'
-          category: ${{ steps.setup.outputs.flavor }}-${{ steps.setup.outputs.flavor_release }}-${{ steps.setup.outputs.variant }}-${{ inputs.arch }}-${{ inputs.model }}${{ inputs.trusted_boot && '-uki' || '' }}
+          category: ${{ steps.setup.outputs.flavor }}-${{ steps.setup.outputs.flavor_release }}-${{ steps.setup.outputs.variant }}-${{ inputs.arch }}-${{ inputs.model }}${{ steps.setup.outputs.k8s }}${{ inputs.trusted_boot && '-uki' || '' }}
 
       # The step name no longer promises an SBOM, because `sbom` is now an
       # input. A step called "with SBOM" that pushed without one would be the

--- a/.github/workflows/reusable-factory.yaml
+++ b/.github/workflows/reusable-factory.yaml
@@ -586,23 +586,37 @@ jobs:
           UKI="$UKI_SUFFIX"
           COMMIT_SHA="${{ github.sha }}"
 
-          # Set kubernetes suffix (leading dash) if a k8s distro+version
-          # pair was passed; empty otherwise. Consumers use this in
+          # Set kubernetes suffix (leading dash) if a k8s distro was
+          # passed; empty otherwise. Consumers use this in
           # custom_tag_format so cells without k8s don't get a stray dash
-          # (e.g. `...-generic--v4.3.0`) and cells with k8s get the
-          # distro+version pair disambiguating them from each other and
-          # from the no-k8s cell.
+          # (e.g. `...-generic--v4.3.0`) and cells with k8s get a segment
+          # disambiguating them from each other and from the no-k8s cell.
+          #
+          # Gated on the distro, not the version: the distro is known
+          # whether or not the caller pinned a version, and it is the
+          # distro that tells two otherwise-identical cells apart. Gating
+          # on the version instead made `kubernetes_version: auto` (which
+          # resolves to the empty string above so kairos-init picks the
+          # version) drop the distro from the tag entirely, so a k3s cell
+          # and a k0s cell sharing an arch/model pushed to the same tag
+          # and whichever finished last silently won.
+          #
+          # The version is appended only when pinned, so `auto` yields
+          # `-k0s` rather than a trailing bare dash.
+          #
+          # reusable-qemu-test.yaml and _uki-test.yaml reconstruct this
+          # same segment in shell to find the image under test. Keep all
+          # three in lockstep.
           K8S=""
-          if [[ -n "$KUBERNETES_VERSION" ]]; then
-            K8S="-$KUBERNETES_DISTRO-$SANITIZED_KUBERNETES_VERSION"
+          if [[ -n "$KUBERNETES_DISTRO" ]]; then
+            K8S="-$KUBERNETES_DISTRO"
+            if [[ -n "$SANITIZED_KUBERNETES_VERSION" ]]; then
+              K8S="$K8S-$SANITIZED_KUBERNETES_VERSION"
+            fi
           fi
 
           # Generate default tag
-          if [[ -n "$KUBERNETES_VERSION" ]]; then
-            DEFAULT_TAG="$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION-$KUBERNETES_DISTRO-$SANITIZED_KUBERNETES_VERSION$UKI"
-          else
-            DEFAULT_TAG="$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION$UKI"
-          fi
+          DEFAULT_TAG="$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION$K8S$UKI"
 
           # Use custom tag format if provided, otherwise use default
           if [[ -n "${{ inputs.custom_tag_format }}" ]]; then
@@ -647,9 +661,7 @@ jobs:
             DEFAULT_ARTIFACT_NAME="kairos-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL-$VERSION"
 
             # Append kubernetes distro and version if defined
-            if [[ -n "$KUBERNETES_DISTRO" ]]; then
-              DEFAULT_ARTIFACT_NAME="$DEFAULT_ARTIFACT_NAME-$KUBERNETES_DISTRO-$SANITIZED_KUBERNETES_VERSION"
-            fi
+            DEFAULT_ARTIFACT_NAME="$DEFAULT_ARTIFACT_NAME$K8S"
 
             # Append UKI suffix if trusted boot is enabled
             DEFAULT_ARTIFACT_NAME="$DEFAULT_ARTIFACT_NAME$UKI"

--- a/.github/workflows/reusable-factory.yaml
+++ b/.github/workflows/reusable-factory.yaml
@@ -983,10 +983,12 @@ jobs:
           output: trivy.sarif
           severity: critical
 
-      # The category identifies one analysis of one artifact. Two uploads
-      # sharing it within a run are rejected as a misconfiguration, so it
-      # has to carry every axis the matrix varies -- including $K8S, since
-      # `variant` collapses k3s and k0s to `standard`.
+      # The category sub-partitions one tool's results for one artifact.
+      # Two uploads of the same tool sharing it within a run are rejected
+      # as a misconfiguration, so it has to carry every axis the matrix
+      # varies -- including $K8S, since `variant` collapses k3s and k0s to
+      # `standard`. Trivy and Grype below share a value on purpose: they
+      # are different tools, so they are different partitions.
       - name: Upload Trivy scan results to GitHub Security tab
         if: inputs.trivy_sarif
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -24,8 +24,23 @@ on:
         type: string
         default: "generic"
       kubernetes_distro:
+        description: |
+          k8s distro baked into the image under test: k3s, k0s, or empty
+          for a core image. Feeds the $K8S segment of the tag this
+          workflow reconstructs to find that image, so it must match the
+          `kubernetes_distro` the build cell was given. Getting it wrong
+          points the suite at a different cell's image.
         required: false
         type: string
+      kubernetes_version:
+        description: |
+          k8s version baked into the image under test, or "auto" when the
+          build cell let kairos-init choose. Only affects the tag this
+          workflow reconstructs; must match the build cell's
+          `kubernetes_version`.
+        required: false
+        type: string
+        default: 'auto'
       release-matcher:
         description: "The release matcher to use for the latest release. Full regex match"
         required: false
@@ -68,8 +83,9 @@ on:
         description: |
           Registry path (registry/namespace/repo, no tag) where the Kairos
           OS container image was pushed. Combined with the tag suffix
-          `<flavor>-<flavor_release>-<variant>-<arch>-<model>-<sha>` to
-          form the IMAGE_NAME ginkgo tests docker-pull from inside the VM.
+          `<flavor>-<flavor_release>-<variant>-<arch>-<model><k8s>-<sha>`
+          to form the IMAGE_NAME ginkgo tests docker-pull from inside the
+          VM, where `<k8s>` comes from kubernetes_distro/kubernetes_version.
 
           The literal `${flavor}` (bash brace syntax) is expanded to the
           flavor derived from base_image; use it when each flavor lives
@@ -303,23 +319,37 @@ jobs:
           ARCH: ${{ inputs.arch }}
           MODEL: ${{ inputs.model }}
           KUBERNETES_DISTRO: ${{ inputs.kubernetes_distro }}
+          KUBERNETES_VERSION_INPUT: ${{ inputs.kubernetes_version }}
         run: |
           # Match _build-iso.yaml's custom_tag_format:
           # $FLAVOR-$FLAVOR_RELEASE-$VARIANT-$ARCH-$MODEL$K8S-$VERSION$UKI
-          # Reusable-qemu-test only tests non-UKI, non-per-k8s-version cells
-          # today, so $K8S is derived from what factory-action would produce
-          # for the same kubernetes_distro/version inputs and $UKI stays empty.
-          # $VERSION uses the same `git describe --tags --dirty --always`
-          # rule factory-action's setup step uses so both sides land on the
-          # same tag.
+          # Reusable-qemu-test only tests non-UKI cells today, so $UKI stays
+          # empty. $VERSION uses the same `git describe --tags --dirty
+          # --always` rule factory-action's setup step uses so both sides
+          # land on the same tag.
           VERSION=$(git describe --tags --dirty --always)
           if [[ "$VERSION" =~ ^[a-f0-9]+$ ]]; then
             VERSION="v0.0.0-$VERSION"
           fi
-          # Currently no caller passes kubernetes_version to this reusable,
-          # so K8S stays empty; keep the placeholder wired so future callers
-          # can flip it on without a second edit here.
+          # $K8S derivation, kept identical to reusable-factory.yaml's
+          # setup step (and to _uki-test.yaml). "auto" resolves to the
+          # empty string there so kairos-init picks the version, and the
+          # segment is gated on the distro so it survives that. Change one
+          # copy without the others and the suite pulls a tag nobody
+          # pushed, or worse, another cell's image.
+          if [[ "$KUBERNETES_VERSION_INPUT" == "auto" ]]; then
+            KUBERNETES_VERSION=""
+          else
+            KUBERNETES_VERSION="$KUBERNETES_VERSION_INPUT"
+          fi
+          SANITIZED_KUBERNETES_VERSION="${KUBERNETES_VERSION//+/-}"
           K8S=""
+          if [[ -n "$KUBERNETES_DISTRO" ]]; then
+            K8S="-$KUBERNETES_DISTRO"
+            if [[ -n "$SANITIZED_KUBERNETES_VERSION" ]]; then
+              K8S="$K8S-$SANITIZED_KUBERNETES_VERSION"
+            fi
+          fi
           # Expand the literal `${flavor}` token in the caller-provided
           # prefix. Callers that don't use the token (or take the
           # default) pass through unchanged.

--- a/.github/workflows/reusable-qemu-test.yaml
+++ b/.github/workflows/reusable-qemu-test.yaml
@@ -32,6 +32,7 @@ on:
           points the suite at a different cell's image.
         required: false
         type: string
+        default: ''
       kubernetes_version:
         description: |
           k8s version baked into the image under test, or "auto" when the

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,11 @@ lint-workflows-actions:
 # .github/scripts/verify_k8s_tag.py extracts the real `run:` shell out of
 # all three files via PyYAML and executes it under bash, so a future
 # drift shows up as a mismatch rather than as a passing test of stale
-# text. Like actionlint above, this is a local-only check -- not currently
+# text. It also walks pr.yaml/master.yaml and requires every qemu/UKI
+# test job to resolve to exactly one build-iso matrix cell, which is the
+# other half of #4579: a test job whose kubernetes_distro does not match
+# the cell it consumes boots one image and reports as another's coverage.
+# Like actionlint above, this is a local-only check -- not currently
 # wired into a CI job -- because it needs PyYAML and this is otherwise a
 # Python-free repo. Requires: pip install pyyaml.
 # ============================================================================

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,28 @@ lint-workflows-actions:
 	        \( -name 'pr.yaml' -o -name 'master.yaml' -o -name 'release.yaml' -o -name '_*.yaml' \))
 
 # ============================================================================
+# k8s image-tag derivation regression guard (kairos-io/kairos#4579).
+#
+# reusable-factory.yaml derives the $K8S image-tag segment in shell, and
+# reusable-qemu-test.yaml / _uki-test.yaml each hand-reconstruct the same
+# segment to find the image a test consumes -- reusable-factory.yaml is a
+# cross-repo callable, so the three copies cannot be collapsed into one
+# composite action/script. #4579 was exactly that: the derivation drifted
+# and a k3s cell and a k0s cell silently collided on the same pushed tag.
+#
+# .github/scripts/verify_k8s_tag.py extracts the real `run:` shell out of
+# all three files via PyYAML and executes it under bash, so a future
+# drift shows up as a mismatch rather than as a passing test of stale
+# text. Like actionlint above, this is a local-only check -- not currently
+# wired into a CI job -- because it needs PyYAML and this is otherwise a
+# Python-free repo. Requires: pip install pyyaml.
+# ============================================================================
+
+.PHONY: verify-k8s-tag
+verify-k8s-tag:
+	@python3 .github/scripts/verify_k8s_tag.py
+
+# ============================================================================
 # Local Go lint. Mirrors the golangci-lint step in
 # .github/workflows/reusable-linting.yaml -- same image tag (pinned in
 # .golangci-version), same flags, same CGO_ENABLED, same embed-stub


### PR DESCRIPTION
> Automated triage agent (`kairos-triage-agent`) running as `@itxaka-agent`.
> This comment was generated by software. A human maintainer can override
> any action taken here.

Fixes: kairos-io/kairos#4579

## What this does

`reusable-factory.yaml` derived the `$K8S` image-tag segment from `$KUBERNETES_VERSION`, which resolves to empty under the default `auto` version. On the `pr.yaml`/`master.yaml` paths that meant a k3s cell and a would-be k0s cell push to the exact same tag, with whichever cell finishes last silently winning (`fail-fast: false`). This PR:

- Keys `$K8S` (and the SARIF upload category, and the release/pr/master artifact name) off `$KUBERNETES_DISTRO` instead, matching the pattern the artifact-name block already used correctly.
- Threads `kubernetes_distro` through to `reusable-qemu-test.yaml` and `_uki-test.yaml`, which independently reconstruct the same tag in shell to find the image a test job consumes.
- Adds a build-only (`iso: false`) `amd64-standard-k0s` cell to `pr.yaml`/`master.yaml`, so the k0s provider's build-time work (`BuildEvent`, which does real installation/relocation work — see kairos-io/kairos#4299, which shipped a defect there unnoticed) gets exercised before release day instead of only in `release.yaml`'s tag-triggered `build-iso-k0s` job.
- Adds `.github/scripts/verify_k8s_tag.py` (`make verify-k8s-tag`) as a permanent regression guard: it reads the tag/artifact formats and matrix definitions out of the actual workflow YAML (not retyped literals) and executes the real derivation shell, so a future edit to any of the three copies shows up as a guard failure instead of silent drift.

## Compatibility note for other repos

`reusable-factory.yaml` is called cross-repo (`kairos-io/hadron` is a known consumer, pinned at `master` or a SHA per this repo's README). This change moves the pushed tag for any caller that passes a `kubernetes_distro` with the default `kubernetes_version: auto`: `...-generic-v1.2.3` → `...-generic-k3s-v1.2.3` (or whichever distro they pass). This is the intended fix — the old behavior silently dropped the distro — but it is a visible tag-naming change reaching other repos on merge.

## Review notes carried forward (non-blocking)

Three small items the reviewer flagged in the final round as worth knowing about but not worth another round on:

- `verify_k8s_tag.py` pins a fixed `version` value when modelling the factory's tag derivation, so the `auto`-version branch of the real shell is read but never executed by the harness.
- `reusable-qemu-test.yaml` and `_uki-test.yaml` still hand-type the artifact name (a fourth copy of the format the harness reads but doesn't yet cross-check); untouched by this PR and still correct today.
- One commit (`6f80b707`) is a one-line correction to a comment two commits earlier (`a8336670`) — left as separate commits per this branch's convention of not squashing before merge.

## How this was produced

This PR was opened by an automated triage loop: a coder role implemented the fix, a tester role independently reproduced the bug and re-verified every claim (including two builder-role empirical checks against GitHub's documented SARIF code-scanning behavior), and a reviewer role went through three rounds before approving. Full chronological summary in the linked issue comment below.

Audit trail: https://github.com/kairos-io/kairos/issues/4579#issuecomment-5618621306
