### PR TITLE
fix(provider): log the agent installer output, not the server one

### DIFF
--- a/provider/internal/provider/buildEvent.go
+++ b/provider/internal/provider/buildEvent.go
@@ -110,8 +110,8 @@ func BuildEvent(e *pluggable.Event) pluggable.EventResponse {
 		agentCmd.Env = env
 		out2, err := agentCmd.CombinedOutput()
 		if err != nil {
-			l.Logger.Error().Err(err).Msgf("Failed to run k3s agent installer script: %s", string(out))
-			returnData.Error = fmt.Sprintf("Failed to run k3s agent installer script: %s", string(out))
+			l.Logger.Error().Err(err).Msgf("Failed to run k3s agent installer script: %s", string(out2))
+			returnData.Error = fmt.Sprintf("Failed to run k3s agent installer script: %s", string(out2))
 			returnData.State = bus.EventResponseError
 			return returnData
 		}


### PR DESCRIPTION
When the k3s agent installer script exits non-zero, BuildEvent logged string(out) instead of string(out2), so every "Failed to run k3s agent installer script" error surfaces the previous (successful) server-install output and drops the actual agent-install output on the floor. That made the recent build-iso/amd64-standard failures on master unactionable: the log ends at "systemd: Creating service file /etc/systemd/system/k3s.service", which is the last line of the server install, and there is no trace of what the agent invocation actually said before exiting.

Log out2 in both the zerolog message and the returned Error string.

