### PR TITLE
fix(kairos-init): add systemd-resolved to more distros' initramfs, safely

### DIFF
--- a/kairos-init/pkg/stages/steps_init.go
+++ b/kairos-init/pkg/stages/steps_init.go
@@ -910,6 +910,13 @@ func dracutNetworkModules(root string, sis values.System, l logger.KairosLogger)
 	// Otherwise other modules provide their own resolvers, while networkd
 	// leaves /etc/resolv.conf to resolved, so an initramfs that has networkd
 	// and no resolved cannot resolve names at all.
+	//
+	// Ubuntu 22.04 keeps the plain networkd list even though it matches every
+	// other condition: jammy only ever published dracut 051 (universe, with
+	// nothing newer in -updates, -backports or -security) and dracut grew the
+	// systemd-resolved module in 054, so no package on that release can put
+	// the module into the build root. Getting resolved into the 22.04
+	// initramfs needs a newer dracut for jammy, not a change here.
 	if strings.Contains(networkModule, dracutModSystemdNetworkd) &&
 		!strings.Contains(networkModule, dracutModSystemdResolved) &&
 		resolvedModuleAvailable(root) {

--- a/kairos-init/pkg/stages/steps_init.go
+++ b/kairos-init/pkg/stages/steps_init.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -32,6 +33,14 @@ const (
 	dracutModSystemdNetworkd = "systemd-networkd"
 	dracutModSystemdResolved = "systemd-resolved"
 	serviceSSHD              = "sshd"
+)
+
+// Paths, relative to the root of the image being built, that tell which
+// network daemons the initramfs can use.
+const (
+	networkManagerBinary  = "usr/sbin/NetworkManager"
+	systemdNetworkdBinary = "usr/lib/systemd/systemd-networkd"
+	systemdResolvedBinary = "usr/lib/systemd/systemd-resolved"
 )
 
 // GetInitrdStage Returns the initrd stage
@@ -793,6 +802,117 @@ func getLatestKernel(l logger.KairosLogger) (string, error) {
 	return kernel.GetLatest(config.DefaultConfig.Model, l)
 }
 
+// dracutNetworkModules returns the dracut network modules for the given system
+// and whether the sysext module can be used. Availability of the userspace
+// daemons is checked under root, which is "/" outside of tests.
+func dracutNetworkModules(root string, sis values.System, l logger.KairosLogger) (string, bool, error) {
+	// Add proper network and systemd-sysext if needed
+	// We default to systemd-networkd+network-legacy and sysext enabled
+	// If its ubuntu <= 22.04 we need to disable sysext
+	// If its ubuntu <= 20.04 we need to use the plain network module
+	// network-legacy is needed for ipxe as it comes up very fast which makes the livenet stuff work properly
+	// otherwise systemd-networkd does not trigger the dracut hooks to let it know that its up and running
+	// https://github.com/dracutdevs/dracut/issues/1822
+	networkModule := "systemd-networkd network-legacy"
+	sysextModule := true
+
+	if sis.Distro == values.Ubuntu {
+		ver, err := semver.NewVersion(sis.Version)
+		if err != nil {
+			l.Logger.Error().Msgf("Failed to parse the version %s: %s", sis.Version, err)
+			return "", false, err
+		}
+		constraint, _ := semver.NewConstraint("<=22.04")
+		// If its <= 22.04 we need to use the plain network module and disable sysext
+		if constraint.Check(ver) {
+			l.Logger.Debug().Str("distro", string(sis.Distro)).Str("version", sis.Version).Msg("Disabling sysext")
+			sysextModule = false
+			constraint, _ = semver.NewConstraint("<=20.04")
+			// If its <= 20.04 we need to use the plain network module
+			if constraint.Check(ver) {
+				l.Logger.Debug().Str("distro", string(sis.Distro)).Str("version", sis.Version).Msg("Using the plain network module")
+				networkModule = "network"
+			}
+		}
+		constraint, _ = semver.NewConstraint(">=24.04")
+		// If its >= 24.04 we need to append resolved to the network module
+		if constraint.Check(ver) {
+			networkModule += " systemd-resolved"
+		}
+		constraint, _ = semver.NewConstraint(">=26.04")
+		if constraint.Check(ver) {
+			// For 26.04+, network-legacy is merged into systemd-networkd and removed
+			networkModule = "systemd-networkd systemd-resolved"
+		}
+	}
+
+	if sis.Family == values.RedHatFamily {
+		// Check sysext first
+		ver, err := semver.NewVersion(sis.Version)
+		if err != nil {
+			l.Logger.Error().Msgf("Failed to parse the version %s: %s", sis.Version, err)
+			return "", false, err
+		}
+		constraint, _ := semver.NewConstraint("<9.0")
+		// If its < 9.0 we need to disable sysext
+		if constraint.Check(ver) {
+			l.Logger.Debug().Str("distro", string(sis.Distro)).Str("version", sis.Version).Msg("Disabling sysext")
+			sysextModule = false
+		}
+
+		// Now network
+		// we default to NetworkManager
+		// if systemd-network is available we use it instead
+		// depending on the version we might add network-legacy
+		// Every branch below reassigns networkModule unconditionally,
+		// so we do not need to clear it first.
+		// Do we have NetworkManager? Then add it and skip the rest of checks
+		if _, err := os.Stat(filepath.Join(root, networkManagerBinary)); err == nil {
+			networkModule = "network-manager"
+		} else {
+			// Nothing seems to ship networkd modules for dracut in the RHEL+clones so only add them under Fedora
+			if sis.Distro == values.Fedora {
+				// Do we have systemd-networkd?
+				if _, err := os.Stat(filepath.Join(root, systemdNetworkdBinary)); err == nil {
+					networkModule = dracutModSystemdNetworkd
+					// Systemd resolved modules only make sense if networkd is used alongside
+					// Otherwise other modules provide their own resolvers
+					// Do we have systemd-resolved?
+					if _, err := os.Stat(filepath.Join(root, systemdResolvedBinary)); err == nil {
+						networkModule += " systemd-resolved"
+					}
+				} else {
+					// Fallback: if neither NetworkManager nor systemd-networkd is available on Fedora,
+					// add either network or network-legacy based on the version, same as other distros.
+					// network-legacy was dropped from 10.0 onwards
+					constraint, _ = semver.NewConstraint("<10")
+					if constraint.Check(ver) {
+						networkModule = "network-legacy"
+					} else {
+						networkModule = "network"
+					}
+				}
+			} else {
+				// On other distros add either network or network-legacy
+				// network-legacy was dropped from 10.0 onwards
+				constraint, _ = semver.NewConstraint("<10")
+				if constraint.Check(ver) {
+					networkModule = "network-legacy"
+				} else {
+					networkModule = "network"
+				}
+			}
+		}
+	}
+
+	// Hadron uses the full systemd network stuff
+	if sis.Distro == values.Hadron {
+		networkModule = "systemd-networkd systemd-resolved"
+	}
+
+	return networkModule, sysextModule, nil
+}
+
 // GetKairosInitramfsFilesStage installs the kairos initramfs files
 // This stage is used to install the initramfs files that are needed for the system to boot
 func GetKairosInitramfsFilesStage(sis values.System, l logger.KairosLogger) ([]schema.Stage, error) {
@@ -876,108 +996,9 @@ func GetKairosInitramfsFilesStage(sis values.System, l logger.KairosLogger) ([]s
 			},
 		}...)
 	} else {
-		// Add proper network and systemd-sysext if needed
-		// We default to systemd-networkd+network-legacy and sysext enabled
-		// If its ubuntu <= 22.04 we need to disable sysext
-		// If its ubuntu <= 20.04 we need to use the plain network module
-		// network-legacy is needed for ipxe as it comes up very fast which makes the livenet stuff work properly
-		// otherwise systemd-networkd does not trigger the dracut hooks to let it know that its up and running
-		// https://github.com/dracutdevs/dracut/issues/1822
-		networkModule := "systemd-networkd network-legacy"
-		sysextModule := true
-
-		if sis.Distro == values.Ubuntu {
-			ver, err := semver.NewVersion(sis.Version)
-			if err != nil {
-				l.Logger.Error().Msgf("Failed to parse the version %s: %s", sis.Version, err)
-				return []schema.Stage{}, err
-			}
-			constraint, _ := semver.NewConstraint("<=22.04")
-			// If its <= 22.04 we need to use the plain network module and disable sysext
-			if constraint.Check(ver) {
-				l.Logger.Debug().Str("distro", string(sis.Distro)).Str("version", sis.Version).Msg("Disabling sysext")
-				sysextModule = false
-				constraint, _ = semver.NewConstraint("<=20.04")
-				// If its <= 20.04 we need to use the plain network module
-				if constraint.Check(ver) {
-					l.Logger.Debug().Str("distro", string(sis.Distro)).Str("version", sis.Version).Msg("Using the plain network module")
-					networkModule = "network"
-				}
-			}
-			constraint, _ = semver.NewConstraint(">=24.04")
-			// If its >= 24.04 we need to append resolved to the network module
-			if constraint.Check(ver) {
-				networkModule += " systemd-resolved"
-			}
-			constraint, _ = semver.NewConstraint(">=26.04")
-			if constraint.Check(ver) {
-				// For 26.04+, network-legacy is merged into systemd-networkd and removed
-				networkModule = "systemd-networkd systemd-resolved"
-			}
-		}
-
-		if sis.Family == values.RedHatFamily {
-			// Check sysext first
-			ver, err := semver.NewVersion(sis.Version)
-			if err != nil {
-				l.Logger.Error().Msgf("Failed to parse the version %s: %s", sis.Version, err)
-				return []schema.Stage{}, err
-			}
-			constraint, _ := semver.NewConstraint("<9.0")
-			// If its < 9.0 we need to disable sysext
-			if constraint.Check(ver) {
-				l.Logger.Debug().Str("distro", string(sis.Distro)).Str("version", sis.Version).Msg("Disabling sysext")
-				sysextModule = false
-			}
-
-			// Now network
-			// we default to NetworkManager
-			// if systemd-network is available we use it instead
-			// depending on the version we might add network-legacy
-			// Every branch below reassigns networkModule unconditionally,
-			// so we do not need to clear it first.
-			// Do we have NetworkManager? Then add it and skip the rest of checks
-			if _, err := os.Stat("/usr/sbin/NetworkManager"); err == nil {
-				networkModule = "network-manager"
-			} else {
-				// Nothing seems to ship networkd modules for dracut in the RHEL+clones so only add them under Fedora
-				if sis.Distro == values.Fedora {
-					// Do we have systemd-networkd?
-					if _, err := os.Stat("/usr/lib/systemd/systemd-networkd"); err == nil {
-						networkModule = dracutModSystemdNetworkd
-						// Systemd resolved modules only make sense if networkd is used alongside
-						// Otherwise other modules provide their own resolvers
-						// Do we have systemd-resolved?
-						if _, err := os.Stat("/usr/lib/systemd/systemd-resolved"); err == nil {
-							networkModule += " systemd-resolved"
-						}
-					} else {
-						// Fallback: if neither NetworkManager nor systemd-networkd is available on Fedora,
-						// add either network or network-legacy based on the version, same as other distros.
-						// network-legacy was dropped from 10.0 onwards
-						constraint, _ = semver.NewConstraint("<10")
-						if constraint.Check(ver) {
-							networkModule = "network-legacy"
-						} else {
-							networkModule = "network"
-						}
-					}
-				} else {
-					// On other distros add either network or network-legacy
-					// network-legacy was dropped from 10.0 onwards
-					constraint, _ = semver.NewConstraint("<10")
-					if constraint.Check(ver) {
-						networkModule = "network-legacy"
-					} else {
-						networkModule = "network"
-					}
-				}
-			}
-		}
-
-		// Hadron uses the full systemd network stuff
-		if sis.Distro == values.Hadron {
-			networkModule = "systemd-networkd systemd-resolved"
+		networkModule, sysextModule, err := dracutNetworkModules("/", sis, l)
+		if err != nil {
+			return []schema.Stage{}, err
 		}
 
 		l.Logger.Debug().Str("networkModule", networkModule).Bool("sysextModule", sysextModule).Msg("Adding dracut modules to initramfs")

--- a/kairos-init/pkg/stages/steps_init.go
+++ b/kairos-init/pkg/stages/steps_init.go
@@ -41,6 +41,7 @@ const (
 	networkManagerBinary  = "usr/sbin/NetworkManager"
 	systemdNetworkdBinary = "usr/lib/systemd/systemd-networkd"
 	systemdResolvedBinary = "usr/lib/systemd/systemd-resolved"
+	dracutModulesDir      = "usr/lib/dracut/modules.d"
 )
 
 // GetInitrdStage Returns the initrd stage
@@ -875,12 +876,6 @@ func dracutNetworkModules(root string, sis values.System, l logger.KairosLogger)
 				// Do we have systemd-networkd?
 				if _, err := os.Stat(filepath.Join(root, systemdNetworkdBinary)); err == nil {
 					networkModule = dracutModSystemdNetworkd
-					// Systemd resolved modules only make sense if networkd is used alongside
-					// Otherwise other modules provide their own resolvers
-					// Do we have systemd-resolved?
-					if _, err := os.Stat(filepath.Join(root, systemdResolvedBinary)); err == nil {
-						networkModule += " systemd-resolved"
-					}
 				} else {
 					// Fallback: if neither NetworkManager nor systemd-networkd is available on Fedora,
 					// add either network or network-legacy based on the version, same as other distros.
@@ -910,7 +905,33 @@ func dracutNetworkModules(root string, sis values.System, l logger.KairosLogger)
 		networkModule = "systemd-networkd systemd-resolved"
 	}
 
+	// Systemd resolved modules only make sense if networkd is used alongside.
+	// Otherwise other modules provide their own resolvers, while networkd
+	// leaves /etc/resolv.conf to resolved, so an initramfs that has networkd
+	// and no resolved cannot resolve names at all.
+	if strings.Contains(networkModule, dracutModSystemdNetworkd) &&
+		!strings.Contains(networkModule, dracutModSystemdResolved) &&
+		resolvedModuleAvailable(root) {
+		l.Logger.Debug().Str("distro", string(sis.Distro)).Str("version", sis.Version).Msg("Adding the systemd-resolved module")
+		networkModule += " " + dracutModSystemdResolved
+	}
+
 	return networkModule, sysextModule, nil
+}
+
+// resolvedModuleAvailable reports whether the systemd-resolved dracut module
+// can be pulled into an initramfs built from root. The module aborts the dracut
+// run when the daemon is missing, and older dracut releases do not ship it at
+// all, so both have to be there before asking for it.
+func resolvedModuleAvailable(root string) bool {
+	if _, err := os.Stat(filepath.Join(root, systemdResolvedBinary)); err != nil {
+		return false
+	}
+
+	// The module directory carries a priority prefix that changes between
+	// dracut releases.
+	modules, err := filepath.Glob(filepath.Join(root, dracutModulesDir, "*"+dracutModSystemdResolved))
+	return err == nil && len(modules) > 0
 }
 
 // GetKairosInitramfsFilesStage installs the kairos initramfs files

--- a/kairos-init/pkg/stages/steps_init.go
+++ b/kairos-init/pkg/stages/steps_init.go
@@ -911,12 +911,12 @@ func dracutNetworkModules(root string, sis values.System, l logger.KairosLogger)
 	// leaves /etc/resolv.conf to resolved, so an initramfs that has networkd
 	// and no resolved cannot resolve names at all.
 	//
-	// Ubuntu 22.04 keeps the plain networkd list even though it matches every
-	// other condition: jammy only ever published dracut 051 (universe, with
-	// nothing newer in -updates, -backports or -security) and dracut grew the
-	// systemd-resolved module in 054, so no package on that release can put
-	// the module into the build root. Getting resolved into the 22.04
-	// initramfs needs a newer dracut for jammy, not a change here.
+	// Ubuntu 22.04 keeps "systemd-networkd network-legacy" even though it
+	// matches every other condition: jammy only ever published dracut 051
+	// (universe, with nothing newer in -updates, -backports or -security) and
+	// dracut grew the systemd-resolved module in 054, so no package on that
+	// release can put the module into the build root. Getting resolved into
+	// the 22.04 initramfs needs a newer dracut for jammy, not a change here.
 	if strings.Contains(networkModule, dracutModSystemdNetworkd) &&
 		!strings.Contains(networkModule, dracutModSystemdResolved) &&
 		resolvedModuleAvailable(root) {

--- a/kairos-init/pkg/stages/steps_init.go
+++ b/kairos-init/pkg/stages/steps_init.go
@@ -41,6 +41,7 @@ const (
 	networkManagerBinary  = "usr/sbin/NetworkManager"
 	systemdNetworkdBinary = "usr/lib/systemd/systemd-networkd"
 	systemdResolvedBinary = "usr/lib/systemd/systemd-resolved"
+	resolvectlBinary      = "usr/bin/resolvectl"
 	dracutModulesDir      = "usr/lib/dracut/modules.d"
 )
 
@@ -920,12 +921,20 @@ func dracutNetworkModules(root string, sis values.System, l logger.KairosLogger)
 }
 
 // resolvedModuleAvailable reports whether the systemd-resolved dracut module
-// can be pulled into an initramfs built from root. The module aborts the dracut
-// run when the daemon is missing, and older dracut releases do not ship it at
-// all, so both have to be there before asking for it.
+// can be pulled into an initramfs built from root.
+//
+// Every prerequisite the module declares has to be satisfied, because a module
+// named in add_dracutmodules whose check() fails takes the whole dracut run
+// down with it - it exits 1 and writes no initramfs at all rather than leaving
+// the module out. check() requires both resolvectl and the resolved daemon, so
+// a root carrying only one of the two is not enough. Dracut itself only grew
+// the module in 054, hence the module directory probe on top: older releases
+// ship the daemon but have nothing to ask dracut for.
 func resolvedModuleAvailable(root string) bool {
-	if _, err := os.Stat(filepath.Join(root, systemdResolvedBinary)); err != nil {
-		return false
+	for _, binary := range []string{systemdResolvedBinary, resolvectlBinary} {
+		if _, err := os.Stat(filepath.Join(root, binary)); err != nil {
+			return false
+		}
 	}
 
 	// The module directory carries a priority prefix that changes between

--- a/kairos-init/pkg/stages/steps_init_test.go
+++ b/kairos-init/pkg/stages/steps_init_test.go
@@ -140,6 +140,8 @@ func TestDracutNetworkModules(t *testing.T) {
 			wantSysext: false,
 		},
 		{
+			// What jammy actually looks like: the daemon and resolvectl are
+			// there, dracut 051 has no systemd-resolved module to ask for.
 			name:       "ubuntu 22.04 without the resolved dracut module",
 			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "22.04"},
 			files:      []string{fixtureResolved, fixtureResolvectl},

--- a/kairos-init/pkg/stages/steps_init_test.go
+++ b/kairos-init/pkg/stages/steps_init_test.go
@@ -1,8 +1,12 @@
 package stages
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/kairos-io/kairos/v4/kairos-init/pkg/values"
+	"github.com/kairos-io/kairos/v4/sdk/types/logger"
 	"github.com/rs/zerolog"
 )
 
@@ -33,6 +37,153 @@ func TestGetDracutCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getDracutCommand("6.12.0", tt.level); got != tt.want {
 				t.Fatalf("getDracutCommand() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Paths a fabricated build root can contain, to drive the daemon and dracut
+// module probes in dracutNetworkModules.
+const (
+	fixtureNetworkManager = "usr/sbin/NetworkManager"
+	fixtureNetworkd       = "usr/lib/systemd/systemd-networkd"
+	fixtureResolved       = "usr/lib/systemd/systemd-resolved"
+	fixtureResolvedModule = "usr/lib/dracut/modules.d/11systemd-resolved/module-setup.sh"
+)
+
+// buildRoot fabricates a build root containing the given files.
+func buildRoot(t *testing.T, files ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, f := range files {
+		path := filepath.Join(root, f)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed to create %s: %s", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, nil, 0o755); err != nil {
+			t.Fatalf("failed to write %s: %s", path, err)
+		}
+	}
+	return root
+}
+
+func TestDracutNetworkModules(t *testing.T) {
+	log := logger.NewKairosLogger("test", "fatal", true)
+
+	tests := []struct {
+		name       string
+		sis        values.System
+		files      []string
+		wantModule string
+		wantSysext bool
+	}{
+		{
+			// Bug: systemd-networkd without systemd-resolved leaves the
+			// initramfs without a resolver. kairos-io/kairos#835.
+			name:       "ubuntu 22.04 skips resolved",
+			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "22.04"},
+			files:      []string{fixtureResolved, fixtureResolvedModule},
+			wantModule: "systemd-networkd network-legacy",
+			wantSysext: false,
+		},
+		{
+			name:       "ubuntu 22.04 without the resolved dracut module",
+			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "22.04"},
+			files:      []string{fixtureResolved},
+			wantModule: "systemd-networkd network-legacy",
+			wantSysext: false,
+		},
+		{
+			name:       "ubuntu 20.04 uses the plain network module",
+			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "20.04"},
+			files:      []string{fixtureResolved, fixtureResolvedModule},
+			wantModule: "network",
+			wantSysext: false,
+		},
+		{
+			name:       "ubuntu 24.04 adds resolved",
+			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "24.04"},
+			files:      []string{fixtureResolved, fixtureResolvedModule},
+			wantModule: "systemd-networkd network-legacy systemd-resolved",
+			wantSysext: true,
+		},
+		{
+			name:       "ubuntu 26.04 drops network-legacy",
+			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "26.04"},
+			files:      []string{fixtureResolved, fixtureResolvedModule},
+			wantModule: "systemd-networkd systemd-resolved",
+			wantSysext: true,
+		},
+		{
+			// Bug: kairos-io/kairos#835.
+			name:       "opensuse leap skips resolved",
+			sis:        values.System{Distro: values.OpenSUSELeap, Family: values.SUSEFamily, Version: "15.6"},
+			files:      []string{fixtureResolved, fixtureResolvedModule},
+			wantModule: "systemd-networkd network-legacy",
+			wantSysext: true,
+		},
+		{
+			// Bug: kairos-io/kairos#835.
+			name:       "debian skips resolved",
+			sis:        values.System{Distro: values.Debian, Family: values.DebianFamily, Version: "13"},
+			files:      []string{fixtureResolved, fixtureResolvedModule},
+			wantModule: "systemd-networkd network-legacy",
+			wantSysext: true,
+		},
+		{
+			name:       "rhel 9 uses NetworkManager",
+			sis:        values.System{Distro: values.RedHat, Family: values.RedHatFamily, Version: "9.5"},
+			files:      []string{fixtureNetworkManager, fixtureResolved, fixtureResolvedModule},
+			wantModule: "network-manager",
+			wantSysext: true,
+		},
+		{
+			name:       "rocky 9 without NetworkManager falls back to network-legacy",
+			sis:        values.System{Distro: values.RockyLinux, Family: values.RedHatFamily, Version: "9.5"},
+			files:      []string{fixtureResolved, fixtureResolvedModule},
+			wantModule: "network-legacy",
+			wantSysext: true,
+		},
+		{
+			name:       "rhel 8 disables sysext",
+			sis:        values.System{Distro: values.RedHat, Family: values.RedHatFamily, Version: "8.10"},
+			files:      []string{fixtureNetworkManager},
+			wantModule: "network-manager",
+			wantSysext: false,
+		},
+		{
+			name:       "fedora with networkd adds resolved",
+			sis:        values.System{Distro: values.Fedora, Family: values.RedHatFamily, Version: "42"},
+			files:      []string{fixtureNetworkd, fixtureResolved, fixtureResolvedModule},
+			wantModule: "systemd-networkd systemd-resolved",
+			wantSysext: true,
+		},
+		{
+			name:       "fedora with networkd and no resolved dracut module",
+			sis:        values.System{Distro: values.Fedora, Family: values.RedHatFamily, Version: "42"},
+			files:      []string{fixtureNetworkd, fixtureResolved},
+			wantModule: "systemd-networkd systemd-resolved",
+			wantSysext: true,
+		},
+		{
+			name:       "hadron uses networkd and resolved",
+			sis:        values.System{Distro: values.Hadron, Family: values.HadronFamily, Version: "1.0"},
+			wantModule: "systemd-networkd systemd-resolved",
+			wantSysext: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			module, sysext, err := dracutNetworkModules(buildRoot(t, tt.files...), tt.sis, log)
+			if err != nil {
+				t.Fatalf("dracutNetworkModules() returned an error: %s", err)
+			}
+			if module != tt.wantModule {
+				t.Errorf("dracutNetworkModules() module = %q, want %q", module, tt.wantModule)
+			}
+			if sysext != tt.wantSysext {
+				t.Errorf("dracutNetworkModules() sysext = %t, want %t", sysext, tt.wantSysext)
 			}
 		})
 	}

--- a/kairos-init/pkg/stages/steps_init_test.go
+++ b/kairos-init/pkg/stages/steps_init_test.go
@@ -48,6 +48,7 @@ const (
 	fixtureNetworkManager = "usr/sbin/NetworkManager"
 	fixtureNetworkd       = "usr/lib/systemd/systemd-networkd"
 	fixtureResolved       = "usr/lib/systemd/systemd-resolved"
+	fixtureResolvectl     = "usr/bin/resolvectl"
 	fixtureResolvedModule = "usr/lib/dracut/modules.d/11systemd-resolved/module-setup.sh"
 )
 
@@ -67,11 +68,13 @@ func buildRoot(t *testing.T, files ...string) string {
 	return root
 }
 
-// TestResolvedModuleAvailable exercises resolvedModuleAvailable directly, for
-// all four combinations of "daemon present" x "dracut module present". The
-// dracutNetworkModules table above only ever drives this through the full
-// selection, and never happens to cover the module-without-daemon case, so it
-// is worth pinning on its own: the function is documented to require both.
+// TestResolvedModuleAvailable exercises resolvedModuleAvailable directly, over
+// the combinations of "resolved daemon present" x "resolvectl present" x
+// "dracut module present". The dracutNetworkModules table below only ever
+// drives this through the full selection and never covers the partial roots,
+// so it is worth pinning on its own: all three have to be there, and a root
+// missing any one of them must not get the module. Asking dracut for a module
+// whose check() fails aborts the initramfs build outright.
 func TestResolvedModuleAvailable(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -79,22 +82,32 @@ func TestResolvedModuleAvailable(t *testing.T) {
 		want  bool
 	}{
 		{
-			name:  "daemon and module both present",
-			files: []string{fixtureResolved, fixtureResolvedModule},
+			name:  "daemon, resolvectl and module all present",
+			files: []string{fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			want:  true,
 		},
 		{
-			name:  "daemon present, module missing",
-			files: []string{fixtureResolved},
+			name:  "daemon and resolvectl present, module missing",
+			files: []string{fixtureResolved, fixtureResolvectl},
 			want:  false,
 		},
 		{
-			name:  "module present, daemon missing",
+			name:  "daemon and module present, resolvectl missing",
+			files: []string{fixtureResolved, fixtureResolvedModule},
+			want:  false,
+		},
+		{
+			name:  "resolvectl and module present, daemon missing",
+			files: []string{fixtureResolvectl, fixtureResolvedModule},
+			want:  false,
+		},
+		{
+			name:  "module present, both binaries missing",
 			files: []string{fixtureResolvedModule},
 			want:  false,
 		},
 		{
-			name:  "neither present",
+			name:  "nothing present",
 			files: nil,
 			want:  false,
 		},
@@ -122,14 +135,14 @@ func TestDracutNetworkModules(t *testing.T) {
 		{
 			name:       "ubuntu 22.04 adds resolved",
 			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "22.04"},
-			files:      []string{fixtureResolved, fixtureResolvedModule},
+			files:      []string{fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			wantModule: "systemd-networkd network-legacy systemd-resolved",
 			wantSysext: false,
 		},
 		{
 			name:       "ubuntu 22.04 without the resolved dracut module",
 			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "22.04"},
-			files:      []string{fixtureResolved},
+			files:      []string{fixtureResolved, fixtureResolvectl},
 			wantModule: "systemd-networkd network-legacy",
 			wantSysext: false,
 		},
@@ -138,28 +151,28 @@ func TestDracutNetworkModules(t *testing.T) {
 			// resolved has nothing to do here.
 			name:       "ubuntu 20.04 uses the plain network module",
 			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "20.04"},
-			files:      []string{fixtureResolved, fixtureResolvedModule},
+			files:      []string{fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			wantModule: "network",
 			wantSysext: false,
 		},
 		{
 			name:       "ubuntu 24.04 adds resolved",
 			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "24.04"},
-			files:      []string{fixtureResolved, fixtureResolvedModule},
+			files:      []string{fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			wantModule: "systemd-networkd network-legacy systemd-resolved",
 			wantSysext: true,
 		},
 		{
 			name:       "ubuntu 26.04 drops network-legacy",
 			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "26.04"},
-			files:      []string{fixtureResolved, fixtureResolvedModule},
+			files:      []string{fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			wantModule: "systemd-networkd systemd-resolved",
 			wantSysext: true,
 		},
 		{
 			name:       "opensuse leap adds resolved",
 			sis:        values.System{Distro: values.OpenSUSELeap, Family: values.SUSEFamily, Version: "15.6"},
-			files:      []string{fixtureResolved, fixtureResolvedModule},
+			files:      []string{fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			wantModule: "systemd-networkd network-legacy systemd-resolved",
 			wantSysext: true,
 		},
@@ -172,8 +185,18 @@ func TestDracutNetworkModules(t *testing.T) {
 		{
 			name:       "debian adds resolved",
 			sis:        values.System{Distro: values.Debian, Family: values.DebianFamily, Version: "13"},
-			files:      []string{fixtureResolved, fixtureResolvedModule},
+			files:      []string{fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			wantModule: "systemd-networkd network-legacy systemd-resolved",
+			wantSysext: true,
+		},
+		{
+			// The module's check() wants resolvectl too, and dracut fails the
+			// build outright when a module it was told to add cannot install
+			// itself, so a root without it has to be left alone.
+			name:       "debian without resolvectl",
+			sis:        values.System{Distro: values.Debian, Family: values.DebianFamily, Version: "13"},
+			files:      []string{fixtureResolved, fixtureResolvedModule},
+			wantModule: "systemd-networkd network-legacy",
 			wantSysext: true,
 		},
 		{
@@ -181,14 +204,14 @@ func TestDracutNetworkModules(t *testing.T) {
 			// /etc/resolv.conf themselves, so they get no resolved.
 			name:       "rhel 9 uses NetworkManager",
 			sis:        values.System{Distro: values.RedHat, Family: values.RedHatFamily, Version: "9.5"},
-			files:      []string{fixtureNetworkManager, fixtureResolved, fixtureResolvedModule},
+			files:      []string{fixtureNetworkManager, fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			wantModule: "network-manager",
 			wantSysext: true,
 		},
 		{
 			name:       "rocky 9 without NetworkManager falls back to network-legacy",
 			sis:        values.System{Distro: values.RockyLinux, Family: values.RedHatFamily, Version: "9.5"},
-			files:      []string{fixtureResolved, fixtureResolvedModule},
+			files:      []string{fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			wantModule: "network-legacy",
 			wantSysext: true,
 		},
@@ -202,7 +225,7 @@ func TestDracutNetworkModules(t *testing.T) {
 		{
 			name:       "fedora with networkd adds resolved",
 			sis:        values.System{Distro: values.Fedora, Family: values.RedHatFamily, Version: "42"},
-			files:      []string{fixtureNetworkd, fixtureResolved, fixtureResolvedModule},
+			files:      []string{fixtureNetworkd, fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			wantModule: "systemd-networkd systemd-resolved",
 			wantSysext: true,
 		},
@@ -211,7 +234,7 @@ func TestDracutNetworkModules(t *testing.T) {
 			// build, so the daemon alone is not enough.
 			name:       "fedora with networkd and no resolved dracut module",
 			sis:        values.System{Distro: values.Fedora, Family: values.RedHatFamily, Version: "42"},
-			files:      []string{fixtureNetworkd, fixtureResolved},
+			files:      []string{fixtureNetworkd, fixtureResolved, fixtureResolvectl},
 			wantModule: "systemd-networkd",
 			wantSysext: true,
 		},

--- a/kairos-init/pkg/stages/steps_init_test.go
+++ b/kairos-init/pkg/stages/steps_init_test.go
@@ -133,7 +133,11 @@ func TestDracutNetworkModules(t *testing.T) {
 		wantSysext bool
 	}{
 		{
-			name:       "ubuntu 22.04 adds resolved",
+			// No jammy package ships the systemd-resolved dracut module: the
+			// release is stuck on dracut 051 and the module landed in 054. This
+			// row drives the selection logic against a backported or vendored
+			// dracut, not a stock 22.04 build root.
+			name:       "ubuntu 22.04 with a dracut that ships the module adds resolved",
 			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "22.04"},
 			files:      []string{fixtureResolved, fixtureResolvectl, fixtureResolvedModule},
 			wantModule: "systemd-networkd network-legacy systemd-resolved",

--- a/kairos-init/pkg/stages/steps_init_test.go
+++ b/kairos-init/pkg/stages/steps_init_test.go
@@ -78,12 +78,10 @@ func TestDracutNetworkModules(t *testing.T) {
 		wantSysext bool
 	}{
 		{
-			// Bug: systemd-networkd without systemd-resolved leaves the
-			// initramfs without a resolver. kairos-io/kairos#835.
-			name:       "ubuntu 22.04 skips resolved",
+			name:       "ubuntu 22.04 adds resolved",
 			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "22.04"},
 			files:      []string{fixtureResolved, fixtureResolvedModule},
-			wantModule: "systemd-networkd network-legacy",
+			wantModule: "systemd-networkd network-legacy systemd-resolved",
 			wantSysext: false,
 		},
 		{
@@ -94,6 +92,8 @@ func TestDracutNetworkModules(t *testing.T) {
 			wantSysext: false,
 		},
 		{
+			// The plain network module writes /etc/resolv.conf itself, so
+			// resolved has nothing to do here.
 			name:       "ubuntu 20.04 uses the plain network module",
 			sis:        values.System{Distro: values.Ubuntu, Family: values.DebianFamily, Version: "20.04"},
 			files:      []string{fixtureResolved, fixtureResolvedModule},
@@ -115,22 +115,28 @@ func TestDracutNetworkModules(t *testing.T) {
 			wantSysext: true,
 		},
 		{
-			// Bug: kairos-io/kairos#835.
-			name:       "opensuse leap skips resolved",
+			name:       "opensuse leap adds resolved",
 			sis:        values.System{Distro: values.OpenSUSELeap, Family: values.SUSEFamily, Version: "15.6"},
 			files:      []string{fixtureResolved, fixtureResolvedModule},
+			wantModule: "systemd-networkd network-legacy systemd-resolved",
+			wantSysext: true,
+		},
+		{
+			name:       "opensuse leap without resolved installed",
+			sis:        values.System{Distro: values.OpenSUSELeap, Family: values.SUSEFamily, Version: "15.6"},
 			wantModule: "systemd-networkd network-legacy",
 			wantSysext: true,
 		},
 		{
-			// Bug: kairos-io/kairos#835.
-			name:       "debian skips resolved",
+			name:       "debian adds resolved",
 			sis:        values.System{Distro: values.Debian, Family: values.DebianFamily, Version: "13"},
 			files:      []string{fixtureResolved, fixtureResolvedModule},
-			wantModule: "systemd-networkd network-legacy",
+			wantModule: "systemd-networkd network-legacy systemd-resolved",
 			wantSysext: true,
 		},
 		{
+			// NetworkManager and the legacy network modules write
+			// /etc/resolv.conf themselves, so they get no resolved.
 			name:       "rhel 9 uses NetworkManager",
 			sis:        values.System{Distro: values.RedHat, Family: values.RedHatFamily, Version: "9.5"},
 			files:      []string{fixtureNetworkManager, fixtureResolved, fixtureResolvedModule},
@@ -159,10 +165,12 @@ func TestDracutNetworkModules(t *testing.T) {
 			wantSysext: true,
 		},
 		{
+			// Asking dracut for a module it does not ship fails the initramfs
+			// build, so the daemon alone is not enough.
 			name:       "fedora with networkd and no resolved dracut module",
 			sis:        values.System{Distro: values.Fedora, Family: values.RedHatFamily, Version: "42"},
 			files:      []string{fixtureNetworkd, fixtureResolved},
-			wantModule: "systemd-networkd systemd-resolved",
+			wantModule: "systemd-networkd",
 			wantSysext: true,
 		},
 		{

--- a/kairos-init/pkg/stages/steps_init_test.go
+++ b/kairos-init/pkg/stages/steps_init_test.go
@@ -67,6 +67,48 @@ func buildRoot(t *testing.T, files ...string) string {
 	return root
 }
 
+// TestResolvedModuleAvailable exercises resolvedModuleAvailable directly, for
+// all four combinations of "daemon present" x "dracut module present". The
+// dracutNetworkModules table above only ever drives this through the full
+// selection, and never happens to cover the module-without-daemon case, so it
+// is worth pinning on its own: the function is documented to require both.
+func TestResolvedModuleAvailable(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []string
+		want  bool
+	}{
+		{
+			name:  "daemon and module both present",
+			files: []string{fixtureResolved, fixtureResolvedModule},
+			want:  true,
+		},
+		{
+			name:  "daemon present, module missing",
+			files: []string{fixtureResolved},
+			want:  false,
+		},
+		{
+			name:  "module present, daemon missing",
+			files: []string{fixtureResolvedModule},
+			want:  false,
+		},
+		{
+			name:  "neither present",
+			files: nil,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolvedModuleAvailable(buildRoot(t, tt.files...)); got != tt.want {
+				t.Errorf("resolvedModuleAvailable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDracutNetworkModules(t *testing.T) {
 	log := logger.NewKairosLogger("test", "fatal", true)
 


### PR DESCRIPTION
> Automated triage agent (`kairos-triage-agent`) running as `@itxaka-agent`.
> This comment was generated by software. A human maintainer can override any
> action taken here.

Fixes: #835

## What

Some Kairos targets never got the `systemd-resolved` dracut module added to their initramfs, so DNS never resolved that early in boot — the "no DNS at initramfs stage" half of #835 (the other half, the `dns:` cloud-config stage on `systemd-resolved` hosts, lives in `mudler/yip` and is out of scope here; see the takeover comment on the issue).

`kairos-init/pkg/stages/steps_init.go` now adds `systemd-resolved` to the dracut network-module list wherever `systemd-networkd` drives the initramfs and the module is actually available on the build root (both the `systemd-resolved` daemon binary and `resolvectl` present, matching what the module's own `check()` requires). This closes the gap for Ubuntu 21.04–22.04*, Debian, and openSUSE/SLES.

\* **Ubuntu 22.04 is not fixed by this PR.** Its packaged dracut (051, across every jammy suite) predates the upstream `systemd-resolved` dracut module, which only landed at dracut 054. No installable package closes this gap today; that's documented in a code comment rather than silently left as a mystery or forced (forcing an unavailable module makes dracut abort the whole image build — see below).

Also fixed along the way: the module-availability probe originally checked only the `systemd-resolved` daemon binary. The module's own `check()` requires `resolvectl` too, and dracut hard-aborts the entire image build (no initramfs produced) when a module forced via `add_dracutmodules` fails its `check()`. Left unchanged, on a root with the daemon but not `resolvectl`, this fix would have turned "missing DNS" into "build fails outright" — worse than the original bug. The probe now checks both binaries.

The RedHat family (outside Fedora-with-networkd) and Ubuntu ≤20.04 are deliberately left alone: their dracut modules (`network-manager`, `network`/`network-legacy`) already write `/etc/resolv.conf` themselves, so they already have working DNS in the initramfs.

## Verification

Unit tests cover the module-selection logic (table-driven, `kairos-init/pkg/stages/steps_init_test.go`) against both fabricated build roots and facts confirmed against real, published Kairos container images (`quay.io/kairos/core-*`) and the real Ubuntu package archive for the jammy-dracut-version claim. No ISO was built and no VM was booted for this ticket — the change is internal to kairos-init's build-time dracut module selection, with no existing isolated repro short of the full image-build pipeline.

Full round-by-round audit trail (what each review round found, and how each finding was resolved or empirically verified): https://github.com/kairos-io/kairos/issues/835#issuecomment-5632796718
