### PR TITLE
fix(kairos-init): use POSIX case instead of [[ ]] in netboot init

### DIFF
--- a/kairos-init/pkg/bundled/alpineInit/initramfs-init
+++ b/kairos-init/pkg/bundled/alpineInit/initramfs-init
@@ -374,8 +374,10 @@ if grep -q netboot /proc/cmdline; then
   rd_break pre-netboot
 
   for x in $(cat /proc/cmdline); do
-    # shellcheck disable=SC2039
-    [[ $x = root=live:* ]] || continue
+    case "$x" in
+      root=live:*) ;;
+      *) continue ;;
+    esac
     root=${x#root=live:}
   done
 


### PR DESCRIPTION
## What

`kairos-init/pkg/bundled/alpineInit/initramfs-init` (the alpine-derived netboot init script) uses a bash-only `[[ ]]` glob test to detect the `root=live:` cmdline argument:

```sh
[[ $x = root=live:* ]] || continue
```

## Why it breaks

Busybox builds without `CONFIG_ASH_BASH_COMPAT` can't parse `[[ ]]` at all. Hadron's own busybox config (`files/busybox/minimal.config` in kairos-io/hadron) explicitly disables both `CONFIG_ASH` and `CONFIG_ASH_BASH_COMPAT`. On a Hadron-based image netbooted with `root=live:<url>`, the init script dies at this exact line, before it ever reaches the `wget` that fetches the squashfs. PID 1 exits, and the kernel panics with `Kernel panic - not syncing: No working init found. Try passing init= option to kernel.`

Reproduced live tonight: AuroraBoot netbooted a Hadron+k0s image successfully up through kernel+initrd delivery (confirmed in server logs), the target machine never requested the squashfs at all, and hit exactly this panic.

## Fix

Replaced the bashism with a POSIX `case` statement, portable to any busybox ash build:

```sh
case "$x" in
  root=live:*) ;;
  *) continue ;;
esac
```

Verified the resulting script parses cleanly under a real `busybox sh -n`.

This is not an agent, Mauro used AI to help write this.

<img width="1516" height="742" alt="Screenshot 2026-09-10 at 16 04 29" src="https://github.com/user-attachments/assets/e003735a-ce2f-4a12-9401-eb8b18c190f4" />


