### PR TITLE
fix(tests): set cpu type

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -423,6 +423,7 @@ func defaultVMOptsNoDrives(stateDir string) []types.MachineOption {
 
 	memory := getEnvOrDefault("MEMORY", "2048")
 	cpus := getEnvOrDefault("CPUS", "2")
+	cpuType := getEnvOrDefault("CPU_TYPE", "host")
 	arch := getEnvOrDefault("ARCH", "x86_64")
 
 	opts := []types.MachineOption{
@@ -430,6 +431,7 @@ func defaultVMOptsNoDrives(stateDir string) []types.MachineOption {
 		types.WithISO(os.Getenv("ISO")),
 		types.WithMemory(memory),
 		types.WithCPU(cpus),
+		types.WithCPUType(cpuType),
 		types.WithSSHPort(strconv.Itoa(sshPort)),
 		types.WithID(vmName),
 		types.WithSSHUser(user()),

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -423,7 +423,7 @@ func defaultVMOptsNoDrives(stateDir string) []types.MachineOption {
 
 	memory := getEnvOrDefault("MEMORY", "2048")
 	cpus := getEnvOrDefault("CPUS", "2")
-	cpuType := getEnvOrDefault("CPU_TYPE", "host")
+	cpuType := getEnvOrDefault("CPU_TYPE", "")
 	arch := getEnvOrDefault("ARCH", "x86_64")
 
 	opts := []types.MachineOption{
@@ -487,6 +487,12 @@ func defaultVMOptsNoDrives(stateDir string) []types.MachineOption {
 			if m.Arch == "x86_64" {
 				m.Args = append(m.Args,
 					"-enable-kvm",
+				)
+			}
+
+			if  os.Getenv("CPU_TYPE") == "" && m.Arch == "x86_64" {
+				m.Args = append(m.Args,
+				 	"-cpu","host",
 				)
 			}
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -426,6 +426,10 @@ func defaultVMOptsNoDrives(stateDir string) []types.MachineOption {
 	cpuType := getEnvOrDefault("CPU_TYPE", "")
 	arch := getEnvOrDefault("ARCH", "x86_64")
 
+	if cpuType == "" && arch == "x86_64" {
+		cpuType = "host"
+	}
+
 	opts := []types.MachineOption{
 		types.QEMUEngine,
 		types.WithISO(os.Getenv("ISO")),
@@ -487,12 +491,6 @@ func defaultVMOptsNoDrives(stateDir string) []types.MachineOption {
 			if m.Arch == "x86_64" {
 				m.Args = append(m.Args,
 					"-enable-kvm",
-				)
-			}
-
-			if  os.Getenv("CPU_TYPE") == "" && m.Arch == "x86_64" {
-				m.Args = append(m.Args,
-				 	"-cpu","host",
 				)
 			}
 


### PR DESCRIPTION
Hola chicos,

While running tests locally I had issues with system couldn't boot at all:

```bash
[    7.300364] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00007f00
[    7.302649] CPU: 1 PID: 1 Comm: init Not tainted 5.14.0-687.45.1.el9_8.x86_64 #1
[    7.304578] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS Arch Linux 1.17.0-2-2 04/01/2014
.............................................................................................................
[    7.471100] ---[ end Kernel panic - not syncing: Attempted to kill init! exitcode=0x00007f00 ]---
```

with the help of @jimmykarily and @Itxaka root cause was found and it was related to qemu cpu support. When no `-cpu` flag set it uses generic qemu x86-64-v1 model, while rocky has a minimum architecture baseline of x86-64-v2.